### PR TITLE
cmake: improve error message if Boost not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,13 +119,13 @@ list(APPEND EXTRA_LIBRARIES ${CMAKE_DL_LIBS})
 # add_definitions( -DHAVE_CONFIG_H )
 
 if (EXTERNAL_BOOST)
-  set(Boost_VERSION 1.55.0)
+  set(NEEDED Boost_VERSION 1.55.0)
   if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5")
-    set(Boost_VERSION 1.58.0) #issue #8
+    set(NEEDED_Boost_VERSION 1.58.0) #issue #8
   endif()
-  find_package(Boost ${Boost_VERSION} COMPONENTS mpi python serialization filesystem)
+  find_package(Boost ${NEEDED_Boost_VERSION} COMPONENTS mpi python serialization filesystem)
   if(NOT Boost_FOUND)
-    message(FATAL_ERROR "Boost not found, make sure you have installed boost and it's dev packages. To hint cmake to your Boost installation, use the option -DBOOST_ROOT=/path/to/boost. As last resort you can use our internal replacement with -DEXTERNAL_BOOST=OFF")
+    message(FATAL_ERROR "Boost (required at least version ${NEEDED_Boost_VERSION}) not found, make sure you have installed boost and it's dev packages. To hint cmake to your Boost installation, use the option -DBOOST_ROOT=/path/to/boost. As last resort you can use our internal replacement with -DEXTERNAL_BOOST=OFF")
   endif(NOT Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIRS})
 else(EXTERNAL_BOOST)


### PR DESCRIPTION
In addtion Boost_VERSION is an internal variable to FindBoost.cmake,
so let's not use it.