### PR TITLE
Switch to new travis infrastructure 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,42 @@
 language: cpp
 
+sudo: false
+
+addons:
+  apt:
+    sources: boost-latest 
+    packages:
+      - ccache
+      - libfftw3-dev
+      - cmake
+      - doxygen
+      - libopenmpi-dev
+      - openmpi-bin
+      - libboost1.55-all-dev
+      - python-sphinx
+      - python-matplotlib
+
 before_install:
- - sudo add-apt-repository -y ppa:brad-froehle/backports #newer mpi4py
- - sudo add-apt-repository -y ppa:boost-latest/ppa  # boost 1.55
- - sudo apt-get update
- - sudo apt-get install cmake libfftw3-dev libopenmpi-dev openmpi-bin
- - if [[ $EXTERNAL = ON ]]; then sudo apt-get install libboost1.55-all-dev python-mpi4py; fi
- - if [[ $BUILD_UG = ON ]]; then sudo apt-get install python-sphinx python-matplotlib && git clone https://github.com/espressopp/espressopp.github.io.git doc/ug/_build/html; fi
- - if [[ $BUILD_UG = ON ]]; then wget --no-check-certificate -qO- http://www.cmake.org/files/v${CMAKE_VERSION:0:3}/cmake-${CMAKE_VERSION}.tar.gz | tar -xz && export cmake=$PWD/cmake-${CMAKE_VERSION}/bin/cmake; fi
+ - if [[ ${BUILD_UG} ]]; then git clone https://github.com/espressopp/espressopp.github.io.git doc/ug/_build/html; fi
+ - mkdir -p "$HOME/bin"
+ - if [[ ${CMAKE_VERSION} ]]; then wget --no-check-certificate -qO- http://www.cmake.org/files/v${CMAKE_VERSION:0:3}/cmake-${CMAKE_VERSION}.tar.gz | tar -xz && ln -s $PWD/cmake-${CMAKE_VERSION}/bin/cmake "$HOME/bin/cmake"; fi
+ - ln -s /usr/bin/ccache "$HOME/bin/clang++"
+ - ln -s /usr/bin/ccache "$HOME/bin/clang"
+ - if [[ ${EXTERNAL} = ON ]]; then pip install --user mpi4py==1.3.1; fi 
 
 env: #maybe add mpich later
-  - EXTERNAL=ON BUILD_UG=ON CMAKE_VERSION=3.1.3-Linux-x86_64
-  - EXTERNAL=OFF
+  global:
+    - CCACHE_CPP2=yes
+  matrix:
+    - EXTERNAL=ON BUILD_UG=ON CMAKE_VERSION=3.1.3-Linux-x86_64
+    - EXTERNAL=OFF
 
 script:
   - mkdir build && cd build && 
-    ${cmake:=cmake} -DEXTERNAL_BOOST=$EXTERNAL -DEXTERNAL_MPI4PY=$EXTERNAL .. && 
+    PATH="$HOME/bin:/usr/lib/ccache:$PATH" cmake -DEXTERNAL_BOOST=$EXTERNAL -DEXTERNAL_MPI4PY=$EXTERNAL .. && 
     make -j4 all ${BUILD_UG:+ug} &&
     make test ARGS="-V" &&
-    sudo make install
+    make install DESTDIR="${HOME}"
 
 after_success:
   - if [[ ${BUILD_UG} = ON && ${TRAVIS_JOB_NUMBER} = *.1 ]]; then
@@ -34,6 +52,10 @@ after_success:
         git diff --no-color;
       fi;
     fi
+
+cache:
+  directories:
+    - $HOME/.ccache
 
 compiler:
   - clang

--- a/cmake/FindMPI4PY.cmake
+++ b/cmake/FindMPI4PY.cmake
@@ -25,14 +25,20 @@ if(PYTHON_EXECUTABLE)
   else()
     set(MPI4PY_VERSION 0.0)
   endif()
+
+  execute_process(COMMAND
+      "${PYTHON_EXECUTABLE}" "-c" "import mpi4py; print mpi4py.get_include()"
+      OUTPUT_VARIABLE MPI4PY_INCLUDE_DIR
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+  
 endif(PYTHON_EXECUTABLE)
 
-find_path (MPI4PY_INCLUDES mpi4py/mpi4py.h HINTS ${PYTHON_SITEDIR}/mpi4py/include )
+find_path (MPI4PY_INCLUDES mpi4py/mpi4py.h HINTS ${MPI4PY_INCLUDE_DIR} ${PYTHON_SITEDIR}/mpi4py/include )
 if(NOT MPI4PY_INCLUDES)
   message("     mpi4py.h not found. Please make sure you have installed the developer version of mpi4py")
 endif()
 
-find_file (MPI4PY_LIBRARIES MPI.so HINTS ${PYTHON_SITEDIR}/mpi4py)
+find_file (MPI4PY_LIBRARIES MPI.so HINTS ${MPI4PY_INCLUDE_DIR}/.. ${PYTHON_SITEDIR}/mpi4py)
 
 # handle the QUIETLY and REQUIRED arguments and set MPI4PY_FOUND to TRUE if
 # all listed variables are TRUE


### PR DESCRIPTION
Container-based infrastructure see:
https://docs.travis-ci.com/user/workers/container-based-infrastructure/

In short:
- start up faster
- allow the use of caches for public repositories
- disallow the use of sudo, setuid and setgid executables
