### PR TITLE
Fixed SystemMonitor in case of parallel run.

### DIFF
--- a/src/analysis/SystemMonitor.cpp
+++ b/src/analysis/SystemMonitor.cpp
@@ -29,36 +29,20 @@ namespace espressopp {
 namespace analysis {
 
 void SystemMonitor::perform_action() {
+  current_step_ = integrator_->getStep();
+  values_->clear();
+  values_->push_back(current_step_);
+  values_->push_back(current_step_ * integrator_->getTimeStep());
+
+  computeObservables();
   if (system_->comm->rank() == 0) {
-    current_step_ = integrator_->getStep();
-    values_->clear();
-    values_->push_back(current_step_);
-    values_->push_back(current_step_ * integrator_->getTimeStep());
-
-    computeKineticEnergy();
-    computeObservables();
-
-    write();
+    output_->write();
   }
 }
 
 void SystemMonitor::computeObservables() {
   for (ObservableList::iterator it = observables_.begin(); it != observables_.end(); ++it) {
     values_->push_back(it->second->compute_real());
-  }
-}
-
-void SystemMonitor::computeKineticEnergy() {
-  real T = temp_->computeRaw();
-  real ekin = (3.0/2.0) * npart_->compute_real() * T;
-  values_->push_back(T);
-  values_->push_back(ekin);
-}
-
-void SystemMonitor::write() {
-  // That's a text file, let's only write on one node.
-  if (system_->comm->rank() == 0) {
-    output_->write();
   }
 }
 
@@ -93,14 +77,12 @@ void SystemMonitor::info() {
 
 void SystemMonitor::addObservable(std::string name, shared_ptr<Observable> obs,
     bool is_visible) {
-  if (system_->comm->rank() == 0) {
-    observables_.push_back(std::make_pair(name, obs));
-    header_->push_back(name);
-    if (is_visible)
-      visible_observables_.push_back(1);
-    else
-      visible_observables_.push_back(0);
-  }
+  observables_.push_back(std::make_pair(name, obs));
+  header_->push_back(name);
+  if (is_visible)
+    visible_observables_.push_back(1);
+  else
+    visible_observables_.push_back(0);
 }
 
 void SystemMonitor::registerPython() {

--- a/src/analysis/SystemMonitor.hpp
+++ b/src/analysis/SystemMonitor.hpp
@@ -78,9 +78,6 @@ class SystemMonitor : public ParticleAccess {
     header_ = make_shared<std::vector<std::string> >();
     values_ = make_shared<std::vector<real> >();
 
-    temp_ = shared_ptr<Temperature>(new Temperature(system));
-    npart_ = shared_ptr<NPart>(new NPart(system));
-
     output_->system_ = system;
     output_->keys_ = header_;
     output_->values_ = values_;
@@ -89,10 +86,6 @@ class SystemMonitor : public ParticleAccess {
     if (system->comm->rank() == 0) {
       header_->push_back("step");
       header_->push_back("time");
-      header_->push_back("T");
-      header_->push_back("Ekin");
-      visible_observables_.push_back(1);
-      visible_observables_.push_back(1);
       visible_observables_.push_back(1);
       visible_observables_.push_back(1);
     }
@@ -106,9 +99,7 @@ class SystemMonitor : public ParticleAccess {
   static void registerPython();
 
  private:
-  void write();
   void computeObservables();
-  void computeKineticEnergy();
 
   void addObservable(std::string name, shared_ptr<Observable> obs, bool is_visible);
 
@@ -120,8 +111,6 @@ class SystemMonitor : public ParticleAccess {
   std::vector<int> visible_observables_;
   shared_ptr<System> system_;
   shared_ptr<integrator::MDIntegrator> integrator_;
-  shared_ptr<Temperature> temp_;
-  shared_ptr<NPart> npart_;
 
   shared_ptr<SystemMonitorOutputCSV> output_;
   ObservableList observables_;


### PR DESCRIPTION
Call to gather-all was not done on all cpus. Still it seems to be suboptimal as there is no point to have available the total calculations of observables on all cpus.

*minor*: removed calculation of a temperature and a kinetic energy in the SystemMonitor, it should be done
as other observables. 