### PR TITLE
gets rid of singularity in force

### DIFF
--- a/src/interaction/DihedralHarmonicNCos.hpp
+++ b/src/interaction/DihedralHarmonicNCos.hpp
@@ -141,10 +141,10 @@ namespace espressopp {
         // cosine between planes
         real cos_phi = (rijjk * rjkkn) * (inv_rijjk * inv_rjkkn);
         real _phi = acos(cos_phi);
-        if (cos_phi > 1.0) {
+        if (cos_phi >= 1.0) {
           cos_phi = 1.0;
           _phi = 1e-10; //not 0.0, because 1.0/sin(_phi) would cause a singularity
-        } else if (cos_phi < -1.0) {
+        } else if (cos_phi <= -1.0) {
           cos_phi = -1.0;
           _phi = M_PI-1e-10;
         }


### PR DESCRIPTION
This change from > to >= and < to <= is necessary because the condition cos_phi exactly = 1.0 or -1.0 can occur in practice.