### PR TITLE
add CTestTestfile.cmake to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ CMakeCache.txt
 CPack*.cmake
 install_manifest.txt
 doc/dg/html/
+CTestTestfile.cmake


### PR DESCRIPTION
`CTestTestfile.cmake` files are autogenerated and clutter the git status. If that problem also bothers others, I propose to add them to gitignore