### PR TITLE
Revert ".travis.yml: added code_climate token"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,3 @@ cache:
 compiler:
   - clang
   - gcc
-
-addons:
-  code_climate:
-   repo_token: 74ff64a9c455ce02fc2b30eac0a40b86c331585185742d1045f40299260f032c


### PR DESCRIPTION
This reverts commit 693a4ade9cf1e6b12d503f0374a315315722cb06.

Token is useless for c++ code, we will look into coverall.