### PR TITLE
Example of running uncrustify on the src/storage 

### DIFF
--- a/src/storage/CellGrid.cpp
+++ b/src/storage/CellGrid.cpp
@@ -1,24 +1,24 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
+
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include <cmath>
 
@@ -34,123 +34,117 @@ using namespace espressopp;
 LOG4ESPP_LOGGER(CellGrid::logger, "DomainDecomposition.CellGrid");
 
 CellGridIllegal::CellGridIllegal()
-  : std::runtime_error("cell grid dimensions have to be positive") {}
+      :std::runtime_error("cell grid dimensions have to be positive") { }
 
-CellGrid::CellGrid(const Int3D& _size, const real _myLeft[3], const real _myRight[3], int _frame):
-        Grid(_size[0]+2*_frame, _size[1]+2*_frame, _size[2]+2*_frame),
-        frame(_frame), extraSize(2*frame)
-{
-  if (_size[0] <= 0 || _size[1] <= 0 || _size[2] <= 0) {
+CellGrid::CellGrid(const Int3D &_size, const real _myLeft[3], const real _myRight[3], int _frame):
+  Grid(_size[0] + 2 * _frame, _size[1] + 2 * _frame, _size[2] + 2 * _frame),
+  frame(_frame), extraSize(2 * frame) {
+  if ((_size[0] <= 0) || (_size[1] <= 0) || (_size[2] <= 0)) {
     throw CellGridIllegal();
   }
 
-  for(int i = 0; i < 3; ++i) {
+  for (int i = 0; i < 3; ++i) {
     myLeft[i] = _myLeft[i];
     myRight[i] = _myRight[i];
 
-    cellSize[i]           = (myRight[i] - myLeft[i])/real(_size[i]);
+    cellSize[i]           = (myRight[i] - myLeft[i]) / real(_size[i]);
     invCellSize[i]        = 1.0 / cellSize[i];
   }
 
   smallestCellDiameter = std::min(std::min(cellSize[0], cellSize[1]), cellSize[2]);
 }
 
-longint CellGrid::getNumberOfInnerCells() const
-{
+longint CellGrid::getNumberOfInnerCells() const {
   longint res = getGridSize(0);
+
   for (int i = 1; i < 3; ++i) {
     res *= getGridSize(i);
   }
+
   return res;
 }
 
-
-longint CellGrid::mapPositionToCell(const Real3D& pos) const {
+longint CellGrid::mapPositionToCell(const Real3D &pos) const {
   int cpos[3];
 
-  for(int i = 0; i < 3; ++i) {
+  for (int i = 0; i < 3; ++i) {
     real lpos = pos[i] - myLeft[i];
+
     if (lpos <= 0) cpos[i] = 0;
-    else cpos[i] = static_cast<int>(lpos*invCellSize[i]) + frame;
+    else cpos[i] = static_cast<int>(lpos * invCellSize[i]) + frame;
   }
+
   return mapPositionToIndex(cpos);
 }
 
-
-longint CellGrid::mapPositionToCellClipped(const Real3D& pos) const
-{
+longint CellGrid::mapPositionToCellClipped(const Real3D &pos) const {
   int cpos[3];
 
-  for(int i = 0; i < 3; ++i) {
+  for (int i = 0; i < 3; ++i) {
     real lpos = pos[i] - myLeft[i];
 
-    cpos[i] = static_cast<int>(lpos*invCellSize[i]) + frame;
+    cpos[i] = static_cast<int>(lpos * invCellSize[i]) + frame;
 
     if (cpos[i] < frame) {
       cpos[i] = frame;
-    }
-    else if (cpos[i] >= getFrameGridSize(i) - frame) {
+    } else if (cpos[i] >= getFrameGridSize(i) - frame)   {
       cpos[i] = getFrameGridSize(i) - frame - 1;
     }
   }
-  return mapPositionToIndex(cpos);  
+
+  return mapPositionToIndex(cpos);
 }
 
-longint CellGrid::mapPositionToCellChecked(const Real3D& pos) const
-{
+longint CellGrid::mapPositionToCellChecked(const Real3D &pos) const {
   int cpos[3];
 
-  for(int i = 0; i < 3; ++i) {
+  for (int i = 0; i < 3; ++i) {
     real lpos = pos[i] - myLeft[i];
 
-    cpos[i] = static_cast<int>(lpos*invCellSize[i]) + frame;
-    
+    cpos[i] = static_cast<int>(lpos * invCellSize[i]) + frame;
+
     /* particles outside our box. Still take them if
        VERY close or nonperiodic boundary */
     if (cpos[i] < frame) {
       if (lpos >= -ROUND_ERROR_PREC) {
-	cpos[i] = frame;
+        cpos[i] = frame;
+      } else   {
+        return noCell;
       }
-      else {
-	return noCell;
-      }
-    }
-    else if (cpos[i] >= getFrameGridSize(i) - frame) {
+    } else if (cpos[i] >= getFrameGridSize(i) - frame)   {
       if (pos[i] <= myRight[i] + ROUND_ERROR_PREC) {
-	cpos[i] = getFrameGridSize(i) - frame - 1;
-      }
-      else {
-	return noCell;
+        cpos[i] = getFrameGridSize(i) - frame - 1;
+      } else   {
+        return noCell;
       }
     }
   }
-  return mapPositionToIndex(cpos);  
+
+  return mapPositionToIndex(cpos);
 }
 
-bool CellGrid::mapPositionToCellCheckedAndClipped(longint &cell, const Real3D& pos) const
-{
+bool CellGrid::mapPositionToCellCheckedAndClipped(longint &cell, const Real3D &pos) const {
   int cpos[3];
   bool outside = false;
 
-  for(int i = 0; i < 3; ++i) {
+  for (int i = 0; i < 3; ++i) {
     real lpos = pos[i] - myLeft[i];
 
-    cpos[i] = static_cast<int>(lpos*invCellSize[i]) + frame;
-    
+    cpos[i] = static_cast<int>(lpos * invCellSize[i]) + frame;
+
     /* particles outside our box. Still take them if
        VERY close or nonperiodic boundary */
     if (cpos[i] < frame) {
       cpos[i] = frame;
 
       if (lpos < -ROUND_ERROR_PREC) {
-	outside = true;
+        outside = true;
       }
-    }
-    else if (cpos[i] >= getFrameGridSize(i) - frame) {
+    } else if (cpos[i] >= getFrameGridSize(i) - frame)   {
       cpos[i] = getFrameGridSize(i) - frame - 1;
 
       if (pos[i] > myRight[i] + ROUND_ERROR_PREC) {
-	outside = true;
+        outside = true;
       }
     }
   }
@@ -158,13 +152,13 @@ bool CellGrid::mapPositionToCellCheckedAndClipped(longint &cell, const Real3D& p
   cell = mapPositionToIndex(cpos);
 
   LOG4ESPP_TRACE(logger, "mapping position ("
-		 << pos[0] << ", "
-		 << pos[1] << ", "
-		 << pos[2] << ") to grid position ("
-		 << cpos[0] << ", "
-		 << cpos[1] << ", "
-		 << cpos[2] << ") <-> "
-		 << cell);
+          << pos[0] << ", "
+          << pos[1] << ", "
+          << pos[2] << ") to grid position ("
+          << cpos[0] << ", "
+          << cpos[1] << ", "
+          << cpos[2] << ") <-> "
+          << cell);
 
   return outside;
 }

--- a/src/storage/CellGrid.hpp
+++ b/src/storage/CellGrid.hpp
@@ -1,31 +1,32 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
+
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 // ESPP_CLASS
 #ifndef _STORAGE_CELLGRID_HPP
 #define _STORAGE_CELLGRID_HPP
+
 /*
-  local ghost cell grid representation. Taken from domain_decomposition.c.
-*/
+   local ghost cell grid representation. Taken from domain_decomposition.c.
+ */
 
 #include <stdexcept>
 #include "esutil/Grid.hpp"
@@ -33,138 +34,148 @@
 #include "Real3D.hpp"
 
 namespace espressopp {
-  class CellGridIllegal: public std::runtime_error
-  {
-  public:
-    CellGridIllegal();
-  };
+class CellGridIllegal : public std::runtime_error {
+public:
+  CellGridIllegal();
+};
 
+/** Grid with a ghost frame. This represents the cell grid of the
+    domain decomposition. */
+class CellGrid : public esutil::Grid {
+public:
+  CellGrid() { }
 
-  /** Grid with a ghost frame. This represents the cell grid of the
-      domain decomposition. */
-  class CellGrid: public esutil::Grid
-  {
-  public:
-    CellGrid() {}
+  CellGrid(const Int3D &grid,const real _myLeft[3],const real _myRight[3],int frame);
 
-    CellGrid(const Int3D& grid,
-	     const real _myLeft[3],
-	     const real _myRight[3],
-	     int frame);
+  int getFrameWidth() const {return frame; }
 
-    int getFrameWidth() const { return frame; }
+  /// map coordinate to cell (ghost or non-ghost). This is used for AdResS
+  longint mapPositionToCell(const Real3D &pos) const;
 
-    /// map coordinate to cell (ghost or non-ghost). This is used for AdResS
-    longint mapPositionToCell(const Real3D& pos) const;
-    /// map coordinate to a non-ghost cell. Positions outside the inner grid are clipped back
-    longint mapPositionToCellClipped(const Real3D& pos) const;
-    /// map coordinate to a non-ghost cell. Returns noCell if the position is outside the inner grid
-    longint mapPositionToCellChecked(const Real3D& pos) const;
-    /** map coordinate to a non-ghost cell. Returns true if the returned cell is clipped, i.e. the
-	position is outside the inner grid */
-    bool mapPositionToCellCheckedAndClipped(longint &, const Real3D& pos) const;
+  /// map coordinate to a non-ghost cell. Positions outside the inner grid are clipped back
+  longint mapPositionToCellClipped(const Real3D &pos) const;
 
-    /// check wether a position is in the inner domain
-    bool isInnerPosition(real pos[3]) {
-      return (pos[0] >= getMyLeft(0) && pos[0] < getMyRight(0) &&
-              pos[1] >= getMyLeft(1) && pos[1] < getMyRight(1) &&
-              pos[2] >= getMyLeft(2) && pos[2] < getMyRight(2));
-    }
-    /// check whether a cell is in the inner grid
-    bool isInnerCell(int m, int n, int o) const {
-      return (m >= getInnerCellsBegin(0) && m < getInnerCellsEnd(0)) &&
-             (n >= getInnerCellsBegin(1) && n < getInnerCellsEnd(1)) &&
-             (o >= getInnerCellsBegin(2) && o < getInnerCellsEnd(2));
-    }
+  /// map coordinate to a non-ghost cell. Returns noCell if the position is outside the inner grid
+  longint mapPositionToCellChecked(const Real3D &pos) const;
 
-    /// get start of inner grid
-    longint getInnerCellsBegin(int i) const { return frame; }
-    /// get first element after inner elements
-    longint getInnerCellsEnd(int i) const { return Grid::getGridSize(i) - frame; }
+  /** map coordinate to a non-ghost cell. Returns true if the returned cell is clipped, i.e. the
+     position is outside the inner grid */
+  bool mapPositionToCellCheckedAndClipped(longint &, const Real3D &pos) const;
 
-    /// inner size without the ghost frame
-    int getGridSize(int i)      const { return Grid::getGridSize(i) - extraSize; }
-    /// full size including the ghost frame
-    int getFrameGridSize(int i) const { return Grid::getGridSize(i); }
+  /// check wether a position is in the inner domain
+  bool isInnerPosition(real pos[3]) {
+    return pos[0] >= getMyLeft(0) && pos[0] < getMyRight(0) &&
+           pos[1] >= getMyLeft(1) && pos[1] < getMyRight(1) &&
+           pos[2] >= getMyLeft(2) && pos[2] < getMyRight(2);
+  }
 
-    /// start coordinates of the domain
-    real getMyLeft(int i) const { return myLeft[i]; }
-    /// start coordinates of the domain
-    const real *getMyLeft() const { return myLeft; }
-    /// end coordinates of the domain
-    real getMyRight(int i) const { return myRight[i]; }
-    /// end coordinates of the domain
-    const real *getMyRight() const { return myRight; }
+  /// check whether a cell is in the inner grid
+  bool isInnerCell(int m, int n, int o) const {
+    return (m >= getInnerCellsBegin(0) && m < getInnerCellsEnd(0)) &&
+           (n >= getInnerCellsBegin(1) && n < getInnerCellsEnd(1)) &&
+           (o >= getInnerCellsBegin(2) && o < getInnerCellsEnd(2));
+  }
 
-    /// size of a cell
-    real getCellSize(int i) const { return cellSize[i]; }
-    /// size of a cell
-    const real *getCellSize() const { return cellSize; }
+  /// get start of inner grid
+  longint getInnerCellsBegin(int i) const {return frame; }
 
-    /// inverse of the size of a cell
-    real getInverseCellSize(int i) const { return invCellSize[i]; }
-    /// inverse of the size of a cell
-    const real *getInverseCellSize() const { return invCellSize; }
+  /// get first element after inner elements
+  longint getInnerCellsEnd(int i) const {return Grid::getGridSize(i) - frame; }
 
-    longint getNumberOfInnerCells() const;
+  /// inner size without the ghost frame
+  int getGridSize(int i)      const {return Grid::getGridSize(i) - extraSize; }
 
-    real getSmallestCellDiameter() const { return smallestCellDiameter; }
+  /// full size including the ghost frame
+  int getFrameGridSize(int i) const {return Grid::getGridSize(i); }
 
-    static const longint noCell = static_cast<longint>(-1);
+  /// start coordinates of the domain
+  real getMyLeft(int i) const {return myLeft[i]; }
 
-    void scaleVolume(real s) {
-      if (s > 0) {
-    	for (int i=0; i<3; ++i) {
-    	  myLeft[i] *= s;
-    	  myRight[i] *= s;
-    	  cellSize[i] *= s;
-    	  invCellSize[i] /= s;
-    	}
-        smallestCellDiameter *= s;
+  /// start coordinates of the domain
+  const real *getMyLeft() const {return myLeft; }
+
+  /// end coordinates of the domain
+  real getMyRight(int i) const {return myRight[i]; }
+
+  /// end coordinates of the domain
+  const real *getMyRight() const {return myRight; }
+
+  /// size of a cell
+  real getCellSize(int i) const {return cellSize[i]; }
+
+  /// size of a cell
+  const real *getCellSize() const {return cellSize; }
+
+  /// inverse of the size of a cell
+  real getInverseCellSize(int i) const {return invCellSize[i]; }
+
+  /// inverse of the size of a cell
+  const real *getInverseCellSize() const {return invCellSize; }
+
+  longint getNumberOfInnerCells() const;
+
+  real getSmallestCellDiameter() const {return smallestCellDiameter; }
+
+  static const longint noCell = static_cast<longint>(-1);
+
+  void scaleVolume(real s) {
+    if (s > 0) {
+      for (int i = 0; i < 3; ++i) {
+        myLeft[i] *= s;
+        myRight[i] *= s;
+        cellSize[i] *= s;
+        invCellSize[i] /= s;
       }
-      else {
-    	  ;
-    	  // TODO: do nothing or throw error if s <= 0 ?
-      }
+
+      smallestCellDiameter *= s;
+    } else   {
+      ;
+
+      // TODO: do nothing or throw error if s <= 0 ?
     }
-    void scaleVolume(Real3D s) {
-      if (s[0]>0 && s[1]>0 && s[2]>0) {
-    	for (int i=0; i<3; ++i) {
-    	  myLeft[i] *= s[i];
-    	  myRight[i] *= s[i];
-    	  cellSize[i] *= s[i];
-    	  invCellSize[i] /= s[i];
-    	}
-        smallestCellDiameter = std::min(std::min(cellSize[0], cellSize[1]), cellSize[2]);
+  }
+
+  void scaleVolume(Real3D s) {
+    if ((s[0] > 0) && (s[1] > 0) && (s[2] > 0)) {
+      for (int i = 0; i < 3; ++i) {
+        myLeft[i] *= s[i];
+        myRight[i] *= s[i];
+        cellSize[i] *= s[i];
+        invCellSize[i] /= s[i];
       }
-      else {
-    	  ;
-    	  // TODO: do nothing or throw error if s <= 0 ?
-      }
+
+      smallestCellDiameter = std::min(std::min(cellSize[0], cellSize[1]), cellSize[2]);
+    } else   {
+      ;
+
+      // TODO: do nothing or throw error if s <= 0 ?
     }
-    
+  }
 
-  private:
-    /// size of frame around
-    int frame;
-    /// twice the size of frame around
-    int extraSize;
+private:
+  /// size of frame around
+  int frame;
 
-    /// Left (bottom, front) corner of the inner domain
-    real myLeft[3];
-    /// Right (top, back) corner of the inner domain
-    real myRight[3];
+  /// twice the size of frame around
+  int extraSize;
 
-    /// cell size
-    real cellSize[3];
-    /// inverse cell size
-    real invCellSize[3];
+  /// Left (bottom, front) corner of the inner domain
+  real myLeft[3];
 
-    /// smallest diameter of the cell
-    real smallestCellDiameter;
+  /// Right (top, back) corner of the inner domain
+  real myRight[3];
 
-    static LOG4ESPP_DECL_LOGGER(logger);
-  };
+  /// cell size
+  real cellSize[3];
+
+  /// inverse cell size
+  real invCellSize[3];
+
+  /// smallest diameter of the cell
+  real smallestCellDiameter;
+
+  static LOG4ESPP_DECL_LOGGER(logger);
+};
 }
 
 #endif

--- a/src/storage/DomainDecomposition.cpp
+++ b/src/storage/DomainDecomposition.cpp
@@ -1,25 +1,24 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
 
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "python.hpp"
 
@@ -43,744 +42,797 @@
 using namespace boost;
 using namespace std;
 
-namespace espressopp { 
-  namespace storage {
+namespace espressopp {
+namespace storage {
+const int DD_COMM_TAG = 0xab;
+
+LOG4ESPP_LOGGER(DomainDecomposition::logger, "DomainDecomposition");
+
+std::string formatMismatchMessage(const Int3D &gridRequested,int
+    nodesAvailable) {
+  std::ostringstream out;
 
 
-  const int DD_COMM_TAG = 0xab;
+  out << "requested node grid (" << gridRequested
+      << ") does not match number of nodes in the communicator (" << nodesAvailable << ")";
+  return out.str();
+}
 
-  LOG4ESPP_LOGGER(DomainDecomposition::logger, "DomainDecomposition");
+NodeGridMismatch::NodeGridMismatch(const Int3D &gridRequested, int nodesAvailable)
+      :std::invalid_argument
+            (formatMismatchMessage(gridRequested, nodesAvailable))
+{ }
 
-  std::string formatMismatchMessage(const Int3D& gridRequested,
-                    int nodesAvailable) {
-    std::ostringstream out;
-    out << "requested node grid (" << gridRequested
-            << ") does not match number of nodes in the communicator (" << nodesAvailable << ")";
-    return out.str();
-  }
-
-  NodeGridMismatch::
-  NodeGridMismatch(const Int3D& gridRequested, int nodesAvailable)
-    : std::invalid_argument
-  (formatMismatchMessage(gridRequested, nodesAvailable))
-  {}
-
-  DomainDecomposition::
-  DomainDecomposition(shared_ptr< System > _system,
-          const Int3D& _nodeGrid,
-          const Int3D& _cellGrid)
-    : Storage(_system), exchangeBufferSize(0) {
-    LOG4ESPP_INFO(logger, "node grid = "
+DomainDecomposition::DomainDecomposition(shared_ptr<System> _system,const Int3D &_nodeGrid,const
+    Int3D &_cellGrid)
+      :Storage(_system), exchangeBufferSize(0) {
+  LOG4ESPP_INFO(logger, "node grid = "
           << _nodeGrid[0] << "x" << _nodeGrid[1] << "x" << _nodeGrid[2]
           << " cell grid = "
           << _cellGrid[0] << "x" << _cellGrid[1] << "x" << _cellGrid[2]);
 
-    createCellGrid(_nodeGrid, _cellGrid);
-    initCellInteractions();
-    prepareGhostCommunication();
-    LOG4ESPP_DEBUG(logger, "done");
+  createCellGrid(_nodeGrid, _cellGrid);
+  initCellInteractions();
+  prepareGhostCommunication();
+  LOG4ESPP_DEBUG(logger, "done");
+}
+
+void DomainDecomposition::createCellGrid(const Int3D &_nodeGrid, const Int3D &_cellGrid) {
+  real myLeft[3];
+  real myRight[3];
+
+
+  nodeGrid = NodeGrid(_nodeGrid, getSystem()->comm->rank(), getSystem()->bc->getBoxL());
+
+  if (nodeGrid.getNumberOfCells() != getSystem()->comm->size()) {
+    throw NodeGridMismatch(_nodeGrid, getSystem()->comm->size());
   }
 
-  void DomainDecomposition:: createCellGrid(const Int3D& _nodeGrid, const Int3D& _cellGrid) {
-    real myLeft[3];
-    real myRight[3];
-
-    nodeGrid = NodeGrid(_nodeGrid, getSystem()->comm->rank(), getSystem()->bc->getBoxL());
-
-    if (nodeGrid.getNumberOfCells() != getSystem()->comm->size()) {
-      throw NodeGridMismatch(_nodeGrid, getSystem()->comm->size());
-    }
-
-    LOG4ESPP_INFO(logger, "my node grid position: "
+  LOG4ESPP_INFO(logger, "my node grid position: "
           << nodeGrid.getNodePosition(0) << " "
           << nodeGrid.getNodePosition(1) << " "
           << nodeGrid.getNodePosition(2) << " -> "
           << getSystem()->comm->rank());
 
-    LOG4ESPP_DEBUG(logger, "my neighbors: "
-           << nodeGrid.getNodeNeighborIndex(0) << "<->"
-           << nodeGrid.getNodeNeighborIndex(1) << ", "
-           << nodeGrid.getNodeNeighborIndex(2) << "<->"
-           << nodeGrid.getNodeNeighborIndex(3) << ", "
-           << nodeGrid.getNodeNeighborIndex(4) << "<->"
-           << nodeGrid.getNodeNeighborIndex(5));
+  LOG4ESPP_DEBUG(logger, "my neighbors: "
+          << nodeGrid.getNodeNeighborIndex(0) << "<->"
+          << nodeGrid.getNodeNeighborIndex(1) << ", "
+          << nodeGrid.getNodeNeighborIndex(2) << "<->"
+          << nodeGrid.getNodeNeighborIndex(3) << ", "
+          << nodeGrid.getNodeNeighborIndex(4) << "<->"
+          << nodeGrid.getNodeNeighborIndex(5));
 
-    for (int i = 0; i < 3; ++i) {
-      myLeft[i] = nodeGrid.getMyLeft(i);
-      myRight[i] = nodeGrid.getMyRight(i);
-    }
+  for (int i = 0; i < 3; ++i) {
+    myLeft[i] = nodeGrid.getMyLeft(i);
+    myRight[i] = nodeGrid.getMyRight(i);
+  }
 
-    cellGrid = CellGrid(_cellGrid, myLeft, myRight, 1);
+  cellGrid = CellGrid(_cellGrid, myLeft, myRight, 1);
 
-    LOG4ESPP_INFO(logger, "local box "
+  LOG4ESPP_INFO(logger, "local box "
           << myLeft[0] << "-" << myRight[0] << ", "
           << myLeft[1] << "-" << myRight[1] << ", "
           << myLeft[2] << "-" << myRight[2]);
 
-    longint nLocalCells = 1;
-    longint nRealCells = 1;
-    for (int i = 0; i < 3; ++i) {
-      nRealCells *= cellGrid.getGridSize(i);
-      nLocalCells *= cellGrid.getFrameGridSize(i);
-    }
+  longint nLocalCells = 1;
+  longint nRealCells = 1;
 
-    resizeCells(nLocalCells);
-
-    realCells.reserve(nRealCells);
-    ghostCells.reserve(nLocalCells - nRealCells);
-
-    markCells();
-
-    LOG4ESPP_DEBUG(logger, "total # cells=" << nLocalCells
-           << ", # real cells=" << nRealCells
-           << ", frame cell grid = (" << cellGrid.getFrameGridSize(0)
-           << ", " << cellGrid.getFrameGridSize(1)
-           << ", " << cellGrid.getFrameGridSize(2)
-           << ")");
+  for (int i = 0; i < 3; ++i) {
+    nRealCells *= cellGrid.getGridSize(i);
+    nLocalCells *= cellGrid.getFrameGridSize(i);
   }
 
-  void DomainDecomposition::markCells() {
-    realCells.resize(0);
-    ghostCells.resize(0);
+  resizeCells(nLocalCells);
 
-    for (int o = 0; o < cellGrid.getFrameGridSize(2); ++o) {
-      for (int n = 0; n < cellGrid.getFrameGridSize(1); ++n) {
-        for (int m = 0; m < cellGrid.getFrameGridSize(0); ++m) {
-          Cell *cur = &cells[cellGrid.mapPositionToIndex(m, n, o)];
-          if (cellGrid.isInnerCell(m, n, o)) {
-            LOG4ESPP_TRACE(logger, "cell " << (cur - &cells[0]) << " is inner cell (" << m << ", " << n << ", " << o << ")");
-            realCells.push_back(cur);
-          } else {
-            LOG4ESPP_TRACE(logger, "cell " << (cur - &cells[0]) << " is ghost cell (" << m << ", " << n << ", " << o << ")");
-            ghostCells.push_back(cur);
-          }
-        }
-      }
-    }
-  }
+  realCells.reserve(nRealCells);
+  ghostCells.reserve(nLocalCells - nRealCells);
 
-  // TODO one should take care of rc and system size
-  /** scale position coordinates of all real particles by factor s */
-  void DomainDecomposition::scaleVolume(real s, bool particleCoordinates){
-	if(particleCoordinates) Storage::scaleVolume( s );
-    
-    real maxCut = getSystem() -> maxCutoff;
-    real skinL = getSystem() -> getSkin();
-    real cs = maxCut + skinL;
-    if( cs > s*cellGrid.getSmallestCellDiameter() ){
-      Real3D Li = getSystem() -> bc -> getBoxL(); // getting the system size
-      real minL = min(Li[0], min(Li[1],Li[2]));
-      if(cs > minL){
-        esutil::Error err(getSystemRef().comm);
-        stringstream msg;
-        msg<<"Error. The current system size "<< minL <<" smaller then cutoff+skin "<< cs;
-        err.setException( msg.str() );
-      }
-      else{
-        cellAdjust();
-      }
-    }
-    else{
-      cellGrid.scaleVolume( s );
-      nodeGrid.scaleVolume( s );
-    }
-  }
-  // anisotropic version
-  void DomainDecomposition::scaleVolume(Real3D s, bool particleCoordinates){
-	if(particleCoordinates) Storage::scaleVolume( s );
-    
-    real maxCut = getSystem() -> maxCutoff;
-    real skinL = getSystem() -> getSkin();
-    real cs = maxCut + skinL;
-    real cellD = cellGrid.getSmallestCellDiameter();
-    
-    real r0 = s[0]*cellD;
-    real r1 = s[1]*cellD;
-    real r2 = s[2]*cellD;
-    
-    if( cs > min( min( r0, r1), r2 ) ){
-      Real3D Li = getSystem() -> bc -> getBoxL(); // getting the system size
-      real minL = min(Li[0], min(Li[1],Li[2]));
-      if(cs > minL){
-        esutil::Error err(getSystemRef().comm);
-        stringstream msg;
-        msg<<"Error. The current system size "<< minL <<" smaller then cutoff+skin "<< cs;
-        err.setException( msg.str() );
-      }
-      else
-        cellAdjust();
-    }
-    else{
-      cellGrid.scaleVolume(s);
-      nodeGrid.scaleVolume(s);
-    }
-  }
-  
-  Int3D DomainDecomposition::getInt3DCellGrid(){
-    return Int3D( cellGrid.getGridSize(0),
-                  cellGrid.getGridSize(1),
-                  cellGrid.getGridSize(2)
-                );
-  }
-  Int3D DomainDecomposition::getInt3DNodeGrid(){
-    return Int3D( nodeGrid.getGridSize(0),
-                  nodeGrid.getGridSize(1),
-                  nodeGrid.getGridSize(2)
-                );
-  }
+  markCells();
 
-  void DomainDecomposition::cellAdjust(){
-    // create an appropriate cell grid
-    Real3D box_sizeL = getSystem() -> bc -> getBoxL();
-    real skinL = getSystem() -> getSkin();
-    real maxCutoffL = getSystem() -> maxCutoff;
-            
-    // nodeGrid is already defined
-    Int3D _nodeGrid(nodeGrid.getGridSize());
-    // new cellGrid
-    real rc_skin = maxCutoffL + skinL;
-    int ix = (int)(box_sizeL[0] / (rc_skin * _nodeGrid[0]));
-    int iy = (int)(box_sizeL[1] / (rc_skin * _nodeGrid[1]));
-    int iz = (int)(box_sizeL[2] / (rc_skin * _nodeGrid[2]));
-    Int3D _newCellGrid(ix, iy, iz);
+  LOG4ESPP_DEBUG(logger, "total # cells=" << nLocalCells
+                                          << ", # real cells=" << nRealCells
+                                          << ", frame cell grid = (" << cellGrid.getFrameGridSize(0)
+                                          << ", " << cellGrid.getFrameGridSize(1)
+                                          << ", " << cellGrid.getFrameGridSize(2)
+                                          << ")");
+}
 
-    // save all particles to temporary vector
-    std::vector<ParticleList> tmp_pl;
-    size_t _N = realCells.size();
-    tmp_pl.reserve( _N );
-    for(CellList::Iterator it(realCells); it.isValid(); ++it) {
-      tmp_pl.push_back((*it)->particles);
-    }
-    
-    // reset all cells info
-    invalidateGhosts();
-    cells.clear();
-    localCells.clear();
-    realCells.clear();
-    ghostCells.clear();
-    for(int i=0; i<6; i++){
-      commCells[i].reals.clear();
-      commCells[i].ghosts.clear();
-    }
-    
-    // creating new grids
-    createCellGrid(_nodeGrid, _newCellGrid);
-    initCellInteractions();
-    prepareGhostCommunication();
-    
-    // pushing the particles back to the empty cell ("do we have to check particles?")
-    for(int i=0; i<tmp_pl.size(); i++){
-      for (size_t p = 0; p < tmp_pl[i].size(); ++p) {
-        Particle& part = tmp_pl[i][p];
-        const Real3D& pos = part.position();
-        Cell *sortCell = mapPositionToCellClipped(pos);
-        appendUnindexedParticle(sortCell->particles, part);
-      }
-    }
+void DomainDecomposition::markCells() {
+  realCells.resize(0);
+  ghostCells.resize(0);
 
-    for(CellList::Iterator it(realCells); it.isValid(); ++it) {
-      updateLocalParticles((*it)->particles);
-    }
-    
-    exchangeGhosts();
-    onParticlesChanged();
-  }
+  for (int o = 0; o < cellGrid.getFrameGridSize(2); ++o) {
+    for (int n = 0; n < cellGrid.getFrameGridSize(1); ++n) {
+      for (int m = 0; m < cellGrid.getFrameGridSize(0); ++m) {
+        Cell *cur = &cells[cellGrid.mapPositionToIndex(m, n, o)];
 
-  void DomainDecomposition::initCellInteractions() {
-    LOG4ESPP_DEBUG(logger, "setting up neighbors for " << cells.size() << " cells");
-
-    for (int o = cellGrid.getInnerCellsBegin(2); o < cellGrid.getInnerCellsEnd(2); ++o) {
-      for (int n = cellGrid.getInnerCellsBegin(1); n < cellGrid.getInnerCellsEnd(1); ++n) {
-        for (int m = cellGrid.getInnerCellsBegin(0); m < cellGrid.getInnerCellsEnd(0); ++m) {
-          longint cellIdx = cellGrid.mapPositionToIndex(m, n, o);
-          Cell *cell = &cells[cellIdx];
-
-          LOG4ESPP_TRACE(logger, "setting up neighbors for cell " << cell - getFirstCell()
-                << " @ " << m << " " << n << " " << o);
-
-          // there should be always 26 neighbors
-          cell->neighborCells.reserve(26);
-
-          // loop all neighbor cells
-          for (int p = o - 1; p <= o + 1; ++p) {
-            for (int q = n - 1; q <= n + 1; ++q) {
-              for (int r = m - 1; r <= m + 1; ++r) {
-                if (p != o || q != n || r != m) {
-                  longint cell2Idx = cellGrid.mapPositionToIndex(r, q, p);
-                  Cell *cell2 = &cells[cell2Idx];
-                  cell->neighborCells.push_back(NeighborCellInfo(cell2, (cell2Idx<cellIdx)));
-
-                  LOG4ESPP_TRACE(logger, "neighbor cell " << cell2 - getFirstCell()
-                        << " @ " << r << " " << q << " " << p << ((cell2Idx<cellIdx) ? " is" : " is not") << " taken" );
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    LOG4ESPP_DEBUG(logger, "done");
-  }
-
-  Cell *DomainDecomposition::mapPositionToCell(const Real3D& pos) {
-    return &cells[cellGrid.mapPositionToCell(pos)];
-  }
-
-  Cell *DomainDecomposition::mapPositionToCellClipped(const Real3D& pos) {
-    return &cells[cellGrid.mapPositionToCellClipped(pos)];
-  }
-
-  Cell *DomainDecomposition::mapPositionToCellChecked(const Real3D& pos) {
-    longint c = cellGrid.mapPositionToCellChecked(pos);
-    if (c == CellGrid::noCell) {
-      return 0;
-    }
-    else{
-      return &cells[c];
-    }
-  }
-
-  longint DomainDecomposition::mapPositionToNodeClipped(const Real3D& pos) {
-    return nodeGrid.mapPositionToNodeClipped(pos);
-  }
-
-  bool DomainDecomposition::checkIsRealParticle(longint id, const Real3D& pos) {
-    return getSystem()->comm->rank() == mapPositionToNodeClipped(pos);
-  }
-
-  bool DomainDecomposition::appendParticles(ParticleList &l, int dir) {
-    bool outlier = false;
-
-    LOG4ESPP_DEBUG(logger, "got " << l.size() << " particles");
-
-    for (ParticleList::iterator it = l.begin(), end = l.end(); it != end; ++it) {
-      Real3D& pos = it->position();
-
-      if (nodeGrid.getBoundary(dir) != 0) {
-          getSystem()->bc->foldCoordinate(pos, it->image(), nodeGrid.convertDirToCoord(dir));
-          LOG4ESPP_TRACE(logger, "folded coordinate " << nodeGrid.convertDirToCoord(dir)
-                  << " of particle " << it->id());
-      }
-
-      longint cell;
-      if (cellGrid.mapPositionToCellCheckedAndClipped(cell, pos)) {
-          LOG4ESPP_TRACE(logger, "particle " << it->id()
-                  << " @ " << pos << " is not inside node domain");
-          outlier = true;
-      }
-
-      LOG4ESPP_TRACE(logger, "append part " << it->id() << " to cell "
-              << cell);
-
-      appendIndexedParticle(cells[cell].particles, *it);
-    }
-    return outlier;
-  }
-
-  void DomainDecomposition::decomposeRealParticles() {
-
-      //std::cout << getSystem()->comm->rank() << ": " << " decomposeRealParticles\n";
-
-    LOG4ESPP_DEBUG(logger, "starting, expected comm buffer size " << exchangeBufferSize);
-
-    // allocate send/recv buffers. We use the size as we need maximally so far, to avoid reallocation
-    // TODO: This might be a problem when all particles are created on a single node initially!
-    ParticleList sendBufL;
-    sendBufL.reserve(exchangeBufferSize);
-    ParticleList sendBufR;
-    sendBufR.reserve(exchangeBufferSize);
-    ParticleList recvBufL;
-    recvBufL.reserve(exchangeBufferSize);
-    ParticleList recvBufR;
-    recvBufR.reserve(exchangeBufferSize);
-
-    bool allFinished;
-    do {
-      bool finished = true;
-
-      for (int coord = 0; coord < 3; ++coord) {
-        LOG4ESPP_DEBUG(logger, "starting with direction " << coord);
-
-        if (nodeGrid.getGridSize(coord) > 1) {
-          for (std::vector<Cell*>::iterator it = realCells.begin(),
-            end = realCells.end(); it != end; ++it) {
-
-            Cell &cell = **it;
-
-            // do not use an iterator here, since we need to take out particles during the loop
-            for (size_t p = 0; p < cell.particles.size(); ++p) {
-              Particle &part = cell.particles[p];
-              const Real3D& pos = part.position();
-
-              // check whether the particle is now "left" of the local domain
-              if (pos[coord] - cellGrid.getMyLeft(coord) < -ROUND_ERROR_PREC) {
-                LOG4ESPP_TRACE(logger, "send particle left " << part.id());
-                moveIndexedParticle(sendBufL, cell.particles, p);
-                // redo same particle since we took one out here, so it's a new one
-                --p;
-              }
-              // check whether the particle is now "right" of the local domain
-              else if (pos[coord] - cellGrid.getMyRight(coord) >= ROUND_ERROR_PREC) {
-                LOG4ESPP_TRACE(logger, "send particle right " << part.id());
-                moveIndexedParticle(sendBufR, cell.particles, p);
-                --p;
-              }
-              // Sort particles in cells of this node during last direction
-              else if (coord == 2) {
-                const Real3D& pos = part.position();
-                Cell *sortCell = mapPositionToCellChecked(pos);
-                if (sortCell != &cell) {
-                  if (sortCell == 0) {
-                    // particle is not in the local domain
-                    LOG4ESPP_DEBUG(logger, "take another loop: particle " << part.id()
-                            << " @ " << pos <<
-                            " is not inside node domain after neighbor exchange");
-                    // isnan function is C99 only, x != x is only true if x == nan
-                    if (pos[0] != pos[0] || pos[1] != pos[1] || pos[2] != pos[2]) {
-                      // TODO: error handling
-                      LOG4ESPP_ERROR(logger, "particle " << part.id() <<
-                              " has moved to outer space (one or more coordinates are nan)");
-                    } else {
-                      // particle stays where it is, and will be sorted in the next round
-                      finished = false;
-                    }
-                  } else {
-                    // particle is in the local domain
-                    moveIndexedParticle(sortCell->particles, cell.particles, p);
-                    --p;
-                  }
-                }
-              }
-
-            }
-          }
-
-          // Exchange particles, odd-even rule
-          if (nodeGrid.getNodePosition(coord) % 2 == 0) {
-            sendParticles(sendBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
-            recvParticles(recvBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
-            sendParticles(sendBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
-            recvParticles(recvBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
-          } else {
-            recvParticles(recvBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
-            sendParticles(sendBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
-            recvParticles(recvBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
-            sendParticles(sendBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
-          }
-
-          // sort received particles to cells
-          if (appendParticles(recvBufL, 2 * coord) && coord == 2) finished = false;
-          if (appendParticles(recvBufR, 2 * coord + 1) && coord == 2) finished = false;
-
-          // reset send/recv buffers
-          sendBufL.resize(0);
-          sendBufR.resize(0);
-          recvBufL.resize(0);
-          recvBufR.resize(0);
-
-
+        if (cellGrid.isInnerCell(m, n, o)) {
+          LOG4ESPP_TRACE(logger, "cell " << (cur - &cells[0]) << " is inner cell (" << m << ", " <<
+                  n << ", " << o << ")");
+          realCells.push_back(cur);
         } else {
-          /* Single node direction case (no communication)
-            Fold particles that have left the box */
-          for (std::vector< Cell* >::iterator it = realCells.begin(),
+          LOG4ESPP_TRACE(logger, "cell " << (cur - &cells[0]) << " is ghost cell (" << m << ", " <<
+                  n << ", " << o << ")");
+          ghostCells.push_back(cur);
+        }
+      }
+    }
+  }
+}
+
+// TODO one should take care of rc and system size
+
+/** scale position coordinates of all real particles by factor s */
+void DomainDecomposition::scaleVolume(real s, bool particleCoordinates) {
+  if (particleCoordinates) Storage::scaleVolume(s);
+
+  real maxCut = getSystem()->maxCutoff;
+  real skinL = getSystem()->getSkin();
+  real cs = maxCut + skinL;
+
+  if (cs > s * cellGrid.getSmallestCellDiameter()) {
+    Real3D Li = getSystem()->bc->getBoxL();       // getting the system size
+    real minL = min(Li[0], min(Li[1],Li[2]));
+
+    if (cs > minL) {
+      esutil::Error err(getSystemRef().comm);
+      stringstream msg;
+
+      msg << "Error. The current system size " << minL << " smaller then cutoff+skin " << cs;
+      err.setException(msg.str());
+    } else {
+      cellAdjust();
+    }
+  } else {
+    cellGrid.scaleVolume(s);
+    nodeGrid.scaleVolume(s);
+  }
+}
+
+// anisotropic version
+void DomainDecomposition::scaleVolume(Real3D s, bool particleCoordinates) {
+  if (particleCoordinates) Storage::scaleVolume(s);
+
+  real maxCut = getSystem()->maxCutoff;
+  real skinL = getSystem()->getSkin();
+  real cs = maxCut + skinL;
+  real cellD = cellGrid.getSmallestCellDiameter();
+
+  real r0 = s[0] * cellD;
+  real r1 = s[1] * cellD;
+  real r2 = s[2] * cellD;
+
+  if (cs > min(min(r0, r1), r2)) {
+    Real3D Li = getSystem()->bc->getBoxL();       // getting the system size
+    real minL = min(Li[0], min(Li[1],Li[2]));
+
+    if (cs > minL) {
+      esutil::Error err(getSystemRef().comm);
+      stringstream msg;
+
+      msg << "Error. The current system size " << minL << " smaller then cutoff+skin " << cs;
+      err.setException(msg.str());
+    } else {
+      cellAdjust();
+    }
+  } else {
+    cellGrid.scaleVolume(s);
+    nodeGrid.scaleVolume(s);
+  }
+}
+
+Int3D DomainDecomposition::getInt3DCellGrid() {
+  return Int3D(cellGrid.getGridSize(0),
+    cellGrid.getGridSize(1),
+    cellGrid.getGridSize(2)
+  );
+}
+
+Int3D DomainDecomposition::getInt3DNodeGrid() {
+  return Int3D(nodeGrid.getGridSize(0),
+    nodeGrid.getGridSize(1),
+    nodeGrid.getGridSize(2)
+  );
+}
+
+void DomainDecomposition::cellAdjust() {
+  // create an appropriate cell grid
+  Real3D box_sizeL = getSystem()->bc->getBoxL();
+  real skinL = getSystem()->getSkin();
+  real maxCutoffL = getSystem()->maxCutoff;
+
+  // nodeGrid is already defined
+  Int3D _nodeGrid(nodeGrid.getGridSize());
+
+  // new cellGrid
+  real rc_skin = maxCutoffL + skinL;
+  int ix = (int)(box_sizeL[0] / (rc_skin * _nodeGrid[0]));
+  int iy = (int)(box_sizeL[1] / (rc_skin * _nodeGrid[1]));
+  int iz = (int)(box_sizeL[2] / (rc_skin * _nodeGrid[2]));
+  Int3D _newCellGrid(ix, iy, iz);
+
+  // save all particles to temporary vector
+  std::vector<ParticleList> tmp_pl;
+  size_t _N = realCells.size();
+
+
+  tmp_pl.reserve(_N);
+
+  for (CellList::Iterator it(realCells); it.isValid(); ++it) {
+    tmp_pl.push_back((*it)->particles);
+  }
+
+  // reset all cells info
+  invalidateGhosts();
+  cells.clear();
+  localCells.clear();
+  realCells.clear();
+  ghostCells.clear();
+
+  for (int i = 0; i < 6; i++) {
+    commCells[i].reals.clear();
+    commCells[i].ghosts.clear();
+  }
+
+  // creating new grids
+  createCellGrid(_nodeGrid, _newCellGrid);
+  initCellInteractions();
+  prepareGhostCommunication();
+
+  // pushing the particles back to the empty cell ("do we have to check particles?")
+  for (int i = 0; i < tmp_pl.size(); i++) {
+    for (size_t p = 0; p < tmp_pl[i].size(); ++p) {
+      Particle &part = tmp_pl[i][p];
+      const Real3D &pos = part.position();
+      Cell *sortCell = mapPositionToCellClipped(pos);
+
+      appendUnindexedParticle(sortCell->particles, part);
+    }
+  }
+
+  for (CellList::Iterator it(realCells); it.isValid(); ++it) {
+    updateLocalParticles((*it)->particles);
+  }
+
+  exchangeGhosts();
+  onParticlesChanged();
+}
+
+void DomainDecomposition::initCellInteractions() {
+  LOG4ESPP_DEBUG(logger, "setting up neighbors for " << cells.size() << " cells");
+
+  for (int o = cellGrid.getInnerCellsBegin(2); o < cellGrid.getInnerCellsEnd(2); ++o) {
+    for (int n = cellGrid.getInnerCellsBegin(1); n < cellGrid.getInnerCellsEnd(1); ++n) {
+      for (int m = cellGrid.getInnerCellsBegin(0); m < cellGrid.getInnerCellsEnd(0); ++m) {
+        longint cellIdx = cellGrid.mapPositionToIndex(m, n, o);
+        Cell *cell = &cells[cellIdx];
+
+        LOG4ESPP_TRACE(logger, "setting up neighbors for cell " << cell - getFirstCell()
+                                                                << " @ " << m << " " << n << " " <<
+                o);
+
+        // there should be always 26 neighbors
+        cell->neighborCells.reserve(26);
+
+        // loop all neighbor cells
+        for (int p = o - 1; p <= o + 1; ++p) {
+          for (int q = n - 1; q <= n + 1; ++q) {
+            for (int r = m - 1; r <= m + 1; ++r) {
+              if ((p != o) || (q != n) || (r != m)) {
+                longint cell2Idx = cellGrid.mapPositionToIndex(r, q, p);
+                Cell *cell2 = &cells[cell2Idx];
+
+                cell->neighborCells.push_back(NeighborCellInfo(cell2, (cell2Idx < cellIdx)));
+
+                LOG4ESPP_TRACE(logger, "neighbor cell " << cell2 - getFirstCell()
+                                                        << " @ " << r << " " << q << " " << p <<
+                    ((cell2Idx < cellIdx) ? " is" : " is not") << " taken");
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  LOG4ESPP_DEBUG(logger, "done");
+}
+
+Cell *DomainDecomposition::mapPositionToCell(const Real3D &pos) {
+  return &cells[cellGrid.mapPositionToCell(pos)];
+}
+
+Cell *DomainDecomposition::mapPositionToCellClipped(const Real3D &pos) {
+  return &cells[cellGrid.mapPositionToCellClipped(pos)];
+}
+
+Cell *DomainDecomposition::mapPositionToCellChecked(const Real3D &pos) {
+  longint c = cellGrid.mapPositionToCellChecked(pos);
+
+
+  if (c == CellGrid::noCell) {
+    return 0;
+  } else {
+    return &cells[c];
+  }
+}
+
+longint DomainDecomposition::mapPositionToNodeClipped(const Real3D &pos) {
+  return nodeGrid.mapPositionToNodeClipped(pos);
+}
+
+bool DomainDecomposition::checkIsRealParticle(longint id, const Real3D &pos) {
+  return getSystem()->comm->rank() == mapPositionToNodeClipped(pos);
+}
+
+bool DomainDecomposition::appendParticles(ParticleList &l, int dir) {
+  bool outlier = false;
+
+
+  LOG4ESPP_DEBUG(logger, "got " << l.size() << " particles");
+
+  for (ParticleList::iterator it = l.begin(), end = l.end(); it != end; ++it) {
+    Real3D &pos = it->position();
+
+    if (nodeGrid.getBoundary(dir) != 0) {
+      getSystem()->bc->foldCoordinate(pos, it->image(), nodeGrid.convertDirToCoord(dir));
+      LOG4ESPP_TRACE(logger, "folded coordinate " << nodeGrid.convertDirToCoord(dir)
+                                                  << " of particle " << it->id());
+    }
+
+    longint cell;
+
+    if (cellGrid.mapPositionToCellCheckedAndClipped(cell, pos)) {
+      LOG4ESPP_TRACE(logger, "particle " << it->id()
+                                         << " @ " << pos << " is not inside node domain");
+      outlier = true;
+    }
+
+    LOG4ESPP_TRACE(logger, "append part " << it->id() << " to cell "
+                                          << cell);
+
+    appendIndexedParticle(cells[cell].particles, *it);
+  }
+
+  return outlier;
+}
+
+void DomainDecomposition::decomposeRealParticles() {
+  // std::cout << getSystem()->comm->rank() << ": " << " decomposeRealParticles\n";
+
+  LOG4ESPP_DEBUG(logger, "starting, expected comm buffer size " << exchangeBufferSize);
+
+  // allocate send/recv buffers. We use the size as we need maximally so far, to avoid reallocation
+  // TODO: This might be a problem when all particles are created on a single node initially!
+  ParticleList sendBufL;
+
+  sendBufL.reserve(exchangeBufferSize);
+
+  ParticleList sendBufR;
+
+  sendBufR.reserve(exchangeBufferSize);
+
+  ParticleList recvBufL;
+
+  recvBufL.reserve(exchangeBufferSize);
+
+  ParticleList recvBufR;
+
+  recvBufR.reserve(exchangeBufferSize);
+
+  bool allFinished;
+
+  do {
+    bool finished = true;
+
+    for (int coord = 0; coord < 3; ++coord) {
+      LOG4ESPP_DEBUG(logger, "starting with direction " << coord);
+
+      if (nodeGrid.getGridSize(coord) > 1) {
+        for (std::vector<Cell *>::iterator it = realCells.begin(),
             end = realCells.end(); it != end; ++it) {
-            Cell &cell = **it;
-            // do not use an iterator here, since we have need to take out particles during the loop
-            for (size_t p = 0; p < cell.particles.size(); ++p) {
-                Particle &part = cell.particles[p];
-                getSystem()->bc->foldCoordinate(part.position(), part.image(), coord);
-                LOG4ESPP_TRACE(logger, "folded coordinate " << coord << " of particle " << part.id());
+          Cell &cell = **it;
 
-                if (coord == 2) {
-                    Cell *sortCell = mapPositionToCellChecked(part.position());
+          // do not use an iterator here, since we need to take out particles during the loop
+          for (size_t p = 0; p < cell.particles.size(); ++p) {
+            Particle &part = cell.particles[p];
+            const Real3D &pos = part.position();
 
-                    if (sortCell != &cell) {
-                        if (sortCell == 0) {
-                            LOG4ESPP_DEBUG(logger, "take another loop: particle " << part.id()
-                                    << " @ " << part.position()
-                                    << " is not inside node domain after neighbor exchange");
-                            const Real3D& pos = part.position();
-                            // isnan function is C99 only, x != x is only true if x == nan
-                            if (pos[0] != pos[0] || pos[1] != pos[1] || pos[2] != pos[2]) {
-                                LOG4ESPP_ERROR(logger, "particle " << part.id() <<
-                                        " has moved to outer space (one or more coordinates are nan)");
-                            } else {
-                                // particle stays where it is, and will be sorted in the next round
-                                finished = false;
-                            }
-                        } else {
-                            moveIndexedParticle(sortCell->particles, cell.particles, p);
-                            --p;
-                        }
-                    }
+            // check whether the particle is now "left" of the local domain
+            if (pos[coord] - cellGrid.getMyLeft(coord) < -ROUND_ERROR_PREC) {
+              LOG4ESPP_TRACE(logger, "send particle left " << part.id());
+              moveIndexedParticle(sendBufL, cell.particles, p);
+
+              // redo same particle since we took one out here, so it's a new one
+              --p;
+            }
+            // check whether the particle is now "right" of the local domain
+            else if (pos[coord] - cellGrid.getMyRight(coord) >= ROUND_ERROR_PREC) {
+              LOG4ESPP_TRACE(logger, "send particle right " << part.id());
+              moveIndexedParticle(sendBufR, cell.particles, p);
+              --p;
+            }
+            // Sort particles in cells of this node during last direction
+            else if (coord == 2) {
+              const Real3D &pos = part.position();
+              Cell *sortCell = mapPositionToCellChecked(pos);
+
+              if (sortCell != &cell) {
+                if (sortCell == 0) {
+                  // particle is not in the local domain
+                  LOG4ESPP_DEBUG(logger, "take another loop: particle " << part.id()
+                                                                        << " @ " << pos <<
+                          " is not inside node domain after neighbor exchange");
+
+                  // isnan function is C99 only, x != x is only true if x == nan
+                  if ((pos[0] != pos[0]) || (pos[1] != pos[1]) || (pos[2] != pos[2])) {
+                    // TODO: error handling
+                    LOG4ESPP_ERROR(logger, "particle " << part.id() <<
+                            " has moved to outer space (one or more coordinates are nan)");
+                  } else {
+                    // particle stays where it is, and will be sorted in the next round
+                    finished = false;
+                  }
+                } else {
+                  // particle is in the local domain
+                  moveIndexedParticle(sortCell->particles, cell.particles, p);
+                  --p;
                 }
+              }
             }
           }
         }
 
-        LOG4ESPP_DEBUG(logger, "done with direction " << coord);
+        // Exchange particles, odd-even rule
+        if (nodeGrid.getNodePosition(coord) % 2 == 0) {
+          sendParticles(sendBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
+          recvParticles(recvBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
+          sendParticles(sendBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
+          recvParticles(recvBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
+        } else {
+          recvParticles(recvBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
+          sendParticles(sendBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
+          recvParticles(recvBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
+          sendParticles(sendBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
+        }
+
+        // sort received particles to cells
+        if (appendParticles(recvBufL, 2 * coord) && (coord == 2)) finished = false;
+
+        if (appendParticles(recvBufR, 2 * coord + 1) && (coord == 2)) finished = false;
+
+        // reset send/recv buffers
+        sendBufL.resize(0);
+        sendBufR.resize(0);
+        recvBufL.resize(0);
+        recvBufR.resize(0);
+      } else {
+        /* Single node direction case (no communication)
+           Fold particles that have left the box */
+        for (std::vector<Cell *>::iterator it = realCells.begin(),
+            end = realCells.end(); it != end; ++it) {
+          Cell &cell = **it;
+
+          // do not use an iterator here, since we have need to take out particles during the loop
+          for (size_t p = 0; p < cell.particles.size(); ++p) {
+            Particle &part = cell.particles[p];
+
+            getSystem()->bc->foldCoordinate(part.position(), part.image(), coord);
+            LOG4ESPP_TRACE(logger, "folded coordinate " << coord << " of particle " << part.id());
+
+            if (coord == 2) {
+              Cell *sortCell = mapPositionToCellChecked(part.position());
+
+              if (sortCell != &cell) {
+                if (sortCell == 0) {
+                  LOG4ESPP_DEBUG(logger, "take another loop: particle " << part.id()
+                                                                        << " @ " << part.position()
+                                                                        <<
+                          " is not inside node domain after neighbor exchange");
+
+                  const Real3D &pos = part.position();
+
+                  // isnan function is C99 only, x != x is only true if x == nan
+                  if ((pos[0] != pos[0]) || (pos[1] != pos[1]) || (pos[2] != pos[2])) {
+                    LOG4ESPP_ERROR(logger, "particle " << part.id() <<
+                            " has moved to outer space (one or more coordinates are nan)");
+                  } else {
+                    // particle stays where it is, and will be sorted in the next round
+                    finished = false;
+                  }
+                } else {
+                  moveIndexedParticle(sortCell->particles, cell.particles, p);
+                  --p;
+                }
+              }
+            }
+          }
+        }
       }
 
-      // Communicate wether particle exchange is finished
-      mpi::all_reduce(*getSystem()->comm, finished, allFinished, std::logical_and<bool>());
-    } while (!allFinished);
-
-    exchangeBufferSize = std::max(exchangeBufferSize,
-                  std::max(sendBufL.capacity(),
-                       std::max(sendBufR.capacity(),
-                            std::max(recvBufL.capacity(),
-                                 recvBufR.capacity()))));
-
-    LOG4ESPP_DEBUG(logger, "finished exchanging particles, new send/recv buffer size " << exchangeBufferSize);
-
-    LOG4ESPP_DEBUG(logger, "done");
-  }
-
-  void DomainDecomposition::exchangeGhosts() {
-
-    LOG4ESPP_DEBUG(logger, "exchangeGhosts -> ghost communication sizes first, real->ghost");
-    doGhostCommunication(true, true, dataOfExchangeGhosts);
-  }
-
-  void DomainDecomposition::updateGhosts() {
-    LOG4ESPP_DEBUG(logger, "updateGhosts -> ghost communication no sizes, real->ghost");
-    doGhostCommunication(false, true, dataOfUpdateGhosts);
-  }
-
-  void DomainDecomposition::updateGhostsV() {
-    LOG4ESPP_DEBUG(logger, "updateGhostsV -> ghost communication no sizes, real->ghost velocities");
-    doGhostCommunication(false, true, 2); // 2 is the bitflag for particle momentum
-  }
-
-  void DomainDecomposition::collectGhostForces() {
-    LOG4ESPP_DEBUG(logger, "collectGhosts -> ghost communication no sizes, ghost->real");
-    doGhostCommunication(false, false);
-  }
-
-  void DomainDecomposition::fillCells(std::vector<Cell *> &cv,
-                  const int leftBoundary[3],
-                  const int rightBoundary[3]) {
-    LOG4ESPP_DEBUG(logger, "filling: "
-           << leftBoundary[0] << "-" << (rightBoundary[0] - 1) << " "
-           << leftBoundary[1] << "-" << (rightBoundary[1] - 1) << " "
-           << leftBoundary[2] << "-" << (rightBoundary[2] - 1));
-
-    longint total = 1;
-    for (int i = 0; i < 3; ++i) {
-        if (leftBoundary[i] < 0 || leftBoundary[i] > cellGrid.getFrameGridSize(i) ||
-                rightBoundary[i] < 0 || rightBoundary[i] > cellGrid.getFrameGridSize(i) ||
-                leftBoundary[i] >= rightBoundary[i]) {
-            throw std::runtime_error("DomainDecomposition::fillCells: wrong cell grid specified internally");
-        }
-        total *= (rightBoundary[i] - leftBoundary[i]);
-    }
-    cv.reserve(total);
-
-    for (int o = leftBoundary[0]; o < rightBoundary[0]; ++o) {
-        for (int n = leftBoundary[1]; n < rightBoundary[1]; ++n) {
-            for (int m = leftBoundary[2]; m < rightBoundary[2]; ++m) {
-                int i = cellGrid.mapPositionToIndex(o, n, m);
-                LOG4ESPP_TRACE(logger, "add cell " << i);
-                cv.push_back(&cells[i]);
-            }
-        }
+      LOG4ESPP_DEBUG(logger, "done with direction " << coord);
     }
 
-    LOG4ESPP_DEBUG(logger, "expected " << total << " cells, filled with " << cv.size());
+    // Communicate wether particle exchange is finished
+    mpi::all_reduce(*getSystem()->comm, finished, allFinished, std::logical_and<bool>());
+  } while (!allFinished);
+
+  exchangeBufferSize = std::max(exchangeBufferSize,
+    std::max(sendBufL.capacity(),
+    std::max(sendBufR.capacity(),
+    std::max(recvBufL.capacity(),
+    recvBufR.capacity()))));
+
+  LOG4ESPP_DEBUG(logger, "finished exchanging particles, new send/recv buffer size " <<
+          exchangeBufferSize);
+
+  LOG4ESPP_DEBUG(logger, "done");
+}
+
+void DomainDecomposition::exchangeGhosts() {
+  LOG4ESPP_DEBUG(logger, "exchangeGhosts -> ghost communication sizes first, real->ghost");
+  doGhostCommunication(true, true, dataOfExchangeGhosts);
+}
+
+void DomainDecomposition::updateGhosts() {
+  LOG4ESPP_DEBUG(logger, "updateGhosts -> ghost communication no sizes, real->ghost");
+  doGhostCommunication(false, true, dataOfUpdateGhosts);
+}
+
+void DomainDecomposition::updateGhostsV() {
+  LOG4ESPP_DEBUG(logger, "updateGhostsV -> ghost communication no sizes, real->ghost velocities");
+  doGhostCommunication(false, true, 2);   // 2 is the bitflag for particle momentum
+}
+
+void DomainDecomposition::collectGhostForces() {
+  LOG4ESPP_DEBUG(logger, "collectGhosts -> ghost communication no sizes, ghost->real");
+  doGhostCommunication(false, false);
+}
+
+void DomainDecomposition::fillCells(std::vector<Cell *> &cv,const int leftBoundary[3],const int
+    rightBoundary[3]) {
+  LOG4ESPP_DEBUG(logger, "filling: "
+          << leftBoundary[0] << "-" << (rightBoundary[0] - 1) << " "
+          << leftBoundary[1] << "-" << (rightBoundary[1] - 1) << " "
+          << leftBoundary[2] << "-" << (rightBoundary[2] - 1));
+
+  longint total = 1;
+
+  for (int i = 0; i < 3; ++i) {
+    if ((leftBoundary[i] < 0) || (leftBoundary[i] > cellGrid.getFrameGridSize(i)) ||
+        (rightBoundary[i] < 0) || (rightBoundary[i] > cellGrid.getFrameGridSize(i)) ||
+        (leftBoundary[i] >= rightBoundary[i])) {
+      throw std::runtime_error(
+        "DomainDecomposition::fillCells: wrong cell grid specified internally");
+    }
+
+    total *= (rightBoundary[i] - leftBoundary[i]);
   }
 
-  void DomainDecomposition::prepareGhostCommunication() {
-    // direction loop: x, y, z
-    for (int coord = 0; coord < 3; ++coord) {
-        // boundaries of area to send
-        int leftBoundary[3], rightBoundary[3];
-        /* boundaries perpendicular directions are the same for left/right send.
-        We also send the ghost frame that we have already, so the data amount
-        increase with each cycle.
+  cv.reserve(total);
 
-        For a direction that was done already, i.e. is smaller than dir,
-        we take the full ghost frame, otherwise only the inner frame.  */
-        for (int offset = 1; offset <= 2; ++offset) {
-            int otherCoord = (coord + offset) % 3;
-            if (otherCoord < coord) {
-                leftBoundary[otherCoord] = 0;
-                rightBoundary[otherCoord] = cellGrid.getFrameGridSize(otherCoord);
-            } else {
-                leftBoundary[otherCoord] = cellGrid.getInnerCellsBegin(otherCoord);
-                rightBoundary[otherCoord] = cellGrid.getInnerCellsEnd(otherCoord);
-            }
-        }
+  for (int o = leftBoundary[0]; o < rightBoundary[0]; ++o) {
+    for (int n = leftBoundary[1]; n < rightBoundary[1]; ++n) {
+      for (int m = leftBoundary[2]; m < rightBoundary[2]; ++m) {
+        int i = cellGrid.mapPositionToIndex(o, n, m);
 
-        //  lr loop: left right - loop
-        for (int lr = 0; lr < 2; ++lr) {
-            int dir = 2 * coord + lr;
-
-            /* participating real particles from this node */
-            LOG4ESPP_DEBUG(logger, "direction " << dir << " reals");
-
-            if (lr == 0) {
-                leftBoundary[coord] = cellGrid.getInnerCellsBegin(coord);
-                rightBoundary[coord] = cellGrid.getInnerCellsBegin(coord) + cellGrid.getFrameWidth();
-            } else {
-                leftBoundary[coord] = cellGrid.getInnerCellsEnd(coord) - cellGrid.getFrameWidth();
-                rightBoundary[coord] = cellGrid.getInnerCellsEnd(coord);
-            }
-            fillCells(commCells[dir].reals, leftBoundary, rightBoundary);
-
-            /* participating ghosts from this node */
-            LOG4ESPP_DEBUG(logger, "direction " << dir << " ghosts");
-
-            if (lr == 0) {
-                leftBoundary[coord] = cellGrid.getInnerCellsEnd(coord);
-                rightBoundary[coord] = cellGrid.getInnerCellsEnd(coord) + cellGrid.getFrameWidth();
-            } else {
-                leftBoundary[coord] = cellGrid.getInnerCellsBegin(coord) - cellGrid.getFrameWidth();
-                rightBoundary[coord] = cellGrid.getInnerCellsBegin(coord);
-            }
-            fillCells(commCells[dir].ghosts, leftBoundary, rightBoundary);
-        }
+        LOG4ESPP_TRACE(logger, "add cell " << i);
+        cv.push_back(&cells[i]);
+      }
     }
   }
-  
-  void DomainDecomposition::
-  doGhostCommunication(bool sizesFirst, bool realToGhosts, int extradata) {
-    LOG4ESPP_DEBUG(logger, "do ghost communication " << (sizesFirst ? "with sizes " : "")
-           << (realToGhosts ? "reals to ghosts " : "ghosts to reals ") << extradata);
 
-    /* direction loop: x, y, z.
-   Here we could in principle build in a one sided ghost
-   communication, simply by taking the lr loop only over one
-   value. */
-    for (int _coord = 0; _coord < 3; ++_coord) {
-      /* inverted processing order for ghost force communication,
-        since the corner ghosts have to be collected via several
-        nodes. We now add back the corner ghost forces first again
-        to ghost forces, which only eventually go back to the real
-        particle.
-      */
-      int coord = realToGhosts ? _coord : (2 - _coord);
-      real curCoordBoxL = getSystem()->bc->getBoxL()[coord];
+  LOG4ESPP_DEBUG(logger, "expected " << total << " cells, filled with " << cv.size());
+}
 
-      // lr loop: left right
-      for (int lr = 0; lr < 2; ++lr) {
-        int dir         = 2 * coord + lr;
-        int oppositeDir = 2 * coord + (1 - lr);
+void DomainDecomposition::prepareGhostCommunication() {
+  // direction loop: x, y, z
+  for (int coord = 0; coord < 3; ++coord) {
+    // boundaries of area to send
+    int leftBoundary[3], rightBoundary[3];
 
-        Real3D shift(0, 0, 0);
+    /* boundaries perpendicular directions are the same for left/right send.
+       We also send the ghost frame that we have already, so the data amount
+       increase with each cycle.
 
-        shift[coord] = nodeGrid.getBoundary(dir) * curCoordBoxL;
+       For a direction that was done already, i.e. is smaller than dir,
+       we take the full ghost frame, otherwise only the inner frame.  */
+    for (int offset = 1; offset <= 2; ++offset) {
+      int otherCoord = (coord + offset) % 3;
 
-        LOG4ESPP_DEBUG(logger, "direction " << dir);
+      if (otherCoord < coord) {
+        leftBoundary[otherCoord] = 0;
+        rightBoundary[otherCoord] = cellGrid.getFrameGridSize(otherCoord);
+      } else {
+        leftBoundary[otherCoord] = cellGrid.getInnerCellsBegin(otherCoord);
+        rightBoundary[otherCoord] = cellGrid.getInnerCellsEnd(otherCoord);
+      }
+    }
 
-        if (nodeGrid.getGridSize(coord) == 1) {
-          LOG4ESPP_DEBUG(logger, "local communication");
+    //  lr loop: left right - loop
+    for (int lr = 0; lr < 2; ++lr) {
+      int dir = 2 * coord + lr;
 
-          // copy operation, we have to receive as many cells as we send
-          if (commCells[dir].ghosts.size() != commCells[dir].reals.size()) {
-            throw std::runtime_error("DomainDecomposition::doGhostCommunication: send/recv cell structure mismatch during local copy");
+      /* participating real particles from this node */
+      LOG4ESPP_DEBUG(logger, "direction " << dir << " reals");
+
+      if (lr == 0) {
+        leftBoundary[coord] = cellGrid.getInnerCellsBegin(coord);
+        rightBoundary[coord] = cellGrid.getInnerCellsBegin(coord) + cellGrid.getFrameWidth();
+      } else {
+        leftBoundary[coord] = cellGrid.getInnerCellsEnd(coord) - cellGrid.getFrameWidth();
+        rightBoundary[coord] = cellGrid.getInnerCellsEnd(coord);
+      }
+
+      fillCells(commCells[dir].reals, leftBoundary, rightBoundary);
+
+      /* participating ghosts from this node */
+      LOG4ESPP_DEBUG(logger, "direction " << dir << " ghosts");
+
+      if (lr == 0) {
+        leftBoundary[coord] = cellGrid.getInnerCellsEnd(coord);
+        rightBoundary[coord] = cellGrid.getInnerCellsEnd(coord) + cellGrid.getFrameWidth();
+      } else {
+        leftBoundary[coord] = cellGrid.getInnerCellsBegin(coord) - cellGrid.getFrameWidth();
+        rightBoundary[coord] = cellGrid.getInnerCellsBegin(coord);
+      }
+
+      fillCells(commCells[dir].ghosts, leftBoundary, rightBoundary);
+    }
+  }
+}
+
+void DomainDecomposition::doGhostCommunication(bool sizesFirst, bool realToGhosts, int
+    extradata) {
+  LOG4ESPP_DEBUG(logger, "do ghost communication " << (sizesFirst ? "with sizes " : "")
+                                                   << (realToGhosts ? "reals to ghosts " :
+          "ghosts to reals ") << extradata);
+
+  /* direction loop: x, y, z.
+     Here we could in principle build in a one sided ghost
+     communication, simply by taking the lr loop only over one
+     value. */
+  for (int _coord = 0; _coord < 3; ++_coord) {
+    /* inverted processing order for ghost force communication,
+       since the corner ghosts have to be collected via several
+       nodes. We now add back the corner ghost forces first again
+       to ghost forces, which only eventually go back to the real
+       particle.
+     */
+    int coord = realToGhosts ? _coord : (2 - _coord);
+    real curCoordBoxL = getSystem()->bc->getBoxL()[coord];
+
+    // lr loop: left right
+    for (int lr = 0; lr < 2; ++lr) {
+      int dir         = 2 * coord + lr;
+      int oppositeDir = 2 * coord + (1 - lr);
+
+      Real3D shift(0, 0, 0);
+
+      shift[coord] = nodeGrid.getBoundary(dir) * curCoordBoxL;
+
+      LOG4ESPP_DEBUG(logger, "direction " << dir);
+
+      if (nodeGrid.getGridSize(coord) == 1) {
+        LOG4ESPP_DEBUG(logger, "local communication");
+
+        // copy operation, we have to receive as many cells as we send
+        if (commCells[dir].ghosts.size() != commCells[dir].reals.size()) {
+          throw std::runtime_error(
+            "DomainDecomposition::doGhostCommunication: send/recv cell structure mismatch during local copy");
+        }
+
+        for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
+          if (realToGhosts) {
+            copyRealsToGhosts(*commCells[dir].reals[i], *commCells[dir].ghosts[i], extradata,
+                shift);
+          } else {
+            addGhostForcesToReals(*commCells[dir].ghosts[i], *commCells[dir].reals[i]);
           }
+        }
+      } else {
+        // exchange size information, if necessary
+        if (sizesFirst) {
+          LOG4ESPP_DEBUG(logger, "exchanging ghost cell sizes");
+
+          // prepare buffers
+          std::vector<longint> sendSizes, recvSizes;
+
+          sendSizes.reserve(commCells[dir].reals.size());
+
+          for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
+            sendSizes.push_back(commCells[dir].reals[i]->particles.size());
+          }
+
+          recvSizes.resize(commCells[dir].ghosts.size());
+
+          // exchange sizes, odd-even rule
+          if (nodeGrid.getNodePosition(coord) % 2 == 0) {
+            LOG4ESPP_DEBUG(logger, "sending to node " << nodeGrid.getNodeNeighborIndex(dir)
+                                                      << ", then receiving from node " <<
+                    nodeGrid.getNodeNeighborIndex(oppositeDir));
+            getSystem()->comm->send(nodeGrid.getNodeNeighborIndex(dir), DD_COMM_TAG,
+                &(sendSizes[0]), sendSizes.size());
+            getSystem()->comm->recv(nodeGrid.getNodeNeighborIndex(oppositeDir), DD_COMM_TAG,
+                &(recvSizes[0]), recvSizes.size());
+          } else {
+            LOG4ESPP_DEBUG(logger, "receiving from node " << nodeGrid.getNodeNeighborIndex(
+                    oppositeDir)
+                                                          << ", then sending to node " <<
+                    nodeGrid.getNodeNeighborIndex(dir));
+            getSystem()->comm->recv(nodeGrid.getNodeNeighborIndex(oppositeDir), DD_COMM_TAG,
+                &(recvSizes[0]), recvSizes.size());
+            getSystem()->comm->send(nodeGrid.getNodeNeighborIndex(dir), DD_COMM_TAG,
+                &(sendSizes[0]), sendSizes.size());
+          }
+
+          // resize according to received information
+          for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
+            commCells[dir].ghosts[i]->particles.resize(recvSizes[i]);
+          }
+
+          LOG4ESPP_DEBUG(logger, "exchanging ghost cell sizes done");
+        }
+
+        // prepare send and receive buffers
+        longint receiver, sender;
+
+        outBuffer.reset();
+
+        if (realToGhosts) {
+          receiver = nodeGrid.getNodeNeighborIndex(dir);
+          sender = nodeGrid.getNodeNeighborIndex(oppositeDir);
+
+          for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
+            packPositionsEtc(outBuffer, *commCells[dir].reals[i], extradata, shift);
+          }
+        } else {
+          receiver = nodeGrid.getNodeNeighborIndex(oppositeDir);
+          sender = nodeGrid.getNodeNeighborIndex(dir);
 
           for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
-            if (realToGhosts) {
-              copyRealsToGhosts(*commCells[dir].reals[i], *commCells[dir].ghosts[i], extradata, shift);
-            } else {
-              addGhostForcesToReals(*commCells[dir].ghosts[i], *commCells[dir].reals[i]);
-            }
+            packForces(outBuffer, *commCells[dir].ghosts[i]);
           }
         }
-        else {
-          // exchange size information, if necessary
-          if (sizesFirst) {
-            LOG4ESPP_DEBUG(logger, "exchanging ghost cell sizes");
 
-            // prepare buffers
-            std::vector<longint> sendSizes, recvSizes;
-            sendSizes.reserve(commCells[dir].reals.size());
-            for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
-              sendSizes.push_back(commCells[dir].reals[i]->particles.size());
-            }
-            recvSizes.resize(commCells[dir].ghosts.size());
+        // exchange particles, odd-even rule
+        if (nodeGrid.getNodePosition(coord) % 2 == 0) {
+          outBuffer.send(receiver, DD_COMM_TAG);
+          inBuffer.recv(sender, DD_COMM_TAG);
+        } else {
+          inBuffer.recv(sender, DD_COMM_TAG);
+          outBuffer.send(receiver, DD_COMM_TAG);
+        }
 
-            // exchange sizes, odd-even rule
-            if (nodeGrid.getNodePosition(coord) % 2 == 0) {
-              LOG4ESPP_DEBUG(logger, "sending to node " << nodeGrid.getNodeNeighborIndex(dir)
-                        << ", then receiving from node " << nodeGrid.getNodeNeighborIndex(oppositeDir));
-              getSystem()->comm->send(nodeGrid.getNodeNeighborIndex(dir), DD_COMM_TAG, &(sendSizes[0]), sendSizes.size());
-              getSystem()->comm->recv(nodeGrid.getNodeNeighborIndex(oppositeDir), DD_COMM_TAG, &(recvSizes[0]), recvSizes.size());
-            }
-            else {
-              LOG4ESPP_DEBUG(logger, "receiving from node " << nodeGrid.getNodeNeighborIndex(oppositeDir)
-                        << ", then sending to node " << nodeGrid.getNodeNeighborIndex(dir));
-              getSystem()->comm->recv(nodeGrid.getNodeNeighborIndex(oppositeDir), DD_COMM_TAG, &(recvSizes[0]), recvSizes.size());
-              getSystem()->comm->send(nodeGrid.getNodeNeighborIndex(dir), DD_COMM_TAG, &(sendSizes[0]), sendSizes.size());
-            }
-
-            // resize according to received information
-            for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
-              commCells[dir].ghosts[i]->particles.resize(recvSizes[i]);
-            }
-            LOG4ESPP_DEBUG(logger, "exchanging ghost cell sizes done");
+        // unpack received data
+        if (realToGhosts) {
+          for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
+            unpackPositionsEtc(*commCells[dir].ghosts[i], inBuffer, extradata);
           }
-
-          // prepare send and receive buffers
-          longint receiver, sender;
-          outBuffer.reset();
-          if (realToGhosts) {
-            receiver = nodeGrid.getNodeNeighborIndex(dir);
-            sender = nodeGrid.getNodeNeighborIndex(oppositeDir);
-            for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
-              packPositionsEtc(outBuffer, *commCells[dir].reals[i], extradata, shift);
-            }
-          }
-          else {
-            receiver = nodeGrid.getNodeNeighborIndex(oppositeDir);
-            sender = nodeGrid.getNodeNeighborIndex(dir);
-            for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
-              packForces(outBuffer, *commCells[dir].ghosts[i]);
-            }
-          }
-
-          // exchange particles, odd-even rule
-          if (nodeGrid.getNodePosition(coord) % 2 == 0) {
-            outBuffer.send(receiver, DD_COMM_TAG);
-            inBuffer.recv(sender, DD_COMM_TAG);
-          } else {
-            inBuffer.recv(sender, DD_COMM_TAG);
-            outBuffer.send(receiver, DD_COMM_TAG);
-          }
-
-          // unpack received data
-          if (realToGhosts) {
-            for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
-              unpackPositionsEtc(*commCells[dir].ghosts[i], inBuffer, extradata);
-            }
-          }
-          else {
-            for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
-              unpackAndAddForces(*commCells[dir].reals[i], inBuffer);
-            }
+        } else {
+          for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
+            unpackAndAddForces(*commCells[dir].reals[i], inBuffer);
           }
         }
       }
     }
-    LOG4ESPP_DEBUG(logger, "ghost communication finished");
   }
 
-  //////////////////////////////////////////////////
-  // REGISTRATION WITH PYTHON
-  //////////////////////////////////////////////////
-  void DomainDecomposition::registerPython() {
-    using namespace espressopp::python;
-    class_< DomainDecomposition, bases< Storage >, boost::noncopyable >
-    ("storage_DomainDecomposition", init< shared_ptr< System >, const Int3D&, const Int3D& >())
+  LOG4ESPP_DEBUG(logger, "ghost communication finished");
+}
+
+//////////////////////////////////////////////////
+// REGISTRATION WITH PYTHON
+//////////////////////////////////////////////////
+void DomainDecomposition::registerPython() {
+  using namespace espressopp::python;
+  class_<DomainDecomposition, bases<Storage>, boost::noncopyable>
+    ("storage_DomainDecomposition", init<shared_ptr<System>, const Int3D &, const Int3D &>())
     .def("mapPositionToNodeClipped", &DomainDecomposition::mapPositionToNodeClipped)
     .def("getCellGrid", &DomainDecomposition::getInt3DCellGrid)
     .def("getNodeGrid", &DomainDecomposition::getInt3DNodeGrid)
     .def("cellAdjust", &DomainDecomposition::cellAdjust)
-    ;
-  }
-
-
-  }
+  ;
 }
+} // namespace storage
+} // namespace espressopp

--- a/src/storage/DomainDecomposition.hpp
+++ b/src/storage/DomainDecomposition.hpp
@@ -1,24 +1,24 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
+
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 // ESPP_CLASS
 #ifndef _STORAGE_DOMAINDECOMPOSITION_HPP
@@ -28,109 +28,112 @@
 #include "CellGrid.hpp"
 #include "NodeGrid.hpp"
 
-
 namespace espressopp {
-  namespace storage {
-    class NodeGridMismatch: public std::invalid_argument
-    {
-    public:
-      NodeGridMismatch(const Int3D& gridRequested, int nodesAvailable);
-    };
+namespace storage {
+class NodeGridMismatch : public std::invalid_argument {
+public:
+  NodeGridMismatch(const Int3D &gridRequested, int nodesAvailable);
+};
 
-    class DomainDecomposition: public Storage {
-    public:
-      DomainDecomposition(shared_ptr< System > system,
-              const Int3D& _nodeGrid,
-			  const Int3D& _cellGrid);
+class DomainDecomposition : public Storage {
+public:
+  DomainDecomposition(shared_ptr<System> system,const Int3D &_nodeGrid,const Int3D &_cellGrid);
 
-      virtual ~DomainDecomposition() {}
+  virtual ~DomainDecomposition() { }
 
-      virtual void scaleVolume(real s, bool particleCoordinates);
-      virtual void scaleVolume(Real3D s, bool particleCoordinates);
-      
-      // it returns current cell grid like a vector Int3D
-      // mainly in order to use from python
-      virtual Int3D getInt3DCellGrid();
-      Int3D getInt3DNodeGrid();
+  virtual void scaleVolume(real s, bool particleCoordinates);
+  virtual void scaleVolume(Real3D s, bool particleCoordinates);
 
-      // it modifies the cell structure if the cell size becomes smaller then cutoff+skin
-      // as a consequence of the system resizing
-      virtual void cellAdjust();
+  // it returns current cell grid like a vector Int3D
+  // mainly in order to use from python
+  virtual Int3D getInt3DCellGrid();
 
-      virtual Cell *mapPositionToCell(const Real3D& pos);
-      virtual Cell *mapPositionToCellClipped(const Real3D& pos);
-      virtual Cell *mapPositionToCellChecked(const Real3D& pos);
+  Int3D getInt3DNodeGrid();
 
-      longint mapPositionToNodeClipped(const Real3D& pos);
+  // it modifies the cell structure if the cell size becomes smaller then cutoff+skin
+  // as a consequence of the system resizing
+  virtual void cellAdjust();
 
-      const NodeGrid &getNodeGrid() const { return nodeGrid; }
-      const CellGrid &getCellGrid() const { return cellGrid; }
+  virtual Cell *mapPositionToCell(const Real3D &pos);
+  virtual Cell *mapPositionToCellClipped(const Real3D &pos);
+  virtual Cell *mapPositionToCellChecked(const Real3D &pos);
 
-      virtual real getLocalBoxXMin() { return nodeGrid.getMyLeft(0); }
-      virtual real getLocalBoxYMin() { return nodeGrid.getMyLeft(1); }
-      virtual real getLocalBoxZMin() { return nodeGrid.getMyLeft(2); }
-      virtual real getLocalBoxXMax() { return nodeGrid.getMyRight(0); }
-      virtual real getLocalBoxYMax() { return nodeGrid.getMyRight(1); }
-      virtual real getLocalBoxZMax() { return nodeGrid.getMyRight(2); }
+  longint mapPositionToNodeClipped(const Real3D &pos);
 
-      virtual void updateGhosts();
-      virtual void updateGhostsV();
-      virtual void collectGhostForces();
+  const NodeGrid &getNodeGrid() const {return nodeGrid; }
 
-      static void registerPython();
+  const CellGrid &getCellGrid() const {return cellGrid; }
 
-    protected:
-      virtual bool checkIsRealParticle(longint id, const Real3D& pos);
-      virtual void decomposeRealParticles();
-      virtual void exchangeGhosts();
+  virtual real getLocalBoxXMin() {return nodeGrid.getMyLeft(0); }
 
-      virtual void doGhostCommunication(bool sizesFirst,
-				bool realToGhosts,
-				const int dataElements = 0);
+  virtual real getLocalBoxYMin() {return nodeGrid.getMyLeft(1); }
 
-      void prepareGhostCommunication();
+  virtual real getLocalBoxZMin() {return nodeGrid.getMyLeft(2); }
 
-      /// init global Verlet list
-      void initCellInteractions();
-      /// set the grids and allocate space accordingly
-      void createCellGrid(const Int3D& nodeGrid, const Int3D& cellGrid);
-      /// sort cells into local/ghost cell arrays
-      void markCells();
-      /// fill a list of cells with the cells from a certain region of the domain grid
-      void fillCells(std::vector<Cell *> &,
-		     const int leftBoundary[3],
-		     const int rightBoundary[3]);
-      
-      /** read particles from a temporary buffer into the local cell structure.
-	  The direction determines in which direction to fold the particles position.
-	  Returns true if one of the given particles did not belong to this processors
-	  domain.
-      */
-      bool appendParticles(ParticleList &, int dir);
+  virtual real getLocalBoxXMax() {return nodeGrid.getMyRight(0); }
 
-      /// spatial domain decomposition of nodes
-      NodeGrid nodeGrid;
+  virtual real getLocalBoxYMax() {return nodeGrid.getMyRight(1); }
 
-      /// spatial domain decomposition on node in cells
-      CellGrid cellGrid;
+  virtual real getLocalBoxZMax() {return nodeGrid.getMyRight(2); }
 
-      /// expected capacity of send/recv buffers for neighbor communication
-      size_t exchangeBufferSize;
+  virtual void updateGhosts();
+  virtual void updateGhostsV();
+  virtual void collectGhostForces();
 
-      /** which cells to send and receive during one communication step.
-	  In case this is a communication with ourselves, the send-cells
-	  are transferred to the recv-cells. */
-      struct CommCells {
-        std::vector<Cell *> reals;
-        std::vector<Cell *> ghosts;
-      };
-      /** which cells to send left, right, up, down, ...
-	  For the order, see NodeGrid.
-      */
-      CommCells commCells[6];
+  static void registerPython();
 
-      static LOG4ESPP_DECL_LOGGER(logger);
-    };
-  }
+protected:
+  virtual bool checkIsRealParticle(longint id, const Real3D &pos);
+  virtual void decomposeRealParticles();
+  virtual void exchangeGhosts();
+
+  virtual void doGhostCommunication(bool sizesFirst,bool realToGhosts,const int dataElements = 0);
+
+  void prepareGhostCommunication();
+
+  /// init global Verlet list
+  void initCellInteractions();
+
+  /// set the grids and allocate space accordingly
+  void createCellGrid(const Int3D &nodeGrid, const Int3D &cellGrid);
+
+  /// sort cells into local/ghost cell arrays
+  void markCells();
+
+  /// fill a list of cells with the cells from a certain region of the domain grid
+  void fillCells(std::vector<Cell *> &,const int leftBoundary[3],const int rightBoundary[3]);
+
+  /** read particles from a temporary buffer into the local cell structure.
+     The direction determines in which direction to fold the particles position.
+     Returns true if one of the given particles did not belong to this processors
+     domain.
+   */
+  bool appendParticles(ParticleList &, int dir);
+
+  /// spatial domain decomposition of nodes
+  NodeGrid nodeGrid;
+
+  /// spatial domain decomposition on node in cells
+  CellGrid cellGrid;
+
+  /// expected capacity of send/recv buffers for neighbor communication
+  size_t exchangeBufferSize;
+
+  /** which cells to send and receive during one communication step.
+     In case this is a communication with ourselves, the send-cells
+     are transferred to the recv-cells. */
+  struct CommCells {
+    std::vector<Cell *> reals;
+    std::vector<Cell *> ghosts;
+  };
+
+  /** which cells to send left, right, up, down, ...
+     For the order, see NodeGrid.
+   */
+  CommCells commCells[6];
+
+  static LOG4ESPP_DECL_LOGGER(logger);
+};
+}
 }
 #endif

--- a/src/storage/DomainDecompositionAdress.cpp
+++ b/src/storage/DomainDecompositionAdress.cpp
@@ -1,24 +1,24 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
+
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "python.hpp"
 
@@ -38,1161 +38,1199 @@
 using namespace boost;
 using namespace espressopp::iterator;
 
-namespace espressopp { 
-  namespace storage {
+namespace espressopp {
+namespace storage {
+const int DD_COMM_TAG = 0xab;
+
+LOG4ESPP_LOGGER(DomainDecompositionAdress::logger, "DomainDecompositionAdress");
+
+std::string formatMismatchMessage2(const Int3D &gridRequested,int
+    nodesAvailable) {
+  std::ostringstream out;
 
 
-  const int DD_COMM_TAG = 0xab;
+  out << "requested node grid ("
+      << gridRequested
+      << ") does not match number of nodes in the communicator ("
+      << nodesAvailable
+      << ")";
+  return out.str();
+}
 
-  LOG4ESPP_LOGGER(DomainDecompositionAdress::logger, "DomainDecompositionAdress");
+NodeGridMismatch2::NodeGridMismatch2(const Int3D &gridRequested, int nodesAvailable)
+      :std::invalid_argument
+            (formatMismatchMessage2(gridRequested, nodesAvailable))
+{ }
 
-  std::string formatMismatchMessage2(const Int3D& gridRequested,
-                    int nodesAvailable) {
-    std::ostringstream out;
-    out << "requested node grid ("
-    << gridRequested
-    << ") does not match number of nodes in the communicator ("
-    << nodesAvailable
-    << ")";
-    return out.str();
-  }
-
-  NodeGridMismatch2::
-  NodeGridMismatch2(const Int3D& gridRequested, int nodesAvailable)
-    : std::invalid_argument
-      (formatMismatchMessage2(gridRequested, nodesAvailable))
-  {}
-
-  DomainDecompositionAdress::
-  DomainDecompositionAdress(shared_ptr< System > _system,
-          const Int3D& _nodeGrid,
-          const Int3D& _cellGrid)
-    : Storage(_system), exchangeBufferSize(0) {
-    LOG4ESPP_INFO(logger, "node grid = "
+DomainDecompositionAdress::DomainDecompositionAdress(shared_ptr<System> _system,const
+    Int3D &_nodeGrid,const Int3D &_cellGrid)
+      :Storage(_system), exchangeBufferSize(0) {
+  LOG4ESPP_INFO(logger, "node grid = "
           << _nodeGrid[0] << "x" << _nodeGrid[1] << "x" << _nodeGrid[2]
           << " cell grid = "
           << _cellGrid[0] << "x" << _cellGrid[1] << "x" << _cellGrid[2]);
 
-    createCellGrid(_nodeGrid, _cellGrid);
-    initCellInteractions();
-    prepareGhostCommunication();
-    LOG4ESPP_DEBUG(logger, "done");
+  createCellGrid(_nodeGrid, _cellGrid);
+  initCellInteractions();
+  prepareGhostCommunication();
+  LOG4ESPP_DEBUG(logger, "done");
+}
+
+void DomainDecompositionAdress::createCellGrid(const Int3D &_nodeGrid,const
+    Int3D &_cellGrid) {
+  real myLeft[3];
+  real myRight[3];
+
+
+  nodeGrid = NodeGrid(_nodeGrid, getSystem()->comm->rank(), getSystem()->bc->getBoxL());
+
+  if (nodeGrid.getNumberOfCells() != getSystem()->comm->size()) {
+    throw NodeGridMismatch2(_nodeGrid, getSystem()->comm->size());
   }
 
-  void DomainDecompositionAdress::
-  createCellGrid(const Int3D& _nodeGrid,
-         const Int3D& _cellGrid) {
-    real myLeft[3];
-    real myRight[3];
-
-    nodeGrid = NodeGrid(_nodeGrid, getSystem()->comm->rank(), getSystem()->bc->getBoxL());
-
-    if (nodeGrid.getNumberOfCells() != getSystem()->comm->size()) {
-        throw NodeGridMismatch2(_nodeGrid, getSystem()->comm->size());
-    }
-
-    LOG4ESPP_INFO(logger, "my node grid position: "
+  LOG4ESPP_INFO(logger, "my node grid position: "
           << nodeGrid.getNodePosition(0) << " "
           << nodeGrid.getNodePosition(1) << " "
           << nodeGrid.getNodePosition(2) << " -> "
           << getSystem()->comm->rank());
 
-    LOG4ESPP_DEBUG(logger, "my neighbors: "
-           << nodeGrid.getNodeNeighborIndex(0) << "<->"
-           << nodeGrid.getNodeNeighborIndex(1) << ", "
-           << nodeGrid.getNodeNeighborIndex(2) << "<->"
-           << nodeGrid.getNodeNeighborIndex(3) << ", "
-           << nodeGrid.getNodeNeighborIndex(4) << "<->"
-           << nodeGrid.getNodeNeighborIndex(5));
+  LOG4ESPP_DEBUG(logger, "my neighbors: "
+          << nodeGrid.getNodeNeighborIndex(0) << "<->"
+          << nodeGrid.getNodeNeighborIndex(1) << ", "
+          << nodeGrid.getNodeNeighborIndex(2) << "<->"
+          << nodeGrid.getNodeNeighborIndex(3) << ", "
+          << nodeGrid.getNodeNeighborIndex(4) << "<->"
+          << nodeGrid.getNodeNeighborIndex(5));
 
-    for (int i = 0; i < 3; ++i) {
-  myLeft[i] = nodeGrid.getMyLeft(i);
-  myRight[i] = nodeGrid.getMyRight(i);
-    }
+  for (int i = 0; i < 3; ++i) {
+    myLeft[i] = nodeGrid.getMyLeft(i);
+    myRight[i] = nodeGrid.getMyRight(i);
+  }
 
-    cellGrid = CellGrid(_cellGrid, myLeft, myRight, 1);
+  cellGrid = CellGrid(_cellGrid, myLeft, myRight, 1);
 
-    LOG4ESPP_INFO(logger, "local box "
+  LOG4ESPP_INFO(logger, "local box "
           << myLeft[0] << "-" << myRight[0] << ", "
           << myLeft[1] << "-" << myRight[1] << ", "
           << myLeft[2] << "-" << myRight[2]);
 
-    longint nLocalCells = 1;
-    longint nRealCells = 1;
-    for (int i = 0; i < 3; ++i) {
-  nRealCells *= cellGrid.getGridSize(i);
-  nLocalCells *= cellGrid.getFrameGridSize(i);
-    }
+  longint nLocalCells = 1;
+  longint nRealCells = 1;
 
-    resizeCells(nLocalCells);
-
-    realCells.reserve(nRealCells);
-    ghostCells.reserve(nLocalCells - nRealCells);
-
-    markCells();
-
-    LOG4ESPP_DEBUG(logger, "total # cells=" << nLocalCells
-           << ", # real cells=" << nRealCells
-           << ", frame cell grid = (" << cellGrid.getFrameGridSize(0)
-           << ", " << cellGrid.getFrameGridSize(1)
-           << ", " << cellGrid.getFrameGridSize(2)
-           << ")");
+  for (int i = 0; i < 3; ++i) {
+    nRealCells *= cellGrid.getGridSize(i);
+    nLocalCells *= cellGrid.getFrameGridSize(i);
   }
 
-  void DomainDecompositionAdress::markCells() {
-    realCells.resize(0);
-    ghostCells.resize(0);
+  resizeCells(nLocalCells);
 
-    for (int o = 0; o < cellGrid.getFrameGridSize(2); ++o) {
-  for (int n = 0; n < cellGrid.getFrameGridSize(1); ++n) {
-    for (int m = 0; m < cellGrid.getFrameGridSize(0); ++m) {
-      Cell *cur = &cells[cellGrid.mapPositionToIndex(m, n, o)];
-      if (cellGrid.isInnerCell(m, n, o)) {
-        LOG4ESPP_TRACE(logger, "cell " << (cur - &cells[0]) << " is inner cell (" << m << ", " << n << ", " << o << ")");
-        realCells.push_back(cur);
-      } else {
-        LOG4ESPP_TRACE(logger, "cell " << (cur - &cells[0]) << " is ghost cell (" << m << ", " << n << ", " << o << ")");
-        ghostCells.push_back(cur);
-      }
-    }
-  }
-    }
-  }
+  realCells.reserve(nRealCells);
+  ghostCells.reserve(nLocalCells - nRealCells);
 
-  
-  // @TODO should be some implementation for adress!!!
-  /** scale position coordinates of all real particles by factor s */
-  void DomainDecompositionAdress::scaleVolume(real s, bool particleCoordinates){
-    std::cout<<"Nothing happened"<<std::endl;
-  }
-  // anisotropic version
-  void DomainDecompositionAdress::scaleVolume(Real3D s, bool particleCoordinates){
-    std::cout<<"Nothing happened"<<std::endl;
-  }
-  
-  
+  markCells();
 
+  LOG4ESPP_DEBUG(logger, "total # cells=" << nLocalCells
+                                          << ", # real cells=" << nRealCells
+                                          << ", frame cell grid = (" << cellGrid.getFrameGridSize(0)
+                                          << ", " << cellGrid.getFrameGridSize(1)
+                                          << ", " << cellGrid.getFrameGridSize(2)
+                                          << ")");
+}
 
-  void DomainDecompositionAdress::cellAdjust(){
-      // create an appropriate cell grid
-      Real3D box_sizeL = getSystem() -> bc -> getBoxL();
-      real skinL = getSystem() -> getSkin();
-      real maxCutoffL = getSystem() -> maxCutoff;
+void DomainDecompositionAdress::markCells() {
+  realCells.resize(0);
+  ghostCells.resize(0);
 
-      // TODO probably one should handle the error
-      // nodeGrid is already defined
-      Int3D _nodeGrid(nodeGrid.getGridSize());
-      // new cellGrid
-      real rc_skin = maxCutoffL + skinL;
-      int ix = (int)(box_sizeL[0] / (rc_skin * _nodeGrid[0]));
-      int iy = (int)(box_sizeL[1] / (rc_skin * _nodeGrid[1]));
-      int iz = (int)(box_sizeL[2] / (rc_skin * _nodeGrid[2]));
-      Int3D _newCellGrid(ix, iy, iz);
+  for (int o = 0; o < cellGrid.getFrameGridSize(2); ++o) {
+    for (int n = 0; n < cellGrid.getFrameGridSize(1); ++n) {
+      for (int m = 0; m < cellGrid.getFrameGridSize(0); ++m) {
+        Cell *cur = &cells[cellGrid.mapPositionToIndex(m, n, o)];
 
-      // save all particles to temporary vector
-      std::vector<ParticleList> tmp_pl;
-      size_t _N = realCells.size();
-      tmp_pl.reserve( _N );
-      for(CellList::Iterator it(realCells); it.isValid(); ++it) {
-        tmp_pl.push_back((*it)->particles);
-      }
-
-      // reset all cells info
-      invalidateGhosts();
-      cells.clear();
-      localCells.clear();
-      realCells.clear();
-      ghostCells.clear();
-      for(int i=0; i<6; i++){
-        commCells[i].reals.clear();
-        commCells[i].ghosts.clear();
-      }
-
-      // creating new grids
-      createCellGrid(_nodeGrid, _newCellGrid);
-      initCellInteractions();
-      prepareGhostCommunication();
-
-      // pushing the particles back to the empty cell ("do we have to check particles?")
-      for(int i=0; i<tmp_pl.size(); i++){
-        for (size_t p = 0; p < tmp_pl[i].size(); ++p) {
-          Particle& part = tmp_pl[i][p];
-          const Real3D& pos = part.position();
-          Cell *sortCell = mapPositionToCellClipped(pos);
-          appendUnindexedParticle(sortCell->particles, part);
-        }
-      }
-
-      for(CellList::Iterator it(realCells); it.isValid(); ++it) {
-        updateLocalParticles((*it)->particles);
-      }
-
-      exchangeGhosts();
-      onParticlesChanged();
-  }
-
-  Int3D DomainDecompositionAdress::getInt3DCellGrid(){
-    return Int3D( cellGrid.getGridSize(0),
-                  cellGrid.getGridSize(1),
-                  cellGrid.getGridSize(2)
-                );
-  }
-
-
-
-  void DomainDecompositionAdress::initCellInteractions() {
-    LOG4ESPP_DEBUG(logger, "setting up neighbors for " << cells.size() << " cells");
-
-    for (int o = cellGrid.getInnerCellsBegin(2); o < cellGrid.getInnerCellsEnd(2); ++o) {
-  for (int n = cellGrid.getInnerCellsBegin(1); n < cellGrid.getInnerCellsEnd(1); ++n) {
-    for (int m = cellGrid.getInnerCellsBegin(0); m < cellGrid.getInnerCellsEnd(0); ++m) {
-      longint cellIdx = cellGrid.mapPositionToIndex(m, n, o);
-      Cell *cell = &cells[cellIdx];
-
-      LOG4ESPP_TRACE(logger, "setting up neighbors for cell " << cell - getFirstCell()
-             << " @ " << m << " " << n << " " << o);
-
-      // there should be always 26 neighbors
-      cell->neighborCells.reserve(26);
-
-      // loop all neighbor cells
-      for (int p = o - 1; p <= o + 1; ++p) {
-        for (int q = n - 1; q <= n + 1; ++q) {
-      for (int r = m - 1; r <= m + 1; ++r) {
-        if (p != o || q != n || r != m) {
-          longint cell2Idx = cellGrid.mapPositionToIndex(r, q, p);
-          Cell *cell2 = &cells[cell2Idx];
-          cell->neighborCells.push_back(NeighborCellInfo(cell2, (cell2Idx<cellIdx)));
-
-          LOG4ESPP_TRACE(logger, "neighbor cell " << cell2 - getFirstCell()
-                 << " @ " << r << " " << q << " " << p << ((cell2Idx<cellIdx) ? " is" : " is not") << " taken" );
-        }
-      }
+        if (cellGrid.isInnerCell(m, n, o)) {
+          LOG4ESPP_TRACE(logger, "cell " << (cur - &cells[0]) << " is inner cell (" << m << ", " <<
+                  n << ", " << o << ")");
+          realCells.push_back(cur);
+        } else {
+          LOG4ESPP_TRACE(logger, "cell " << (cur - &cells[0]) << " is ghost cell (" << m << ", " <<
+                  n << ", " << o << ")");
+          ghostCells.push_back(cur);
         }
       }
     }
   }
+}
+
+// @TODO should be some implementation for adress!!!
+
+/** scale position coordinates of all real particles by factor s */
+void DomainDecompositionAdress::scaleVolume(real s, bool particleCoordinates) {
+  std::cout << "Nothing happened" << std::endl;
+}
+
+// anisotropic version
+void DomainDecompositionAdress::scaleVolume(Real3D s, bool particleCoordinates) {
+  std::cout << "Nothing happened" << std::endl;
+}
+
+void DomainDecompositionAdress::cellAdjust() {
+  // create an appropriate cell grid
+  Real3D box_sizeL = getSystem()->bc->getBoxL();
+  real skinL = getSystem()->getSkin();
+  real maxCutoffL = getSystem()->maxCutoff;
+
+  // TODO probably one should handle the error
+  // nodeGrid is already defined
+  Int3D _nodeGrid(nodeGrid.getGridSize());
+
+  // new cellGrid
+  real rc_skin = maxCutoffL + skinL;
+  int ix = (int)(box_sizeL[0] / (rc_skin * _nodeGrid[0]));
+  int iy = (int)(box_sizeL[1] / (rc_skin * _nodeGrid[1]));
+  int iz = (int)(box_sizeL[2] / (rc_skin * _nodeGrid[2]));
+  Int3D _newCellGrid(ix, iy, iz);
+
+  // save all particles to temporary vector
+  std::vector<ParticleList> tmp_pl;
+  size_t _N = realCells.size();
+
+
+  tmp_pl.reserve(_N);
+
+  for (CellList::Iterator it(realCells); it.isValid(); ++it) {
+    tmp_pl.push_back((*it)->particles);
+  }
+
+  // reset all cells info
+  invalidateGhosts();
+  cells.clear();
+  localCells.clear();
+  realCells.clear();
+  ghostCells.clear();
+
+  for (int i = 0; i < 6; i++) {
+    commCells[i].reals.clear();
+    commCells[i].ghosts.clear();
+  }
+
+  // creating new grids
+  createCellGrid(_nodeGrid, _newCellGrid);
+  initCellInteractions();
+  prepareGhostCommunication();
+
+  // pushing the particles back to the empty cell ("do we have to check particles?")
+  for (int i = 0; i < tmp_pl.size(); i++) {
+    for (size_t p = 0; p < tmp_pl[i].size(); ++p) {
+      Particle &part = tmp_pl[i][p];
+      const Real3D &pos = part.position();
+      Cell *sortCell = mapPositionToCellClipped(pos);
+
+      appendUnindexedParticle(sortCell->particles, part);
     }
-
-    LOG4ESPP_DEBUG(logger, "done");
   }
 
-  Cell *DomainDecompositionAdress::mapPositionToCell(const Real3D& pos) {
-            return &cells[cellGrid.mapPositionToCell(pos)];
+  for (CellList::Iterator it(realCells); it.isValid(); ++it) {
+    updateLocalParticles((*it)->particles);
   }
 
-  Cell *DomainDecompositionAdress::mapPositionToCellClipped(const Real3D& pos) {
-    return &cells[cellGrid.mapPositionToCellClipped(pos)];
-  }
+  exchangeGhosts();
+  onParticlesChanged();
+}
 
-  Cell *DomainDecompositionAdress::mapPositionToCellChecked(const Real3D& pos) {
-    longint c = cellGrid.mapPositionToCellChecked(pos);
-    if (c == CellGrid::noCell) {
-  return 0;
-    } else {
-  return &cells[c];
+Int3D DomainDecompositionAdress::getInt3DCellGrid() {
+  return Int3D(cellGrid.getGridSize(0),
+    cellGrid.getGridSize(1),
+    cellGrid.getGridSize(2)
+  );
+}
+
+void DomainDecompositionAdress::initCellInteractions() {
+  LOG4ESPP_DEBUG(logger, "setting up neighbors for " << cells.size() << " cells");
+
+  for (int o = cellGrid.getInnerCellsBegin(2); o < cellGrid.getInnerCellsEnd(2); ++o) {
+    for (int n = cellGrid.getInnerCellsBegin(1); n < cellGrid.getInnerCellsEnd(1); ++n) {
+      for (int m = cellGrid.getInnerCellsBegin(0); m < cellGrid.getInnerCellsEnd(0); ++m) {
+        longint cellIdx = cellGrid.mapPositionToIndex(m, n, o);
+        Cell *cell = &cells[cellIdx];
+
+        LOG4ESPP_TRACE(logger, "setting up neighbors for cell " << cell - getFirstCell()
+                                                                << " @ " << m << " " << n << " " <<
+                o);
+
+        // there should be always 26 neighbors
+        cell->neighborCells.reserve(26);
+
+        // loop all neighbor cells
+        for (int p = o - 1; p <= o + 1; ++p) {
+          for (int q = n - 1; q <= n + 1; ++q) {
+            for (int r = m - 1; r <= m + 1; ++r) {
+              if ((p != o) || (q != n) || (r != m)) {
+                longint cell2Idx = cellGrid.mapPositionToIndex(r, q, p);
+                Cell *cell2 = &cells[cell2Idx];
+
+                cell->neighborCells.push_back(NeighborCellInfo(cell2, (cell2Idx < cellIdx)));
+
+                LOG4ESPP_TRACE(logger, "neighbor cell " << cell2 - getFirstCell()
+                                                        << " @ " << r << " " << q << " " << p <<
+                    ((cell2Idx < cellIdx) ? " is" : " is not") << " taken");
+              }
+            }
+          }
+        }
+      }
     }
   }
 
-  longint DomainDecompositionAdress::
-  mapPositionToNodeClipped(const Real3D& pos) {
-    return nodeGrid.mapPositionToNodeClipped(pos);
+  LOG4ESPP_DEBUG(logger, "done");
+}
+
+Cell *DomainDecompositionAdress::mapPositionToCell(const Real3D &pos) {
+  return &cells[cellGrid.mapPositionToCell(pos)];
+}
+
+Cell *DomainDecompositionAdress::mapPositionToCellClipped(const Real3D &pos) {
+  return &cells[cellGrid.mapPositionToCellClipped(pos)];
+}
+
+Cell *DomainDecompositionAdress::mapPositionToCellChecked(const Real3D &pos) {
+  longint c = cellGrid.mapPositionToCellChecked(pos);
+
+
+  if (c == CellGrid::noCell) {
+    return 0;
+  } else {
+    return &cells[c];
+  }
+}
+
+longint DomainDecompositionAdress::mapPositionToNodeClipped(const
+    Real3D &pos) {
+  return nodeGrid.mapPositionToNodeClipped(pos);
+}
+
+bool DomainDecompositionAdress::checkIsRealParticle(longint id, const
+    Real3D &pos) {
+  return getSystem()->comm->rank() == mapPositionToNodeClipped(pos);
+}
+
+void DomainDecompositionAdress::invalidateGhosts() {
+  for (CellListIterator it(getGhostCells());
+      it.isValid(); ++it) {
+    /* remove only ghosts from the hash if the localParticles hash
+       actually points to the ghost.  If there are local ghost cells
+       to implement pbc, the real particle will be the one accessible
+       via localParticles.
+     */
+    removeFromLocalParticles(&(*it), true);
   }
 
-  bool DomainDecompositionAdress::
-  checkIsRealParticle(longint id, const Real3D& pos) {
-    return getSystem()->comm->rank() == mapPositionToNodeClipped(pos);
-  }
+  // for AdResS
+  // std::cout << getSystem()->comm->rank() << ": ----- CLEAR GHOST ADRESS PARTICLES
+  // (AdrATParticlesG) ----\n";
+  // AdrATParticlesG.clear();
+  clearAdrATParticlesG();
 
+  // clear ghost tuples
+  FixedTupleListAdress::iterator it = fixedtupleList->begin();
 
+  for (; it != fixedtupleList->end(); ++it) {
+    Particle *vp = it->first;
 
-
-  void DomainDecompositionAdress::invalidateGhosts() {
-    for(CellListIterator it(getGhostCells());
-    it.isValid(); ++it) {
-  /* remove only ghosts from the hash if the localParticles hash
-     actually points to the ghost.  If there are local ghost cells
-     to implement pbc, the real particle will be the one accessible
-     via localParticles.
-  */
-        removeFromLocalParticles(&(*it), true);
+    if (vp->ghost()) {
+      // std::cout << "erasing ghost particle in tuple: " << vp->id() << "-" << vp->ghost() << "\n";
+      fixedtupleList->erase(it);
     }
+  }
+}
+
+void DomainDecompositionAdress::decompose() {
+  // std::cout << " ---- decompose ----\n";
+  invalidateGhosts();
+  decomposeRealParticles();
+
+  // std::cout << getSystem()->comm->rank() << ": (onTuplesChanged) ";
+  onTuplesChanged();   // for AdResS, renamed to not confuse with bonds
+  // std::cout << " ---- exchange ghosts ---- \n";
+  exchangeGhosts();
+
+  // std::cout << getSystem()->comm->rank() << ": ";
+  onParticlesChanged();
+}
+
+void DomainDecompositionAdress::packPositionsEtc(OutBuffer &buf,Cell &_reals, int extradata, const
+    Real3D &shift) {
+  ParticleList &reals  = _reals.particles;
+
+
+  for (ParticleList::iterator src = reals.begin(), end = reals.end(); src != end; ++src) {
+    buf.write(*src, extradata, shift);
+
+    /*std::cout << getSystem()->comm->rank() << ": -> " << src->id() << "-" << src->ghost() <<
+            " (" << src->getPos() << ") type " << src->getType() << " @ " << &(*src) << " \n";*/
 
     // for AdResS
-    //std::cout << getSystem()->comm->rank() << ": ----- CLEAR GHOST ADRESS PARTICLES (AdrATParticlesG) ----\n";
-    //AdrATParticlesG.clear();
-    clearAdrATParticlesG();
-    // clear ghost tuples
-    FixedTupleListAdress::iterator it = fixedtupleList->begin();
-    for (;it != fixedtupleList->end(); ++it) {
-        Particle* vp = it->first;
-        if (vp->ghost()) {
-            //std::cout << "erasing ghost particle in tuple: " << vp->id() << "-" << vp->ghost() << "\n";
-            fixedtupleList->erase(it);
-        }
+    // write all AT particles belonging to this VP into the buffer
+    FixedTupleListAdress::iterator it;
+
+    it = fixedtupleList->find(&(*src));
+
+    if (it != fixedtupleList->end()) {
+      std::vector<Particle *> atList;
+
+      atList = it->second;
+
+      int size = atList.size();
+
+      buf.write(size);       // write size of vector first
+
+      for (std::vector<Particle *>::iterator itv = atList.begin();
+          itv != atList.end(); ++itv) {
+        Particle &at = **itv;
+
+        /*std::cout << getSystem()->comm->rank() << ":  ---> " << at.id() << "-" << at.ghost() <<
+                " (" << at.position() << ") type " << at.type() << " \n";*/
+
+        buf.write(at, extradata, shift);         // we force extradata to 1
+      }
+    } else {
+      std::cout << getSystem()->comm->rank() << ": packposetc " << "VP particle " << src->id() <<
+              "-" << src->ghost() << " not found in tuples!\n";
+
+      exit(1);
+      return;
     }
   }
+}
 
-  void DomainDecompositionAdress::decompose() {
-    //std::cout << " ---- decompose ----\n";
-    invalidateGhosts();
-    decomposeRealParticles();
-    //std::cout << getSystem()->comm->rank() << ": (onTuplesChanged) ";
-    onTuplesChanged(); // for AdResS, renamed to not confuse with bonds
-    //std::cout << " ---- exchange ghosts ---- \n";
-    exchangeGhosts();
-    //std::cout << getSystem()->comm->rank() << ": ";
-    onParticlesChanged();
+void DomainDecompositionAdress::unpackPositionsEtc(Cell &_ghosts, InBuffer &buf, int extradata) {
+  ParticleList &ghosts  = _ghosts.particles;
+
+
+  for (ParticleList::iterator dst = ghosts.begin(), end = ghosts.end(); dst != end; ++dst) {
+    // std::cout << getSystem()->comm->rank() << ": buf.read(particle, extradata) (unpackPosEtc)
+    // \n";
+    buf.read(*dst, extradata);
+
+    if (extradata & DATA_PROPERTIES) {
+      updateInLocalParticles(&(*dst), true);
+    }
+
+    dst->ghost() = 1;
+
+    // for AdResS
+
+    /*std::cout << getSystem()->comm->rank() << ": <- " << dst->id() << "-" << dst->ghost() <<
+            " (" << dst->getPos() << ") type " << dst->getType() << "\n";*/
+
+    // int numAT = fixedtupleList->getNumPart(dst->id()); // does not work, not sure why
+    int numAT;
+
+    buf.read(numAT);     // read number of AT particles
+
+    FixedTupleListAdress::iterator it;
+
+    it = fixedtupleList->find(&(*dst));
+
+    if (it != fixedtupleList->end()) {
+      std::vector<Particle *> atList = it->second;
+
+      for (std::vector<Particle *>::iterator itv = atList.begin();
+          itv != atList.end(); ++itv) {
+        Particle &atg = **itv;
+
+        buf.read(atg, extradata);         // we force extradata to 1 (although not necessary
+                                          // here...)
+
+        /*std::cout << getSystem()->comm->rank() << ":  <1--- " << atg.id() << "-" << atg.ghost() <<
+                        " (" << atg.position() << ") type " << atg.type() <<
+                        " extradata: " << extradata << "\n";*/
+      }
+    } else {
+      std::vector<Particle *> tmp;
+
+      // Particle* atg; // atom, ghost
+      // Particle tmpatg; // temporary particle, to be inserted into adr. at. ghost part.
+
+      ParticleList tmp2;       // temporary vector
+
+      tmp2.resize(numAT);
+      appendParticleListToGhosts(tmp2);       // insert into list
+
+      ParticleList::iterator itv2  = (getAdrATParticlesG().back()).begin();
+
+      for (int i = 1; i <= numAT; ++i, ++itv2) {
+        // read the AT partcles
+        // std::cout << getSystem()->comm->rank() << ": buf.read(AT particle, extradata)
+        // (unpackPosEtc), i: " << i << "\n";
+
+        /*
+           buf.read(tmpatg, 1); // we force extradata to 1
+
+           atg = appendUnindexedAdrParticle(getAdrATParticlesG(), tmpatg);
+           atg->ghost() = 1;
+
+           tmp.push_back(atg);*/
+
+        Particle &atg = *itv2;
+
+        buf.read(atg, extradata);
+
+        atg.ghost() = 1;
+        tmp.push_back(&atg);
+
+        /*std::cout << getSystem()->comm->rank() << ":  <2--- " << atg.id() << "-" << atg.ghost() <<
+                            " (" << atg.getPos() << ") type " << atg.getType() <<
+                            " extradata: " << extradata << "\n";*/
+
+        /*if (atg->getType() == dst->getType()) { // for testing purposes
+            std::cout << "SERIOUS ERROR, particle is of wrong type\n";
+            exit(-1);
+            return;
+           }*/
+      }
+
+      fixedtupleList->insert(std::make_pair(&(*dst), tmp));
+      tmp.clear();
+    }
   }
+}
 
-  void DomainDecompositionAdress::packPositionsEtc(OutBuffer &buf,
-                   Cell &_reals, int extradata, const Real3D& shift) {
-      ParticleList &reals  = _reals.particles;
-
-      for(ParticleList::iterator src = reals.begin(), end = reals.end(); src != end; ++src) {
-
-        buf.write(*src, extradata, shift);
+void DomainDecompositionAdress::copyRealsToGhosts(Cell &_reals, Cell &_ghosts,int extradata,const
+    Real3D &shift) {
+  ParticleList &reals  = _reals.particles;
+  ParticleList &ghosts = _ghosts.particles;
 
 
-        /*std::cout << getSystem()->comm->rank() << ": -> " << src->id() << "-" << src->ghost() <<
-                " (" << src->getPos() << ") type " << src->getType() << " @ " << &(*src) << " \n";*/
+  ghosts.resize(reals.size());
+
+  // std::cout << "Copy reals to ghosts ... \n";
+
+  for (ParticleList::iterator src = reals.begin(), end = reals.end(), dst = ghosts.begin();
+      src != end; ++src, ++dst) {
+    dst->copyAsGhost(*src, extradata, shift);
+
+    // for AdResS
+    copyGhostTuples(*src, *dst, extradata, shift);
+  }
+}
+
+inline void DomainDecompositionAdress::copyGhostTuples(Particle &src, Particle &dst, int extradata,
+    const Real3D &shift) {
+  // create ghosts of particles in tuples
+  FixedTupleListAdress::iterator its;
 
 
-        // for AdResS
-        // write all AT particles belonging to this VP into the buffer
-        FixedTupleListAdress::iterator it;
-        it = fixedtupleList->find(&(*src));
+  its = fixedtupleList->find(&src);
+
+  if (its != fixedtupleList->end()) {
+    std::vector<Particle *> atList;
+
+    atList = its->second;         // src atomistic list
+
+    FixedTupleListAdress::iterator itd;
+
+    itd = fixedtupleList->find(&dst);
+
+    if (itd == fixedtupleList->end()) {         // if there is no dst tuple
+      std::vector<Particle *> tmp;          // temporary vector
+      ParticleList tmp2;           // temporary vector
+
+      tmp2.resize(atList.size());
+      appendParticleListToGhosts(tmp2);           // insert into list
+
+      ParticleList::iterator itv2  = (getAdrATParticlesG().back()).begin();
+
+      for (std::vector<Particle *>::iterator itv = atList.begin();
+          itv != atList.end(); ++itv, ++itv2) {
+        Particle &at = **itv;
+        Particle &atg = *itv2;
+
+        atg.copyAsGhost(at, extradata, shift);
+        tmp.push_back(&atg);
+      }
+
+      fixedtupleList->insert(std::make_pair(&dst, tmp));
+      tmp.clear();
+    } else {       // if the dst tuple already exists
+      std::vector<Particle *> atgList;
+
+      atgList = itd->second;           // dst atomistic ghost list
+
+      std::vector<Particle *>::iterator itv;
+      std::vector<Particle *>::iterator itv2 = atgList.begin();
+
+      for (itv = atList.begin(); itv != atList.end(); ++itv, ++itv2) {
+        Particle &at  = **itv;
+        Particle &atg = **itv2;
+
+        atg.copyAsGhost(at, extradata, shift);
+      }
+    }
+  } else {
+    std::cout << "copyGhostTuples: VP particle " << src.id() << "-" << src.ghost() << " (" <<
+            src.position() << ")" << " not found in tuples!\n";
+
+    exit(1);
+    return;
+  }
+}
+
+/* -- this is now solved in FixedTupleList.cpp in onparticleschanged()
+   void DomainDecompositionAdress::foldAdrPartCoor(Particle& part, Real3D& oldpos, int coord) {
+
+    if (part.position()[coord] != oldpos[coord]) {
+        real moved = oldpos[coord] - part.position()[coord];
+
+        FixedTupleList::iterator it;
+        it = fixedtupleList->find(&part);
         if (it != fixedtupleList->end()) {
             std::vector<Particle*> atList;
             atList = it->second;
-
-            int size = atList.size();
-            buf.write(size); // write size of vector first
 
             for (std::vector<Particle*>::iterator itv = atList.begin();
                   itv != atList.end(); ++itv) {
                 Particle &at = **itv;
 
-                /*std::cout << getSystem()->comm->rank() << ":  ---> " << at.id() << "-" << at.ghost() <<
-                        " (" << at.position() << ") type " << at.type() << " \n";*/
+                //std::cout << " updating position for AT part " << at.id() << " (" << at.position()
+                   << ") ";
 
-                buf.write(at, extradata, shift); // we force extradata to 1
+                at.position()[coord] = at.position()[coord] - moved;
+                //getSystem()->bc->foldCoordinate(at.position(), at.image(), coord);
+
+                //std::cout << "to (" << at.position() << ")\n";
             }
         }
         else {
-            std::cout << getSystem()->comm->rank() << ": packposetc " << "VP particle "<< src->id() << "-" << src->ghost() << " not found in tuples!\n";
-            exit(1);
-            return;
-        }
-
-      }
-    }
-
-  void DomainDecompositionAdress::unpackPositionsEtc(Cell &_ghosts, InBuffer &buf, int extradata) {
-      ParticleList &ghosts  = _ghosts.particles;
-
-      for(ParticleList::iterator dst = ghosts.begin(), end = ghosts.end(); dst != end; ++dst) {
-
-        //std::cout << getSystem()->comm->rank() << ": buf.read(particle, extradata) (unpackPosEtc) \n";
-        buf.read(*dst, extradata);
-
-        if (extradata & DATA_PROPERTIES) {
-            updateInLocalParticles(&(*dst), true);
-        }
-
-        dst->ghost() = 1;
-
-
-        // for AdResS
-
-        /*std::cout << getSystem()->comm->rank() << ": <- " << dst->id() << "-" << dst->ghost() <<
-                " (" << dst->getPos() << ") type " << dst->getType() << "\n";*/
-
-        //int numAT = fixedtupleList->getNumPart(dst->id()); // does not work, not sure why
-        int numAT;
-        buf.read(numAT); // read number of AT particles
-
-        FixedTupleListAdress::iterator it;
-        it = fixedtupleList->find(&(*dst));
-        if (it != fixedtupleList->end()) {
-            std::vector<Particle*> atList = it->second;
-
-            for (std::vector<Particle*>::iterator itv = atList.begin();
-                    itv != atList.end(); ++itv) {
-                Particle &atg = **itv;
-                buf.read(atg, extradata); // we force extradata to 1 (although not necessary here...)
-
-                /*std::cout << getSystem()->comm->rank() << ":  <1--- " << atg.id() << "-" << atg.ghost() <<
-                                " (" << atg.position() << ") type " << atg.type() <<
-                                " extradata: " << extradata << "\n";*/
-            }
-        }
-        else {
-            std::vector<Particle*> tmp;
-            //Particle* atg; // atom, ghost
-            //Particle tmpatg; // temporary particle, to be inserted into adr. at. ghost part.
-
-
-            ParticleList tmp2; // temporary vector
-            tmp2.resize(numAT);
-            appendParticleListToGhosts(tmp2); // insert into list
-
-            ParticleList::iterator itv2  = (getAdrATParticlesG().back()).begin();
-
-
-            for (int i = 1; i <= numAT; ++i, ++itv2) {
-                // read the AT partcles
-                //std::cout << getSystem()->comm->rank() << ": buf.read(AT particle, extradata) (unpackPosEtc), i: " << i << "\n";
-
-                /*
-                buf.read(tmpatg, 1); // we force extradata to 1
-
-                atg = appendUnindexedAdrParticle(getAdrATParticlesG(), tmpatg);
-                atg->ghost() = 1;
-
-                tmp.push_back(atg);*/
-
-                Particle &atg = *itv2;
-                buf.read(atg, extradata);
-
-                atg.ghost() = 1;
-                tmp.push_back(&atg);
-
-
-
-                /*std::cout << getSystem()->comm->rank() << ":  <2--- " << atg.id() << "-" << atg.ghost() <<
-                                    " (" << atg.getPos() << ") type " << atg.getType() <<
-                                    " extradata: " << extradata << "\n";*/
-
-                /*if (atg->getType() == dst->getType()) { // for testing purposes
-                    std::cout << "SERIOUS ERROR, particle is of wrong type\n";
-                    exit(-1);
-                    return;
-                }*/
-            }
-
-            fixedtupleList->insert(std::make_pair(&(*dst), tmp));
-            tmp.clear();
-        }
-
-
-
-
-      }
-    }
-
-  void DomainDecompositionAdress::copyRealsToGhosts(Cell &_reals, Cell &_ghosts,
-                  int extradata,
-                  const Real3D& shift) {
-
-    ParticleList &reals  = _reals.particles;
-    ParticleList &ghosts = _ghosts.particles;
-
-    ghosts.resize(reals.size());
-
-    //std::cout << "Copy reals to ghosts ... \n";
-
-    for(ParticleList::iterator src = reals.begin(), end = reals.end(), dst = ghosts.begin();
-            src != end; ++src, ++dst) {
-      dst->copyAsGhost(*src, extradata, shift);
-
-      // for AdResS
-      copyGhostTuples(*src, *dst, extradata, shift);
-    }
-  }
-
-
-  inline void DomainDecompositionAdress::copyGhostTuples(Particle& src, Particle& dst, int extradata, const Real3D& shift) {
-
-        // create ghosts of particles in tuples
-        FixedTupleListAdress::iterator its;
-        its = fixedtupleList->find(&src);
-        if (its != fixedtupleList->end()) {
-
-            std::vector<Particle*> atList;
-            atList = its->second; // src atomistic list
-
-            FixedTupleListAdress::iterator itd;
-            itd = fixedtupleList->find(&dst);
-            if (itd == fixedtupleList->end()) { // if there is no dst tuple
-                std::vector<Particle*> tmp; // temporary vector
-                ParticleList tmp2; // temporary vector
-                tmp2.resize(atList.size());
-                appendParticleListToGhosts(tmp2); // insert into list
-                ParticleList::iterator itv2  = (getAdrATParticlesG().back()).begin();
-                for (std::vector<Particle*>::iterator itv = atList.begin();
-                      itv != atList.end(); ++itv, ++itv2) {
-                    Particle &at = **itv;
-                    Particle &atg = *itv2;
-                    atg.copyAsGhost(at, extradata, shift);
-                    tmp.push_back(&atg);
-                }
-                fixedtupleList->insert(std::make_pair(&dst, tmp));
-                tmp.clear();
-            }
-
-            else { // if the dst tuple already exists
-                std::vector<Particle*> atgList;
-                atgList = itd->second; // dst atomistic ghost list
-                std::vector<Particle*>::iterator itv;
-                std::vector<Particle*>::iterator itv2 = atgList.begin();
-                for (itv = atList.begin(); itv != atList.end(); ++itv, ++itv2) {
-                    Particle &at  = **itv;
-                    Particle &atg = **itv2;
-                    atg.copyAsGhost(at, extradata, shift);
-                }
-            }
-
-        }
-        else {
-            std::cout << "copyGhostTuples: VP particle "<< src.id() << "-" << src.ghost() << " (" << src.position() << ")" << " not found in tuples!\n";
+            std::cout << getSystem()->comm->rank() << ": foldAdrPartCoor "
+                    << "VP particle "<< part.id() << "-" << part.ghost() << " not found in
+                       tuples!\n";
             exit(1);
             return;
         }
     }
+   }
+ */
 
-  /* -- this is now solved in FixedTupleList.cpp in onparticleschanged()
-  void DomainDecompositionAdress::foldAdrPartCoor(Particle& part, Real3D& oldpos, int coord) {
+void DomainDecompositionAdress::packForces(OutBuffer &buf, Cell &_ghosts) {
+  ParticleList &ghosts = _ghosts.particles;
 
-      if (part.position()[coord] != oldpos[coord]) {
-          real moved = oldpos[coord] - part.position()[coord];
 
-          FixedTupleList::iterator it;
-          it = fixedtupleList->find(&part);
-          if (it != fixedtupleList->end()) {
-              std::vector<Particle*> atList;
-              atList = it->second;
+  for (ParticleList::iterator src = ghosts.begin(), end = ghosts.end(); src != end; ++src) {
+    buf.write(src->particleForce());
 
-              for (std::vector<Particle*>::iterator itv = atList.begin();
-                    itv != atList.end(); ++itv) {
-                  Particle &at = **itv;
+    LOG4ESPP_TRACE(logger, "from particle " << src->id() << ": packing force " << src->force());
 
-                  //std::cout << " updating position for AT part " << at.id() << " (" << at.position() << ") ";
+    /*std::cout << getSystem()->comm->rank() << ": " << " from particle " << src->id()
+            << " packing force " << src->force() << "\n";*/
 
-                  at.position()[coord] = at.position()[coord] - moved;
-                  //getSystem()->bc->foldCoordinate(at.position(), at.image(), coord);
+    // for AdResS
+    // write all AT particle forces belonging to this VP into the buffer
+    FixedTupleListAdress::iterator it;
 
-                  //std::cout << "to (" << at.position() << ")\n";
-              }
-          }
-          else {
-              std::cout << getSystem()->comm->rank() << ": foldAdrPartCoor "
-                      << "VP particle "<< part.id() << "-" << part.ghost() << " not found in tuples!\n";
-              exit(1);
-              return;
-          }
+    it = fixedtupleList->find(&(*src));
+
+    if (it != fixedtupleList->end()) {
+      std::vector<Particle *> atList;
+
+      atList = it->second;
+
+      for (std::vector<Particle *>::iterator itv = atList.begin();
+          itv != atList.end(); ++itv) {
+        Particle &at = **itv;
+
+        /*std::cout << getSystem()->comm->rank() << ":  ---> " << at.id() << "-" << at.ghost() <<
+                " (" << at.position() << ") type " << at.type() << " \n";*/
+
+        buf.write(at.particleForce());
       }
-  }
-  */
+    } else {
+      std::cout << getSystem()->comm->rank() << ": packforces " << "VP particle " << src->id() <<
+              "-" << src->ghost() << " not found in tuples!\n";
 
-  void DomainDecompositionAdress::packForces(OutBuffer &buf, Cell &_ghosts) {
-
-    ParticleList &ghosts = _ghosts.particles;
-
-    for(ParticleList::iterator src = ghosts.begin(), end = ghosts.end(); src != end; ++src) {
-
-      buf.write(src->particleForce());
-
-      LOG4ESPP_TRACE(logger, "from particle " << src->id() << ": packing force " << src->force());
-
-
-      /*std::cout << getSystem()->comm->rank() << ": " << " from particle " << src->id()
-              << " packing force " << src->force() << "\n";*/
-
-
-
-      // for AdResS
-      // write all AT particle forces belonging to this VP into the buffer
-      FixedTupleListAdress::iterator it;
-      it = fixedtupleList->find(&(*src));
-      if (it != fixedtupleList->end()) {
-          std::vector<Particle*> atList;
-          atList = it->second;
-
-          for (std::vector<Particle*>::iterator itv = atList.begin();
-                itv != atList.end(); ++itv) {
-              Particle &at = **itv;
-
-              /*std::cout << getSystem()->comm->rank() << ":  ---> " << at.id() << "-" << at.ghost() <<
-                      " (" << at.position() << ") type " << at.type() << " \n";*/
-
-              buf.write(at.particleForce());
-          }
-      }
-      else {
-          std::cout << getSystem()->comm->rank() << ": packforces " << "VP particle "<< src->id() << "-" << src->ghost() << " not found in tuples!\n";
-          exit(1);
-          return;
-      }
+      exit(1);
+      return;
     }
   }
+}
 
-  void DomainDecompositionAdress::unpackAndAddForces(Cell &_reals, InBuffer &buf)
-  {
-    LOG4ESPP_DEBUG(logger, "add forces from buffer to cell "
-           << (&_reals - getFirstCell()));
+void DomainDecompositionAdress::unpackAndAddForces(Cell &_reals, InBuffer &buf) {
+  LOG4ESPP_DEBUG(logger, "add forces from buffer to cell "
+          << (&_reals - getFirstCell()));
 
-    ParticleList &reals = _reals.particles;
+  ParticleList &reals = _reals.particles;
 
-    for(ParticleList::iterator dst = reals.begin(), end = reals.end(); dst != end; ++dst) {
-        ParticleForce f;
-        //std::cout << getSystem()->comm->rank() << ": buf.read(force) (unpackAndAddForces) \n";
+  for (ParticleList::iterator dst = reals.begin(), end = reals.end(); dst != end; ++dst) {
+    ParticleForce f;
+
+    // std::cout << getSystem()->comm->rank() << ": buf.read(force) (unpackAndAddForces) \n";
+    buf.read(f);
+    LOG4ESPP_TRACE(logger, "for particle " << dst->id() << ": unpacking force "
+                                           << f.f() << " and adding to " << dst->force());
+    dst->particleForce() += f;
+
+    /*std::cout << getSystem()->comm->rank() << ": " << " for particle " << dst->id() << " unpacking
+       force "
+        << " and adding to " << dst->force() << "\n";*/
+
+    // for AdResS
+
+    // iterate through atomistic particles in fixedtuplelist
+    FixedTupleListAdress::iterator it;
+
+    it = fixedtupleList->find(&(*dst));
+
+    if (it != fixedtupleList->end()) {
+      std::vector<Particle *> atList1;
+
+      atList1 = it->second;
+
+      // std::cout << "AT forces ...\n";
+      for (std::vector<Particle *>::iterator itv = atList1.begin(); itv != atList1.end(); ++itv) {
+        Particle &p3 = **itv;
+
+        // std::cout << getSystem()->comm->rank() << ": buf.read(AT force) (unpackAndAddForces) \n";
         buf.read(f);
-        LOG4ESPP_TRACE(logger, "for particle " << dst->id() << ": unpacking force "
-             << f.f() << " and adding to " << dst->force());
-        dst->particleForce() += f;
-
-
-
-        /*std::cout << getSystem()->comm->rank() << ": " << " for particle " << dst->id() << " unpacking force "
-            << " and adding to " << dst->force() << "\n";*/
-
-
-        // for AdResS
-
-        // iterate through atomistic particles in fixedtuplelist
-        FixedTupleListAdress::iterator it;
-        it = fixedtupleList->find(&(*dst));
-
-        if (it != fixedtupleList->end()) {
-
-           std::vector<Particle*> atList1;
-           atList1 = it->second;
-
-           //std::cout << "AT forces ...\n";
-           for (std::vector<Particle*>::iterator itv = atList1.begin(); itv != atList1.end(); ++itv) {
-               Particle &p3 = **itv;
-               //std::cout << getSystem()->comm->rank() << ": buf.read(AT force) (unpackAndAddForces) \n";
-               buf.read(f);
-               p3.particleForce() += f;
-           }
-        }
-        else {
-           std::cout << " unpackForces: one of the VP particles not found in tuples: " << dst->id() << "-" << dst->ghost();
-           exit(1);
-           return;
-        }
-
-    }
-  }
-
-  void DomainDecompositionAdress::addGhostForcesToReals(Cell &_ghosts, Cell &_reals)
-  {
-
-    ParticleList &reals  = _reals.particles;
-    ParticleList &ghosts = _ghosts.particles;
-
-    for(ParticleList::iterator dst = reals.begin(), end = reals.end(), src = ghosts.begin();
-            dst != end; ++dst, ++src) {
-        LOG4ESPP_TRACE(logger, "for particle " << dst->id() << ": adding force "
-             << src->force() << " to " << dst->force());
-
-        dst->particleForce() += src->particleForce();
-
-        // for AdResS
-        addAdrGhostForcesToReals(*src, *dst);
-    }
-  }
-
-  inline void DomainDecompositionAdress::addAdrGhostForcesToReals(Particle& src, Particle& dst) {
-
-      // iterate through atomistic particles in fixedtuplelist
-      FixedTupleListAdress::iterator its;
-      FixedTupleListAdress::iterator itd;
-      its = fixedtupleList->find(&src);
-      itd = fixedtupleList->find(&dst);
-
-      //std::cout << "\nInteraction " << p1.id() << " - " << p2.id() << "\n";
-      if (its != fixedtupleList->end() && itd != fixedtupleList->end()) {
-
-          std::vector<Particle*> atList1;
-          std::vector<Particle*> atList2;
-          atList1 = its->second;
-          atList2 = itd->second;
-
-          for (std::vector<Particle*>::iterator itv = atList1.begin(),
-                  itv2 = atList2.begin(); itv != atList1.end(); ++itv, ++itv2) {
-
-              Particle &p3 = **itv;
-              Particle &p4 = **itv2;
-
-              p4.particleForce() += p3.particleForce();
-          }
+        p3.particleForce() += f;
       }
-      else {
-          std::cout << " one of the VP particles not found in tuples: " << src.id() << "-" <<
-                  src.ghost() << ", " << dst.id() << "-" << dst.ghost();
-          exit(1);
-          return;
-      }
-  }
+    } else {
+      std::cout << " unpackForces: one of the VP particles not found in tuples: " << dst->id() <<
+              "-" << dst->ghost();
 
-
-
-
-
-
-
-
-
-
-
-
-
-  bool DomainDecompositionAdress::
-  appendParticles(ParticleList &l, int dir) {
-    bool outlier = false;
-
-    LOG4ESPP_DEBUG(logger, "got " << l.size() << " particles");
-
-    for (ParticleList::iterator it = l.begin(),
-        end = l.end(); it != end; ++it) {
-
-        Real3D& pos = it->position();
-        Real3D oldpos = pos;
-
-        if (nodeGrid.getBoundary(dir) != 0) {
-            getSystem()->bc->foldCoordinate(pos, it->image(), nodeGrid.convertDirToCoord(dir));
-            LOG4ESPP_TRACE(logger, "folded coordinate " << nodeGrid.convertDirToCoord(dir)
-                    << " of particle " << it->id());
-        }
-
-        longint cell;
-        if (cellGrid.mapPositionToCellCheckedAndClipped(cell, pos)) {
-            LOG4ESPP_TRACE(logger, "particle " << it->id()
-                    << " @ " << pos << " is not inside node domain");
-            outlier = true;
-        }
-
-        LOG4ESPP_TRACE(logger, "append part " << it->id() << " to cell "
-                << cell);
-
-        appendIndexedParticle(cells[cell].particles, *it);
+      exit(1);
+      return;
     }
-    return outlier;
+  }
+}
+
+void DomainDecompositionAdress::addGhostForcesToReals(Cell &_ghosts, Cell &_reals) {
+  ParticleList &reals  = _reals.particles;
+  ParticleList &ghosts = _ghosts.particles;
+
+
+  for (ParticleList::iterator dst = reals.begin(), end = reals.end(), src = ghosts.begin();
+      dst != end; ++dst, ++src) {
+    LOG4ESPP_TRACE(logger, "for particle " << dst->id() << ": adding force "
+                                           << src->force() << " to " << dst->force());
+
+    dst->particleForce() += src->particleForce();
+
+    // for AdResS
+    addAdrGhostForcesToReals(*src, *dst);
+  }
+}
+
+inline void DomainDecompositionAdress::addAdrGhostForcesToReals(Particle &src, Particle &dst) {
+  // iterate through atomistic particles in fixedtuplelist
+  FixedTupleListAdress::iterator its;
+  FixedTupleListAdress::iterator itd;
+
+
+  its = fixedtupleList->find(&src);
+  itd = fixedtupleList->find(&dst);
+
+  // std::cout << "\nInteraction " << p1.id() << " - " << p2.id() << "\n";
+  if ((its != fixedtupleList->end()) && (itd != fixedtupleList->end())) {
+    std::vector<Particle *> atList1;
+    std::vector<Particle *> atList2;
+
+    atList1 = its->second;
+    atList2 = itd->second;
+
+    for (std::vector<Particle *>::iterator itv = atList1.begin(),
+        itv2 = atList2.begin(); itv != atList1.end(); ++itv, ++itv2) {
+      Particle &p3 = **itv;
+      Particle &p4 = **itv2;
+
+      p4.particleForce() += p3.particleForce();
+    }
+  } else {
+    std::cout << " one of the VP particles not found in tuples: " << src.id() << "-" <<
+        src.ghost() << ", " << dst.id() << "-" << dst.ghost();
+
+    exit(1);
+    return;
+  }
+}
+
+bool DomainDecompositionAdress::appendParticles(ParticleList &l, int
+    dir) {
+  bool outlier = false;
+
+
+  LOG4ESPP_DEBUG(logger, "got " << l.size() << " particles");
+
+  for (ParticleList::iterator it = l.begin(),
+      end = l.end(); it != end; ++it) {
+    Real3D &pos = it->position();
+    Real3D oldpos = pos;
+
+    if (nodeGrid.getBoundary(dir) != 0) {
+      getSystem()->bc->foldCoordinate(pos, it->image(), nodeGrid.convertDirToCoord(dir));
+      LOG4ESPP_TRACE(logger, "folded coordinate " << nodeGrid.convertDirToCoord(dir)
+                                                  << " of particle " << it->id());
+    }
+
+    longint cell;
+
+    if (cellGrid.mapPositionToCellCheckedAndClipped(cell, pos)) {
+      LOG4ESPP_TRACE(logger, "particle " << it->id()
+                                         << " @ " << pos << " is not inside node domain");
+      outlier = true;
+    }
+
+    LOG4ESPP_TRACE(logger, "append part " << it->id() << " to cell "
+                                          << cell);
+
+    appendIndexedParticle(cells[cell].particles, *it);
   }
 
-  void DomainDecompositionAdress::decomposeRealParticles() {
+  return outlier;
+}
 
-      //std::cout << getSystem()->comm->rank() << ": " << " decomposeRealParticles\n";
+void DomainDecompositionAdress::decomposeRealParticles() {
+  // std::cout << getSystem()->comm->rank() << ": " << " decomposeRealParticles\n";
 
-    LOG4ESPP_DEBUG(logger, "starting, expected comm buffer size " << exchangeBufferSize);
+  LOG4ESPP_DEBUG(logger, "starting, expected comm buffer size " << exchangeBufferSize);
 
-    // allocate send/recv buffers. We use the size as we need maximally so far, to avoid reallocation
-    // TODO: This might be a problem when all particles are created on a single node initially!
-    ParticleList sendBufL;
-    sendBufL.reserve(exchangeBufferSize);
-    ParticleList sendBufR;
-    sendBufR.reserve(exchangeBufferSize);
-    ParticleList recvBufL;
-    recvBufL.reserve(exchangeBufferSize);
-    ParticleList recvBufR;
-    recvBufR.reserve(exchangeBufferSize);
+  // allocate send/recv buffers. We use the size as we need maximally so far, to avoid reallocation
+  // TODO: This might be a problem when all particles are created on a single node initially!
+  ParticleList sendBufL;
 
-    bool allFinished;
-    do {
-  bool finished = true;
+  sendBufL.reserve(exchangeBufferSize);
 
-  for (int coord = 0; coord < 3; ++coord) {
-    LOG4ESPP_DEBUG(logger, "starting with direction " << coord);
+  ParticleList sendBufR;
 
-    if (nodeGrid.getGridSize(coord) > 1) {
-      for (std::vector<Cell*>::iterator it = realCells.begin(),
-         end = realCells.end(); it != end; ++it) {
+  sendBufR.reserve(exchangeBufferSize);
 
-        Cell &cell = **it;
+  ParticleList recvBufL;
 
-        // do not use an iterator here, since we need to take out particles during the loop
-        for (size_t p = 0; p < cell.particles.size(); ++p) {
+  recvBufL.reserve(exchangeBufferSize);
+
+  ParticleList recvBufR;
+
+  recvBufR.reserve(exchangeBufferSize);
+
+  bool allFinished;
+
+  do {
+    bool finished = true;
+
+    for (int coord = 0; coord < 3; ++coord) {
+      LOG4ESPP_DEBUG(logger, "starting with direction " << coord);
+
+      if (nodeGrid.getGridSize(coord) > 1) {
+        for (std::vector<Cell *>::iterator it = realCells.begin(),
+            end = realCells.end(); it != end; ++it) {
+          Cell &cell = **it;
+
+          // do not use an iterator here, since we need to take out particles during the loop
+          for (size_t p = 0; p < cell.particles.size(); ++p) {
             Particle &part = cell.particles[p];
-            const Real3D& pos = part.position();
+            const Real3D &pos = part.position();
 
             // check whether the particle is now "left" of the local domain
             if (pos[coord] - cellGrid.getMyLeft(coord) < -ROUND_ERROR_PREC) {
-                LOG4ESPP_TRACE(logger, "send particle left " << part.id());
-                moveIndexedParticle(sendBufL, cell.particles, p);
-                // redo same particle since we took one out here, so it's a new one
-                --p;
+              LOG4ESPP_TRACE(logger, "send particle left " << part.id());
+              moveIndexedParticle(sendBufL, cell.particles, p);
+
+              // redo same particle since we took one out here, so it's a new one
+              --p;
             }
             // check whether the particle is now "right" of the local domain
             else if (pos[coord] - cellGrid.getMyRight(coord) >= ROUND_ERROR_PREC) {
-                LOG4ESPP_TRACE(logger, "send particle right " << part.id());
-                moveIndexedParticle(sendBufR, cell.particles, p);
-                --p;
+              LOG4ESPP_TRACE(logger, "send particle right " << part.id());
+              moveIndexedParticle(sendBufR, cell.particles, p);
+              --p;
             }
             // Sort particles in cells of this node during last direction
             else if (coord == 2) {
-                const Real3D& pos = part.position();
-                Cell *sortCell = mapPositionToCellChecked(pos);
-                if (sortCell != &cell) {
-                    if (sortCell == 0) {
-                        // particle is not in the local domain
-                        LOG4ESPP_DEBUG(logger, "take another loop: particle " << part.id()
-                                << " @ " << pos <<
-                                " is not inside node domain after neighbor exchange");
-                        // isnan function is C99 only, x != x is only true if x == nan
-                        if (pos[0] != pos[0] || pos[1] != pos[1] || pos[2] != pos[2]) {
-                            // TODO: error handling
-                            LOG4ESPP_ERROR(logger, "particle " << part.id() <<
-                                    " has moved to outer space (one or more coordinates are nan)");
-                        } else {
-                            // particle stays where it is, and will be sorted in the next round
-                            finished = false;
-                        }
-                    } else {
-                        // particle is in the local domain
-                        moveIndexedParticle(sortCell->particles, cell.particles, p);
-                        --p;
-                    }
+              const Real3D &pos = part.position();
+              Cell *sortCell = mapPositionToCellChecked(pos);
+
+              if (sortCell != &cell) {
+                if (sortCell == 0) {
+                  // particle is not in the local domain
+                  LOG4ESPP_DEBUG(logger, "take another loop: particle " << part.id()
+                                                                        << " @ " << pos <<
+                          " is not inside node domain after neighbor exchange");
+
+                  // isnan function is C99 only, x != x is only true if x == nan
+                  if ((pos[0] != pos[0]) || (pos[1] != pos[1]) || (pos[2] != pos[2])) {
+                    // TODO: error handling
+                    LOG4ESPP_ERROR(logger, "particle " << part.id() <<
+                            " has moved to outer space (one or more coordinates are nan)");
+                  } else {
+                    // particle stays where it is, and will be sorted in the next round
+                    finished = false;
+                  }
+                } else {
+                  // particle is in the local domain
+                  moveIndexedParticle(sortCell->particles, cell.particles, p);
+                  --p;
                 }
+              }
             }
-
+          }
         }
-      }
 
-      // Exchange particles, odd-even rule
-      if (nodeGrid.getNodePosition(coord) % 2 == 0) {
-        sendParticles(sendBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
-        recvParticles(recvBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
-        sendParticles(sendBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
-        recvParticles(recvBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
+        // Exchange particles, odd-even rule
+        if (nodeGrid.getNodePosition(coord) % 2 == 0) {
+          sendParticles(sendBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
+          recvParticles(recvBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
+          sendParticles(sendBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
+          recvParticles(recvBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
+        } else {
+          recvParticles(recvBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
+          sendParticles(sendBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
+          recvParticles(recvBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
+          sendParticles(sendBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
+        }
+
+        // sort received particles to cells
+        if (appendParticles(recvBufL, 2 * coord) && (coord == 2)) finished = false;
+
+        if (appendParticles(recvBufR, 2 * coord + 1) && (coord == 2)) finished = false;
+
+        // reset send/recv buffers
+        sendBufL.resize(0);
+        sendBufR.resize(0);
+        recvBufL.resize(0);
+        recvBufR.resize(0);
       } else {
-        recvParticles(recvBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
-        sendParticles(sendBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
-        recvParticles(recvBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
-        sendParticles(sendBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
-      }
+        /* Single node direction case (no communication)
+           Fold particles that have left the box */
+        for (std::vector<Cell *>::iterator it = realCells.begin(),
+            end = realCells.end(); it != end; ++it) {
+          Cell &cell = **it;
 
-      // sort received particles to cells
-      if (appendParticles(recvBufL, 2 * coord    ) && coord == 2) finished = false;
-      if (appendParticles(recvBufR, 2 * coord + 1) && coord == 2) finished = false;
-
-      // reset send/recv buffers
-      sendBufL.resize(0);
-      sendBufR.resize(0);
-      recvBufL.resize(0);
-      recvBufR.resize(0);
-
-
-    } else {
-      /* Single node direction case (no communication)
-         Fold particles that have left the box */
-      for (std::vector< Cell* >::iterator it = realCells.begin(),
-         end = realCells.end(); it != end; ++it) {
-        Cell &cell = **it;
-        // do not use an iterator here, since we have need to take out particles during the loop
-        for (size_t p = 0; p < cell.particles.size(); ++p) {
+          // do not use an iterator here, since we have need to take out particles during the loop
+          for (size_t p = 0; p < cell.particles.size(); ++p) {
             Particle &part = cell.particles[p];
+
             getSystem()->bc->foldCoordinate(part.position(), part.image(), coord);
             LOG4ESPP_TRACE(logger, "folded coordinate " << coord << " of particle " << part.id());
 
             if (coord == 2) {
-                Cell *sortCell = mapPositionToCellChecked(part.position());
+              Cell *sortCell = mapPositionToCellChecked(part.position());
 
-                if (sortCell != &cell) {
-                    if (sortCell == 0) {
-                        LOG4ESPP_DEBUG(logger, "take another loop: particle " << part.id()
-                                << " @ " << part.position()
-                                << " is not inside node domain after neighbor exchange");
-                        const Real3D& pos = part.position();
-                        // isnan function is C99 only, x != x is only true if x == nan
-                        if (pos[0] != pos[0] || pos[1] != pos[1] || pos[2] != pos[2]) {
-                            LOG4ESPP_ERROR(logger, "particle " << part.id() <<
-                                    " has moved to outer space (one or more coordinates are nan)");
-                        } else {
-                            // particle stays where it is, and will be sorted in the next round
-                            finished = false;
-                        }
-                    } else {
-                        moveIndexedParticle(sortCell->particles, cell.particles, p);
-                        --p;
-                    }
+              if (sortCell != &cell) {
+                if (sortCell == 0) {
+                  LOG4ESPP_DEBUG(logger, "take another loop: particle " << part.id()
+                                                                        << " @ " << part.position()
+                                                                        <<
+                          " is not inside node domain after neighbor exchange");
+
+                  const Real3D &pos = part.position();
+
+                  // isnan function is C99 only, x != x is only true if x == nan
+                  if ((pos[0] != pos[0]) || (pos[1] != pos[1]) || (pos[2] != pos[2])) {
+                    LOG4ESPP_ERROR(logger, "particle " << part.id() <<
+                            " has moved to outer space (one or more coordinates are nan)");
+                  } else {
+                    // particle stays where it is, and will be sorted in the next round
+                    finished = false;
+                  }
+                } else {
+                  moveIndexedParticle(sortCell->particles, cell.particles, p);
+                  --p;
                 }
+              }
             }
+          }
         }
       }
+
+      LOG4ESPP_DEBUG(logger, "done with direction " << coord);
     }
 
-    LOG4ESPP_DEBUG(logger, "done with direction " << coord);
-  }
+    // Communicate wether particle exchange is finished
+    mpi::all_reduce(*getSystem()->comm, finished, allFinished, std::logical_and<bool>());
+  } while (!allFinished);
 
-  // Communicate wether particle exchange is finished
-  mpi::all_reduce(*getSystem()->comm, finished, allFinished, std::logical_and<bool>());
-    } while (!allFinished);
+  exchangeBufferSize = std::max(exchangeBufferSize,
+    std::max(sendBufL.capacity(),
+    std::max(sendBufR.capacity(),
+    std::max(recvBufL.capacity(),
+    recvBufR.capacity()))));
 
-    exchangeBufferSize = std::max(exchangeBufferSize,
-                  std::max(sendBufL.capacity(),
-                       std::max(sendBufR.capacity(),
-                            std::max(recvBufL.capacity(),
-                                 recvBufR.capacity()))));
+  LOG4ESPP_DEBUG(logger, "finished exchanging particles, new send/recv buffer size " <<
+          exchangeBufferSize);
 
-    LOG4ESPP_DEBUG(logger, "finished exchanging particles, new send/recv buffer size " << exchangeBufferSize);
+  LOG4ESPP_DEBUG(logger, "done");
+}
 
-    LOG4ESPP_DEBUG(logger, "done");
-  }
+void DomainDecompositionAdress::exchangeGhosts() {
+  LOG4ESPP_DEBUG(logger, "exchangeGhosts -> ghost communication sizes first, real->ghost");
+  doGhostCommunication(true, true, dataOfExchangeGhosts);
+}
 
-  void DomainDecompositionAdress::exchangeGhosts() {
+void DomainDecompositionAdress::updateGhosts() {
+  LOG4ESPP_DEBUG(logger, "updateGhosts -> ghost communication no sizes, real->ghost");
+  doGhostCommunication(false, true, dataOfUpdateGhosts);
+}
 
-    LOG4ESPP_DEBUG(logger, "exchangeGhosts -> ghost communication sizes first, real->ghost");
-    doGhostCommunication(true, true, dataOfExchangeGhosts);
-  }
+void DomainDecompositionAdress::updateGhostsV() {
+  LOG4ESPP_DEBUG(logger, "updateGhostsV -> ghost communication no sizes, real->ghost velocities");
+  doGhostCommunication(false, true, 2);   // 2 is the bitflag for particle momentum
+}
 
-  void DomainDecompositionAdress::updateGhosts() {
-    LOG4ESPP_DEBUG(logger, "updateGhosts -> ghost communication no sizes, real->ghost");
-    doGhostCommunication(false, true, dataOfUpdateGhosts);
-  }
+void DomainDecompositionAdress::collectGhostForces() {
+  LOG4ESPP_DEBUG(logger, "collectGhosts -> ghost communication no sizes, ghost->real");
+  doGhostCommunication(false, false);
+}
 
-  void DomainDecompositionAdress::updateGhostsV() {
-    LOG4ESPP_DEBUG(logger, "updateGhostsV -> ghost communication no sizes, real->ghost velocities");
-    doGhostCommunication(false, true, 2); // 2 is the bitflag for particle momentum
-  }
+void DomainDecompositionAdress::fillCells(std::vector<Cell *> &cv,const int leftBoundary[3],const
+    int rightBoundary[3]) {
+  LOG4ESPP_DEBUG(logger, "filling: "
+          << leftBoundary[0] << "-" << (rightBoundary[0] - 1) << " "
+          << leftBoundary[1] << "-" << (rightBoundary[1] - 1) << " "
+          << leftBoundary[2] << "-" << (rightBoundary[2] - 1));
 
-  void DomainDecompositionAdress::collectGhostForces() {
-    LOG4ESPP_DEBUG(logger, "collectGhosts -> ghost communication no sizes, ghost->real");
-    doGhostCommunication(false, false);
-  }
+  longint total = 1;
 
-  void DomainDecompositionAdress::fillCells(std::vector<Cell *> &cv,
-                  const int leftBoundary[3],
-                  const int rightBoundary[3]) {
-    LOG4ESPP_DEBUG(logger, "filling: "
-           << leftBoundary[0] << "-" << (rightBoundary[0] - 1) << " "
-           << leftBoundary[1] << "-" << (rightBoundary[1] - 1) << " "
-           << leftBoundary[2] << "-" << (rightBoundary[2] - 1));
-
-    longint total = 1;
-    for (int i = 0; i < 3; ++i) {
-        if (leftBoundary[i] < 0 || leftBoundary[i] > cellGrid.getFrameGridSize(i) ||
-                rightBoundary[i] < 0 || rightBoundary[i] > cellGrid.getFrameGridSize(i) ||
-                leftBoundary[i] >= rightBoundary[i]) {
-            throw std::runtime_error("DomainDecompositionAdress::fillCells: wrong cell grid specified internally");
-        }
-        total *= (rightBoundary[i] - leftBoundary[i]);
-    }
-    cv.reserve(total);
-
-    for (int o = leftBoundary[0]; o < rightBoundary[0]; ++o) {
-        for (int n = leftBoundary[1]; n < rightBoundary[1]; ++n) {
-            for (int m = leftBoundary[2]; m < rightBoundary[2]; ++m) {
-                int i = cellGrid.mapPositionToIndex(o, n, m);
-                LOG4ESPP_TRACE(logger, "add cell " << i);
-                cv.push_back(&cells[i]);
-            }
-        }
+  for (int i = 0; i < 3; ++i) {
+    if ((leftBoundary[i] < 0) || (leftBoundary[i] > cellGrid.getFrameGridSize(i)) ||
+        (rightBoundary[i] < 0) || (rightBoundary[i] > cellGrid.getFrameGridSize(i)) ||
+        (leftBoundary[i] >= rightBoundary[i])) {
+      throw std::runtime_error(
+        "DomainDecompositionAdress::fillCells: wrong cell grid specified internally");
     }
 
-    LOG4ESPP_DEBUG(logger, "expected " << total << " cells, filled with " << cv.size());
+    total *= (rightBoundary[i] - leftBoundary[i]);
   }
 
-  void DomainDecompositionAdress::prepareGhostCommunication() {
-    // direction loop: x, y, z
-    for (int coord = 0; coord < 3; ++coord) {
-        // boundaries of area to send
-        int leftBoundary[3], rightBoundary[3];
-        /* boundaries perpendicular directions are the same for left/right send.
-        We also send the ghost frame that we have already, so the data amount
-        increase with each cycle.
+  cv.reserve(total);
 
-        For a direction that was done already, i.e. is smaller than dir,
-        we take the full ghost frame, otherwise only the inner frame.  */
-        for (int offset = 1; offset <= 2; ++offset) {
-            int otherCoord = (coord + offset) % 3;
-            if (otherCoord < coord) {
-                leftBoundary[otherCoord] = 0;
-                rightBoundary[otherCoord] = cellGrid.getFrameGridSize(otherCoord);
-            } else {
-                leftBoundary[otherCoord] = cellGrid.getInnerCellsBegin(otherCoord);
-                rightBoundary[otherCoord] = cellGrid.getInnerCellsEnd(otherCoord);
-            }
-        }
+  for (int o = leftBoundary[0]; o < rightBoundary[0]; ++o) {
+    for (int n = leftBoundary[1]; n < rightBoundary[1]; ++n) {
+      for (int m = leftBoundary[2]; m < rightBoundary[2]; ++m) {
+        int i = cellGrid.mapPositionToIndex(o, n, m);
 
-        //  lr loop: left right - loop
-        for (int lr = 0; lr < 2; ++lr) {
-            int dir = 2 * coord + lr;
-
-            /* participating real particles from this node */
-            LOG4ESPP_DEBUG(logger, "direction " << dir << " reals");
-
-            if (lr == 0) {
-                leftBoundary[coord] = cellGrid.getInnerCellsBegin(coord);
-                rightBoundary[coord] = cellGrid.getInnerCellsBegin(coord) + cellGrid.getFrameWidth();
-            } else {
-                leftBoundary[coord] = cellGrid.getInnerCellsEnd(coord) - cellGrid.getFrameWidth();
-                rightBoundary[coord] = cellGrid.getInnerCellsEnd(coord);
-            }
-            fillCells(commCells[dir].reals, leftBoundary, rightBoundary);
-
-            /* participating ghosts from this node */
-            LOG4ESPP_DEBUG(logger, "direction " << dir << " ghosts");
-
-            if (lr == 0) {
-                leftBoundary[coord] = cellGrid.getInnerCellsEnd(coord);
-                rightBoundary[coord] = cellGrid.getInnerCellsEnd(coord) + cellGrid.getFrameWidth();
-            } else {
-                leftBoundary[coord] = cellGrid.getInnerCellsBegin(coord) - cellGrid.getFrameWidth();
-                rightBoundary[coord] = cellGrid.getInnerCellsBegin(coord);
-            }
-            fillCells(commCells[dir].ghosts, leftBoundary, rightBoundary);
-        }
+        LOG4ESPP_TRACE(logger, "add cell " << i);
+        cv.push_back(&cells[i]);
+      }
     }
   }
 
-  void DomainDecompositionAdress::
-  doGhostCommunication(bool sizesFirst, bool realToGhosts, int extradata) {
-    LOG4ESPP_DEBUG(logger, "do ghost communication " << (sizesFirst ? "with sizes " : "")
-           << (realToGhosts ? "reals to ghosts " : "ghosts to reals ") << extradata);
+  LOG4ESPP_DEBUG(logger, "expected " << total << " cells, filled with " << cv.size());
+}
 
-    /* direction loop: x, y, z.
-   Here we could in principle build in a one sided ghost
-   communication, simply by taking the lr loop only over one
-   value. */
-    for (int _coord = 0; _coord < 3; ++_coord) {
-  /* inverted processing order for ghost force communication,
-     since the corner ghosts have to be collected via several
-     nodes. We now add back the corner ghost forces first again
-     to ghost forces, which only eventually go back to the real
-     particle.
-  */
-  int coord = realToGhosts ? _coord : (2 - _coord);
-  real curCoordBoxL = getSystem()->bc->getBoxL()[coord];
+void DomainDecompositionAdress::prepareGhostCommunication() {
+  // direction loop: x, y, z
+  for (int coord = 0; coord < 3; ++coord) {
+    // boundaries of area to send
+    int leftBoundary[3], rightBoundary[3];
 
-  // lr loop: left right
-  for (int lr = 0; lr < 2; ++lr) {
-    int dir         = 2 * coord + lr;
-    int oppositeDir = 2 * coord + (1 - lr);
+    /* boundaries perpendicular directions are the same for left/right send.
+       We also send the ghost frame that we have already, so the data amount
+       increase with each cycle.
 
-    Real3D shift(0, 0, 0);
+       For a direction that was done already, i.e. is smaller than dir,
+       we take the full ghost frame, otherwise only the inner frame.  */
+    for (int offset = 1; offset <= 2; ++offset) {
+      int otherCoord = (coord + offset) % 3;
 
-    shift[coord] = nodeGrid.getBoundary(dir) * curCoordBoxL;
-
-    LOG4ESPP_DEBUG(logger, "direction " << dir);
-
-    if (nodeGrid.getGridSize(coord) == 1) {
-      LOG4ESPP_DEBUG(logger, "local communication");
-
-      // copy operation, we have to receive as many cells as we send
-      if (commCells[dir].ghosts.size() != commCells[dir].reals.size()) {
-        throw std::runtime_error("DomainDecompositionAdress::doGhostCommunication: send/recv cell structure mismatch during local copy");
-      }
-
-      for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
-        if (realToGhosts) {
-          copyRealsToGhosts(*commCells[dir].reals[i], *commCells[dir].ghosts[i], extradata, shift);
-        } else {
-          addGhostForcesToReals(*commCells[dir].ghosts[i], *commCells[dir].reals[i]);
-        }
-      }
-    }
-    else {
-      // exchange size information, if necessary
-      if (sizesFirst) {
-        LOG4ESPP_DEBUG(logger, "exchanging ghost cell sizes");
-
-        // prepare buffers
-        std::vector<longint> sendSizes, recvSizes;
-        sendSizes.reserve(commCells[dir].reals.size());
-        for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
-          sendSizes.push_back(commCells[dir].reals[i]->particles.size());
-        }
-        recvSizes.resize(commCells[dir].ghosts.size());
-
-        // exchange sizes, odd-even rule
-        if (nodeGrid.getNodePosition(coord) % 2 == 0) {
-          LOG4ESPP_DEBUG(logger, "sending to node " << nodeGrid.getNodeNeighborIndex(dir)
-                     << ", then receiving from node " << nodeGrid.getNodeNeighborIndex(oppositeDir));
-          getSystem()->comm->send(nodeGrid.getNodeNeighborIndex(dir), DD_COMM_TAG, &(sendSizes[0]), sendSizes.size());
-          getSystem()->comm->recv(nodeGrid.getNodeNeighborIndex(oppositeDir), DD_COMM_TAG, &(recvSizes[0]), recvSizes.size());
-        }
-        else {
-          LOG4ESPP_DEBUG(logger, "receiving from node " << nodeGrid.getNodeNeighborIndex(oppositeDir)
-                     << ", then sending to node " << nodeGrid.getNodeNeighborIndex(dir));
-          getSystem()->comm->recv(nodeGrid.getNodeNeighborIndex(oppositeDir), DD_COMM_TAG, &(recvSizes[0]), recvSizes.size());
-          getSystem()->comm->send(nodeGrid.getNodeNeighborIndex(dir), DD_COMM_TAG, &(sendSizes[0]), sendSizes.size());
-        }
-
-        // resize according to received information
-        for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
-          commCells[dir].ghosts[i]->particles.resize(recvSizes[i]);
-        }
-        LOG4ESPP_DEBUG(logger, "exchanging ghost cell sizes done");
-      }
-
-      // prepare send and receive buffers
-      longint receiver, sender;
-      outBuffer.reset();
-      if (realToGhosts) {
-        receiver = nodeGrid.getNodeNeighborIndex(dir);
-        sender = nodeGrid.getNodeNeighborIndex(oppositeDir);
-        for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
-          packPositionsEtc(outBuffer, *commCells[dir].reals[i], extradata, shift);
-        }
-      }
-      else {
-        receiver = nodeGrid.getNodeNeighborIndex(oppositeDir);
-        sender = nodeGrid.getNodeNeighborIndex(dir);
-        for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
-          packForces(outBuffer, *commCells[dir].ghosts[i]);
-        }
-      }
-
-      // exchange particles, odd-even rule
-      if (nodeGrid.getNodePosition(coord) % 2 == 0) {
-        outBuffer.send(receiver, DD_COMM_TAG);
-        inBuffer.recv(sender, DD_COMM_TAG);
+      if (otherCoord < coord) {
+        leftBoundary[otherCoord] = 0;
+        rightBoundary[otherCoord] = cellGrid.getFrameGridSize(otherCoord);
       } else {
-        inBuffer.recv(sender, DD_COMM_TAG);
-        outBuffer.send(receiver, DD_COMM_TAG);
-      }
-
-      // unpack received data
-      if (realToGhosts) {
-        for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
-          unpackPositionsEtc(*commCells[dir].ghosts[i], inBuffer, extradata);
-        }
-      }
-      else {
-        for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
-          unpackAndAddForces(*commCells[dir].reals[i], inBuffer);
-        }
+        leftBoundary[otherCoord] = cellGrid.getInnerCellsBegin(otherCoord);
+        rightBoundary[otherCoord] = cellGrid.getInnerCellsEnd(otherCoord);
       }
     }
-  }
+
+    //  lr loop: left right - loop
+    for (int lr = 0; lr < 2; ++lr) {
+      int dir = 2 * coord + lr;
+
+      /* participating real particles from this node */
+      LOG4ESPP_DEBUG(logger, "direction " << dir << " reals");
+
+      if (lr == 0) {
+        leftBoundary[coord] = cellGrid.getInnerCellsBegin(coord);
+        rightBoundary[coord] = cellGrid.getInnerCellsBegin(coord) + cellGrid.getFrameWidth();
+      } else {
+        leftBoundary[coord] = cellGrid.getInnerCellsEnd(coord) - cellGrid.getFrameWidth();
+        rightBoundary[coord] = cellGrid.getInnerCellsEnd(coord);
+      }
+
+      fillCells(commCells[dir].reals, leftBoundary, rightBoundary);
+
+      /* participating ghosts from this node */
+      LOG4ESPP_DEBUG(logger, "direction " << dir << " ghosts");
+
+      if (lr == 0) {
+        leftBoundary[coord] = cellGrid.getInnerCellsEnd(coord);
+        rightBoundary[coord] = cellGrid.getInnerCellsEnd(coord) + cellGrid.getFrameWidth();
+      } else {
+        leftBoundary[coord] = cellGrid.getInnerCellsBegin(coord) - cellGrid.getFrameWidth();
+        rightBoundary[coord] = cellGrid.getInnerCellsBegin(coord);
+      }
+
+      fillCells(commCells[dir].ghosts, leftBoundary, rightBoundary);
     }
-    LOG4ESPP_DEBUG(logger, "ghost communication finished");
-  }
-
-
-
-  class PyDomainDecompositionAdress : public DomainDecompositionAdress {
-      public:
-        PyDomainDecompositionAdress(shared_ptr< System > _system,
-                  const Int3D& _nodeGrid,
-                  const Int3D& _cellGrid)
-      : DomainDecompositionAdress(_system, _nodeGrid, _cellGrid)
-        {}
-      };
-
-
-
-  //////////////////////////////////////////////////
-  // REGISTRATION WITH PYTHON
-  //////////////////////////////////////////////////
-  void DomainDecompositionAdress::registerPython() {
-
-    using namespace espressopp::python;
-    class_< PyDomainDecompositionAdress, bases< Storage >, boost::noncopyable >
-  ("storage_DomainDecompositionAdress",
-   init< shared_ptr< System >,
-   const Int3D&, const Int3D& >())
-  .def("mapPositionToNodeClipped", &DomainDecompositionAdress::mapPositionToNodeClipped)
-  .def("getCellGrid", &DomainDecompositionAdress::getInt3DCellGrid)
-  .def("cellAdjust", &DomainDecompositionAdress::cellAdjust)
-  ;
-  }
-
-
-
- 
-
   }
 }
+
+void DomainDecompositionAdress::doGhostCommunication(bool sizesFirst, bool realToGhosts, int
+    extradata) {
+  LOG4ESPP_DEBUG(logger, "do ghost communication " << (sizesFirst ? "with sizes " : "")
+                                                   << (realToGhosts ? "reals to ghosts " :
+          "ghosts to reals ") << extradata);
+
+  /* direction loop: x, y, z.
+     Here we could in principle build in a one sided ghost
+     communication, simply by taking the lr loop only over one
+     value. */
+  for (int _coord = 0; _coord < 3; ++_coord) {
+    /* inverted processing order for ghost force communication,
+       since the corner ghosts have to be collected via several
+       nodes. We now add back the corner ghost forces first again
+       to ghost forces, which only eventually go back to the real
+       particle.
+     */
+    int coord = realToGhosts ? _coord : (2 - _coord);
+    real curCoordBoxL = getSystem()->bc->getBoxL()[coord];
+
+    // lr loop: left right
+    for (int lr = 0; lr < 2; ++lr) {
+      int dir         = 2 * coord + lr;
+      int oppositeDir = 2 * coord + (1 - lr);
+
+      Real3D shift(0, 0, 0);
+
+      shift[coord] = nodeGrid.getBoundary(dir) * curCoordBoxL;
+
+      LOG4ESPP_DEBUG(logger, "direction " << dir);
+
+      if (nodeGrid.getGridSize(coord) == 1) {
+        LOG4ESPP_DEBUG(logger, "local communication");
+
+        // copy operation, we have to receive as many cells as we send
+        if (commCells[dir].ghosts.size() != commCells[dir].reals.size()) {
+          throw std::runtime_error(
+            "DomainDecompositionAdress::doGhostCommunication: send/recv cell structure mismatch during local copy");
+        }
+
+        for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
+          if (realToGhosts) {
+            copyRealsToGhosts(*commCells[dir].reals[i], *commCells[dir].ghosts[i], extradata,
+                shift);
+          } else {
+            addGhostForcesToReals(*commCells[dir].ghosts[i], *commCells[dir].reals[i]);
+          }
+        }
+      } else {
+        // exchange size information, if necessary
+        if (sizesFirst) {
+          LOG4ESPP_DEBUG(logger, "exchanging ghost cell sizes");
+
+          // prepare buffers
+          std::vector<longint> sendSizes, recvSizes;
+
+          sendSizes.reserve(commCells[dir].reals.size());
+
+          for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
+            sendSizes.push_back(commCells[dir].reals[i]->particles.size());
+          }
+
+          recvSizes.resize(commCells[dir].ghosts.size());
+
+          // exchange sizes, odd-even rule
+          if (nodeGrid.getNodePosition(coord) % 2 == 0) {
+            LOG4ESPP_DEBUG(logger, "sending to node " << nodeGrid.getNodeNeighborIndex(dir)
+                                                      << ", then receiving from node " <<
+                    nodeGrid.getNodeNeighborIndex(oppositeDir));
+            getSystem()->comm->send(nodeGrid.getNodeNeighborIndex(dir), DD_COMM_TAG,
+                &(sendSizes[0]), sendSizes.size());
+            getSystem()->comm->recv(nodeGrid.getNodeNeighborIndex(oppositeDir), DD_COMM_TAG,
+                &(recvSizes[0]), recvSizes.size());
+          } else {
+            LOG4ESPP_DEBUG(logger, "receiving from node " << nodeGrid.getNodeNeighborIndex(
+                    oppositeDir)
+                                                          << ", then sending to node " <<
+                    nodeGrid.getNodeNeighborIndex(dir));
+            getSystem()->comm->recv(nodeGrid.getNodeNeighborIndex(oppositeDir), DD_COMM_TAG,
+                &(recvSizes[0]), recvSizes.size());
+            getSystem()->comm->send(nodeGrid.getNodeNeighborIndex(dir), DD_COMM_TAG,
+                &(sendSizes[0]), sendSizes.size());
+          }
+
+          // resize according to received information
+          for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
+            commCells[dir].ghosts[i]->particles.resize(recvSizes[i]);
+          }
+
+          LOG4ESPP_DEBUG(logger, "exchanging ghost cell sizes done");
+        }
+
+        // prepare send and receive buffers
+        longint receiver, sender;
+
+        outBuffer.reset();
+
+        if (realToGhosts) {
+          receiver = nodeGrid.getNodeNeighborIndex(dir);
+          sender = nodeGrid.getNodeNeighborIndex(oppositeDir);
+
+          for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
+            packPositionsEtc(outBuffer, *commCells[dir].reals[i], extradata, shift);
+          }
+        } else {
+          receiver = nodeGrid.getNodeNeighborIndex(oppositeDir);
+          sender = nodeGrid.getNodeNeighborIndex(dir);
+
+          for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
+            packForces(outBuffer, *commCells[dir].ghosts[i]);
+          }
+        }
+
+        // exchange particles, odd-even rule
+        if (nodeGrid.getNodePosition(coord) % 2 == 0) {
+          outBuffer.send(receiver, DD_COMM_TAG);
+          inBuffer.recv(sender, DD_COMM_TAG);
+        } else {
+          inBuffer.recv(sender, DD_COMM_TAG);
+          outBuffer.send(receiver, DD_COMM_TAG);
+        }
+
+        // unpack received data
+        if (realToGhosts) {
+          for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
+            unpackPositionsEtc(*commCells[dir].ghosts[i], inBuffer, extradata);
+          }
+        } else {
+          for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
+            unpackAndAddForces(*commCells[dir].reals[i], inBuffer);
+          }
+        }
+      }
+    }
+  }
+
+  LOG4ESPP_DEBUG(logger, "ghost communication finished");
+}
+
+class PyDomainDecompositionAdress : public DomainDecompositionAdress {
+public:
+  PyDomainDecompositionAdress(shared_ptr<System> _system,const Int3D &_nodeGrid,const
+      Int3D &_cellGrid)
+        :DomainDecompositionAdress(_system, _nodeGrid, _cellGrid)
+  { }
+};
+
+//////////////////////////////////////////////////
+// REGISTRATION WITH PYTHON
+//////////////////////////////////////////////////
+void DomainDecompositionAdress::registerPython() {
+  using namespace espressopp::python;
+  class_<PyDomainDecompositionAdress, bases<Storage>, boost::noncopyable>
+    ("storage_DomainDecompositionAdress",
+      init<shared_ptr<System>,
+      const Int3D &, const Int3D &>())
+    .def("mapPositionToNodeClipped", &DomainDecompositionAdress::mapPositionToNodeClipped)
+    .def("getCellGrid", &DomainDecompositionAdress::getInt3DCellGrid)
+    .def("cellAdjust", &DomainDecompositionAdress::cellAdjust)
+  ;
+}
+} // namespace storage
+} // namespace espressopp

--- a/src/storage/DomainDecompositionAdress.hpp
+++ b/src/storage/DomainDecompositionAdress.hpp
@@ -1,24 +1,24 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
+
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 // ESPP_CLASS
 #ifndef _STORAGE_DOMAINDECOMPOSITIONADRESS_HPP
@@ -28,158 +28,151 @@
 #include "CellGrid.hpp"
 #include "NodeGrid.hpp"
 
-
 namespace espressopp {
-  namespace storage {
-    class NodeGridMismatch2: public std::invalid_argument
-    {
-    public:
-      NodeGridMismatch2(const Int3D& gridRequested, int nodesAvailable);
-    };
+namespace storage {
+class NodeGridMismatch2 : public std::invalid_argument {
+public:
+  NodeGridMismatch2(const Int3D &gridRequested, int nodesAvailable);
+};
 
-    class DomainDecompositionAdress: public Storage {
-    public:
-      DomainDecompositionAdress(shared_ptr< System > system,
-			  const Int3D& _nodeGrid,
-			  const Int3D& _cellGrid);
+class DomainDecompositionAdress : public Storage {
+public:
+  DomainDecompositionAdress(shared_ptr<System> system,const Int3D &_nodeGrid,const
+      Int3D &_cellGrid);
 
-      virtual ~DomainDecompositionAdress() {}
-      
-      // scale the particle coordinates and cell size
-      virtual void scaleVolume(real s, bool particleCoordinates);
-      virtual void scaleVolume(Real3D s, bool particleCoordinates);
-      virtual Int3D getInt3DCellGrid();
-            
-      // it modifies the cell structure if the cell size becomes smaller then cutoff+skin
-      // as a consequence of the system resizing
-      virtual void cellAdjust();
+  virtual ~DomainDecompositionAdress() { }
 
-      virtual Cell *mapPositionToCell(const Real3D& pos);
-      virtual Cell *mapPositionToCellClipped(const Real3D& pos);
-      virtual Cell *mapPositionToCellChecked(const Real3D& pos);
+  // scale the particle coordinates and cell size
+  virtual void scaleVolume(real s, bool particleCoordinates);
+  virtual void scaleVolume(Real3D s, bool particleCoordinates);
+  virtual Int3D getInt3DCellGrid();
 
-      longint mapPositionToNodeClipped(const Real3D& pos);
+  // it modifies the cell structure if the cell size becomes smaller then cutoff+skin
+  // as a consequence of the system resizing
+  virtual void cellAdjust();
 
-      const NodeGrid &getNodeGrid() const { return nodeGrid; }
-      const CellGrid &getCellGrid() const { return cellGrid; }
+  virtual Cell *mapPositionToCell(const Real3D &pos);
+  virtual Cell *mapPositionToCellClipped(const Real3D &pos);
+  virtual Cell *mapPositionToCellChecked(const Real3D &pos);
 
-      virtual real getLocalBoxXMin() { return nodeGrid.getMyLeft(0); }
-      virtual real getLocalBoxYMin() { return nodeGrid.getMyLeft(1); }
-      virtual real getLocalBoxZMin() { return nodeGrid.getMyLeft(2); }
-      virtual real getLocalBoxXMax() { return nodeGrid.getMyRight(0); }
-      virtual real getLocalBoxYMax() { return nodeGrid.getMyRight(1); }
-      virtual real getLocalBoxZMax() { return nodeGrid.getMyRight(2); }
+  longint mapPositionToNodeClipped(const Real3D &pos);
 
-      // this overrides the Storage decompose(), for the purpose of AdResS
-      // WARNING: this may be wrong ! why isn't this function virtual ?
-      void decompose();
+  const NodeGrid &getNodeGrid() const {return nodeGrid; }
 
+  const CellGrid &getCellGrid() const {return cellGrid; }
 
+  virtual real getLocalBoxXMin() {return nodeGrid.getMyLeft(0); }
 
-      virtual void updateGhosts();
-      virtual void updateGhostsV();
-      virtual void collectGhostForces();
+  virtual real getLocalBoxYMin() {return nodeGrid.getMyLeft(1); }
 
-      static void registerPython();
+  virtual real getLocalBoxZMin() {return nodeGrid.getMyLeft(2); }
 
-    protected:
+  virtual real getLocalBoxXMax() {return nodeGrid.getMyRight(0); }
 
-      /**
-        The below 9 functions override those defined
-        in Storage, for the purpose of AdResS
-       */
+  virtual real getLocalBoxYMax() {return nodeGrid.getMyRight(1); }
 
-      // remove ghost particles from the localParticles index
-      void invalidateGhosts();
+  virtual real getLocalBoxZMax() {return nodeGrid.getMyRight(2); }
 
-      /** pack real particle data for sending. At least positions, maybe
-          shifted, and possibly additional data according to extradata.
+  // this overrides the Storage decompose(), for the purpose of AdResS
+  // WARNING: this may be wrong ! why isn't this function virtual ?
+  void decompose();
 
-          @param shift how to adjust the positions of the particles when sending
-      */
-      void packPositionsEtc(class OutBuffer& buf,
-                      Cell &reals, int extradata, const Real3D& shift);
+  virtual void updateGhosts();
+  virtual void updateGhostsV();
+  virtual void collectGhostForces();
 
-      /** unpack received data for ghosts. */
-      void unpackPositionsEtc(Cell &ghosts, class InBuffer &buf, int extradata);
+  static void registerPython();
 
-      /** copy specified data elements between a real cell and one of its ghosts
+protected:
+  /**
+     The below 9 functions override those defined
+     in Storage, for the purpose of AdResS
+   */
 
-          @param shift how to adjust the positions of the particles when sending
-      */
-      void copyRealsToGhosts(Cell &reals, Cell &ghosts,
-                       int extradata,
-                       const Real3D& shift);
+  // remove ghost particles from the localParticles index
+  void invalidateGhosts();
 
-      void copyGhostTuples(Particle& src, Particle& dst, int extradata, const Real3D& shift);
+  /** pack real particle data for sending. At least positions, maybe
+      shifted, and possibly additional data according to extradata.
 
-      // pack ghost forces for sending.
-      void packForces(OutBuffer& buf, Cell &ghosts);
+      @param shift how to adjust the positions of the particles when sending
+   */
+  void packPositionsEtc(class OutBuffer &buf,
+        Cell &reals, int extradata, const Real3D &shift);
 
-      // unpack received ghost forces. This one ADDS, and is most likely, what you need.
-      void unpackAndAddForces(Cell &reals, class InBuffer &buf);
+  /** unpack received data for ghosts. */
+  void unpackPositionsEtc(Cell & ghosts, class InBuffer & buf, int extradata);
 
-      void addGhostForcesToReals(Cell &ghosts, Cell &reals);
+  /** copy specified data elements between a real cell and one of its ghosts
 
-      // adds ghost forces of Adr AT particles to real Adr AT particles
-      void addAdrGhostForcesToReals(Particle& src, Particle& dst);
+      @param shift how to adjust the positions of the particles when sending
+   */
+  void copyRealsToGhosts(Cell &reals, Cell &ghosts,int extradata,const Real3D &shift);
 
+  void copyGhostTuples(Particle &src, Particle &dst, int extradata, const Real3D &shift);
 
+  // pack ghost forces for sending.
+  void packForces(OutBuffer &buf, Cell &ghosts);
 
+  // unpack received ghost forces. This one ADDS, and is most likely, what you need.
+  void unpackAndAddForces(Cell & reals, class InBuffer & buf);
 
+  void addGhostForcesToReals(Cell &ghosts, Cell &reals);
 
-      virtual bool checkIsRealParticle(longint id, const Real3D& pos);
-      virtual void decomposeRealParticles();
-      virtual void exchangeGhosts();
+  // adds ghost forces of Adr AT particles to real Adr AT particles
+  void addAdrGhostForcesToReals(Particle &src, Particle &dst);
 
-      void doGhostCommunication(bool sizesFirst,
-				bool realToGhosts,
-				const int dataElements = 0);
+  virtual bool checkIsRealParticle(longint id, const Real3D &pos);
+  virtual void decomposeRealParticles();
+  virtual void exchangeGhosts();
 
-      void prepareGhostCommunication();
+  void doGhostCommunication(bool sizesFirst,bool realToGhosts,const int dataElements = 0);
 
-      /// init global Verlet list
-      void initCellInteractions();
-      /// set the grids and allocate space accordingly
-      void createCellGrid(const Int3D& nodeGrid, const Int3D& cellGrid);
-      /// sort cells into local/ghost cell arrays
-      void markCells();
-      /// fill a list of cells with the cells from a certain region of the domain grid
-      void fillCells(std::vector<Cell *> &,
-		     const int leftBoundary[3],
-		     const int rightBoundary[3]);
+  void prepareGhostCommunication();
 
-      /** read particles from a temporary buffer into the local cell structure.
-	  The direction determines in which direction to fold the particles position.
-	  Returns true if one of the given particles did not belong to this processors
-	  domain.
-      */
-      bool appendParticles(ParticleList &, int dir);
+  /// init global Verlet list
+  void initCellInteractions();
 
-      /// spatial domain decomposition of nodes
-      NodeGrid nodeGrid;
+  /// set the grids and allocate space accordingly
+  void createCellGrid(const Int3D &nodeGrid, const Int3D &cellGrid);
 
-      /// spatial domain decomposition on node in cells
-      CellGrid cellGrid;
+  /// sort cells into local/ghost cell arrays
+  void markCells();
 
-      /// expected capacity of send/recv buffers for neighbor communication
-      size_t exchangeBufferSize;
+  /// fill a list of cells with the cells from a certain region of the domain grid
+  void fillCells(std::vector<Cell *> &,const int leftBoundary[3],const int rightBoundary[3]);
 
-      /** which cells to send and receive during one communication step.
-	  In case this is a communication with ourselves, the send-cells
-	  are transferred to the recv-cells. */
-      struct CommCells {
-          std::vector<Cell *> reals;
-          std::vector<Cell *> ghosts;
-      };
-      /** which cells to send left, right, up, down, ...
-	  For the order, see NodeGrid.
-      */
-      CommCells commCells[6];
+  /** read particles from a temporary buffer into the local cell structure.
+     The direction determines in which direction to fold the particles position.
+     Returns true if one of the given particles did not belong to this processors
+     domain.
+   */
+  bool appendParticles(ParticleList &, int dir);
 
-      static LOG4ESPP_DECL_LOGGER(logger);
-    };
+  /// spatial domain decomposition of nodes
+  NodeGrid nodeGrid;
 
-  }
+  /// spatial domain decomposition on node in cells
+  CellGrid cellGrid;
+
+  /// expected capacity of send/recv buffers for neighbor communication
+  size_t exchangeBufferSize;
+
+  /** which cells to send and receive during one communication step.
+     In case this is a communication with ourselves, the send-cells
+     are transferred to the recv-cells. */
+  struct CommCells {
+    std::vector<Cell *> reals;
+    std::vector<Cell *> ghosts;
+  };
+
+  /** which cells to send left, right, up, down, ...
+     For the order, see NodeGrid.
+   */
+  CommCells commCells[6];
+
+  static LOG4ESPP_DECL_LOGGER(logger);
+};
+}
 }
 #endif

--- a/src/storage/DomainDecompositionNonBlocking.cpp
+++ b/src/storage/DomainDecompositionNonBlocking.cpp
@@ -1,31 +1,30 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
 
+   This file is part of ESPResSo++.
 
-//#include "python.hpp"
-//#include <algorithm>
-//#include <cmath>
-//#include <sstream>
-//#include "log4espp.hpp"
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// #include "python.hpp"
+// #include <algorithm>
+// #include <cmath>
+// #include <sstream>
+// #include "log4espp.hpp"
 #include "System.hpp"
 #include "Real3D.hpp"
 #include "DomainDecomposition.hpp"
@@ -38,383 +37,418 @@
 using namespace boost;
 using namespace std;
 
-namespace espressopp { 
-  namespace storage {
+namespace espressopp {
+namespace storage {
+const int DD_COMM_TAG = 0xab;
 
+DomainDecompositionNonBlocking::DomainDecompositionNonBlocking(shared_ptr<System> _system,const
+    Int3D &_nodeGrid,const Int3D &_cellGrid)
+      :DomainDecomposition(_system, _nodeGrid, _cellGrid),
+          inBufferL(*_system->comm),
+          inBufferR(*_system->comm),
+          outBufferL(*_system->comm),
+          outBufferR(*_system->comm),
+          inBufferG(*_system->comm),
+          outBufferG(*_system->comm) { }
 
-  const int DD_COMM_TAG = 0xab;
+void DomainDecompositionNonBlocking::decomposeRealParticles() {
+  // std::cout << getSystem()->comm->rank() << ": " << " decomposeRealParticles\n";
 
-  DomainDecompositionNonBlocking::
-  DomainDecompositionNonBlocking(shared_ptr< System > _system,
-          const Int3D& _nodeGrid,
-          const Int3D& _cellGrid)
-    : DomainDecomposition(_system, _nodeGrid, _cellGrid),
-      inBufferL(*_system->comm),
-      inBufferR(*_system->comm),
-      outBufferL(*_system->comm),
-      outBufferR(*_system->comm),
-      inBufferG(*_system->comm),
-      outBufferG(*_system->comm) {}
+  LOG4ESPP_DEBUG(logger, "starting, expected comm buffer size " << exchangeBufferSize);
 
-  void DomainDecompositionNonBlocking::decomposeRealParticles() {
+  // allocate send/recv buffers. We use the size as we need maximally so far, to avoid reallocation
+  // TODO: This might be a problem when all particles are created on a single node initially!
+  ParticleList sendBufL;
 
-    //std::cout << getSystem()->comm->rank() << ": " << " decomposeRealParticles\n";
+  sendBufL.reserve(exchangeBufferSize);
 
-    LOG4ESPP_DEBUG(logger, "starting, expected comm buffer size " << exchangeBufferSize);
+  ParticleList sendBufR;
 
-    // allocate send/recv buffers. We use the size as we need maximally so far, to avoid reallocation
-    // TODO: This might be a problem when all particles are created on a single node initially!
-    ParticleList sendBufL;
-    sendBufL.reserve(exchangeBufferSize);
-    ParticleList sendBufR;
-    sendBufR.reserve(exchangeBufferSize);
-    ParticleList recvBufL;
-    recvBufL.reserve(exchangeBufferSize);
-    ParticleList recvBufR;
-    recvBufR.reserve(exchangeBufferSize);
+  sendBufR.reserve(exchangeBufferSize);
 
-    bool allFinished;
-    do {
-      bool finished = true;
+  ParticleList recvBufL;
 
-      for (int coord = 0; coord < 3; ++coord) {
-        LOG4ESPP_DEBUG(logger, "starting with direction " << coord);
+  recvBufL.reserve(exchangeBufferSize);
 
-        if (nodeGrid.getGridSize(coord) > 1) {
-          for (std::vector<Cell*>::iterator it = realCells.begin(),
+  ParticleList recvBufR;
+
+  recvBufR.reserve(exchangeBufferSize);
+
+  bool allFinished;
+
+  do {
+    bool finished = true;
+
+    for (int coord = 0; coord < 3; ++coord) {
+      LOG4ESPP_DEBUG(logger, "starting with direction " << coord);
+
+      if (nodeGrid.getGridSize(coord) > 1) {
+        for (std::vector<Cell *>::iterator it = realCells.begin(),
             end = realCells.end(); it != end; ++it) {
+          Cell &cell = **it;
 
-            Cell &cell = **it;
+          // do not use an iterator here, since we need to take out particles during the loop
+          for (size_t p = 0; p < cell.particles.size(); ++p) {
+            Particle &part = cell.particles[p];
+            const Real3D &pos = part.position();
 
-            // do not use an iterator here, since we need to take out particles during the loop
-            for (size_t p = 0; p < cell.particles.size(); ++p) {
-              Particle &part = cell.particles[p];
-              const Real3D& pos = part.position();
+            // check whether the particle is now "left" of the local domain
+            if (pos[coord] - cellGrid.getMyLeft(coord) < -ROUND_ERROR_PREC) {
+              LOG4ESPP_TRACE(logger, "send particle left " << part.id());
+              moveIndexedParticle(sendBufL, cell.particles, p);
 
-              // check whether the particle is now "left" of the local domain
-              if (pos[coord] - cellGrid.getMyLeft(coord) < -ROUND_ERROR_PREC) {
-                LOG4ESPP_TRACE(logger, "send particle left " << part.id());
-                moveIndexedParticle(sendBufL, cell.particles, p);
-                // redo same particle since we took one out here, so it's a new one
-                --p;
-              }
-              // check whether the particle is now "right" of the local domain
-              else if (pos[coord] - cellGrid.getMyRight(coord) >= ROUND_ERROR_PREC) {
-                LOG4ESPP_TRACE(logger, "send particle right " << part.id());
-                moveIndexedParticle(sendBufR, cell.particles, p);
-                --p;
-              }
-              // Sort particles in cells of this node during last direction
-              else if (coord == 2) {
-                const Real3D& pos = part.position();
-                Cell *sortCell = mapPositionToCellChecked(pos);
-                if (sortCell != &cell) {
-                  if (sortCell == 0) {
-                    // particle is not in the local domain
-                    LOG4ESPP_DEBUG(logger, "take another loop: particle " << part.id()
-                            << " @ " << pos <<
-                            " is not inside node domain after neighbor exchange");
-                    // isnan function is C99 only, x != x is only true if x == nan
-                    if (pos[0] != pos[0] || pos[1] != pos[1] || pos[2] != pos[2]) {
-                      // TODO: error handling
-                      LOG4ESPP_ERROR(logger, "particle " << part.id() <<
-                              " has moved to outer space (one or more coordinates are nan)");
-                    } else {
-                      // particle stays where it is, and will be sorted in the next round
-                      finished = false;
-                    }
-                  } else {
-                    // particle is in the local domain
-                    moveIndexedParticle(sortCell->particles, cell.particles, p);
-                    --p;
-                  }
-                }
-              }
-
+              // redo same particle since we took one out here, so it's a new one
+              --p;
             }
-          }
+            // check whether the particle is now "right" of the local domain
+            else if (pos[coord] - cellGrid.getMyRight(coord) >= ROUND_ERROR_PREC) {
+              LOG4ESPP_TRACE(logger, "send particle right " << part.id());
+              moveIndexedParticle(sendBufR, cell.particles, p);
+              --p;
+            }
+            // Sort particles in cells of this node during last direction
+            else if (coord == 2) {
+              const Real3D &pos = part.position();
+              Cell *sortCell = mapPositionToCellChecked(pos);
 
-          mpi::request reqs[4];
+              if (sortCell != &cell) {
+                if (sortCell == 0) {
+                  // particle is not in the local domain
+                  LOG4ESPP_DEBUG(logger, "take another loop: particle " << part.id()
+                                                                        << " @ " << pos <<
+                          " is not inside node domain after neighbor exchange");
 
-          // Exchange particles, odd-even rule
-          if (nodeGrid.getNodePosition(coord) % 2 == 0) {
-            reqs[0]=isendParticles(outBufferL, sendBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
-            reqs[1]=irecvParticles_initiate(  inBufferR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
-            reqs[2]=isendParticles(outBufferR, sendBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
-            reqs[3]=irecvParticles_initiate(  inBufferL, nodeGrid.getNodeNeighborIndex(2 * coord));
-          } else {
-            reqs[0]=irecvParticles_initiate(  inBufferR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
-        	reqs[1]=isendParticles(outBufferL, sendBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
-        	reqs[2]=irecvParticles_initiate(  inBufferL, nodeGrid.getNodeNeighborIndex(2 * coord));
-        	reqs[3]=isendParticles(outBufferR, sendBufR, nodeGrid.getNodeNeighborIndex(2 * coord + 1));
-          }
-
-          mpi::wait_all(reqs, reqs + 4);
-
-          if (nodeGrid.getNodePosition(coord) % 2 == 0) {
-            irecvParticles_finish( inBufferR, recvBufR);
-            irecvParticles_finish( inBufferL, recvBufL);
-          } else {
-            irecvParticles_finish( inBufferR, recvBufR);
-        	irecvParticles_finish( inBufferL, recvBufL);
-          }
-
-          // sort received particles to cells
-          if (appendParticles(recvBufL, 2 * coord) && coord == 2) finished = false;
-          if (appendParticles(recvBufR, 2 * coord + 1) && coord == 2) finished = false;
-
-          // reset send/recv buffers
-          sendBufL.resize(0);
-          sendBufR.resize(0);
-          recvBufL.resize(0);
-          recvBufR.resize(0);
-
-
-        } else {
-          /* Single node direction case (no communication)
-            Fold particles that have left the box */
-          for (std::vector< Cell* >::iterator it = realCells.begin(),
-            end = realCells.end(); it != end; ++it) {
-            Cell &cell = **it;
-            // do not use an iterator here, since we have need to take out particles during the loop
-            for (size_t p = 0; p < cell.particles.size(); ++p) {
-                Particle &part = cell.particles[p];
-                getSystem()->bc->foldCoordinate(part.position(), part.image(), coord);
-                LOG4ESPP_TRACE(logger, "folded coordinate " << coord << " of particle " << part.id());
-
-                if (coord == 2) {
-                    Cell *sortCell = mapPositionToCellChecked(part.position());
-
-                    if (sortCell != &cell) {
-                        if (sortCell == 0) {
-                            LOG4ESPP_DEBUG(logger, "take another loop: particle " << part.id()
-                                    << " @ " << part.position()
-                                    << " is not inside node domain after neighbor exchange");
-                            const Real3D& pos = part.position();
-                            // isnan function is C99 only, x != x is only true if x == nan
-                            if (pos[0] != pos[0] || pos[1] != pos[1] || pos[2] != pos[2]) {
-                                LOG4ESPP_ERROR(logger, "particle " << part.id() <<
-                                        " has moved to outer space (one or more coordinates are nan)");
-                            } else {
-                                // particle stays where it is, and will be sorted in the next round
-                                finished = false;
-                            }
-                        } else {
-                            moveIndexedParticle(sortCell->particles, cell.particles, p);
-                            --p;
-                        }
-                    }
+                  // isnan function is C99 only, x != x is only true if x == nan
+                  if ((pos[0] != pos[0]) || (pos[1] != pos[1]) || (pos[2] != pos[2])) {
+                    // TODO: error handling
+                    LOG4ESPP_ERROR(logger, "particle " << part.id() <<
+                            " has moved to outer space (one or more coordinates are nan)");
+                  } else {
+                    // particle stays where it is, and will be sorted in the next round
+                    finished = false;
+                  }
+                } else {
+                  // particle is in the local domain
+                  moveIndexedParticle(sortCell->particles, cell.particles, p);
+                  --p;
                 }
+              }
             }
           }
         }
 
-        LOG4ESPP_DEBUG(logger, "done with direction " << coord);
+        mpi::request reqs[4];
+
+        // Exchange particles, odd-even rule
+        if (nodeGrid.getNodePosition(coord) % 2 == 0) {
+          reqs[0] = isendParticles(outBufferL, sendBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
+          reqs[1] = irecvParticles_initiate(inBufferR, nodeGrid.getNodeNeighborIndex(2 * coord +
+            1));
+          reqs[2] = isendParticles(outBufferR, sendBufR, nodeGrid.getNodeNeighborIndex(2 * coord +
+            1));
+          reqs[3] = irecvParticles_initiate(inBufferL, nodeGrid.getNodeNeighborIndex(2 * coord));
+        } else {
+          reqs[0] = irecvParticles_initiate(inBufferR, nodeGrid.getNodeNeighborIndex(2 * coord +
+            1));
+          reqs[1] = isendParticles(outBufferL, sendBufL, nodeGrid.getNodeNeighborIndex(2 * coord));
+          reqs[2] = irecvParticles_initiate(inBufferL, nodeGrid.getNodeNeighborIndex(2 * coord));
+          reqs[3] = isendParticles(outBufferR, sendBufR, nodeGrid.getNodeNeighborIndex(2 * coord +
+            1));
+        }
+
+        mpi::wait_all(reqs, reqs + 4);
+
+        if (nodeGrid.getNodePosition(coord) % 2 == 0) {
+          irecvParticles_finish(inBufferR, recvBufR);
+          irecvParticles_finish(inBufferL, recvBufL);
+        } else {
+          irecvParticles_finish(inBufferR, recvBufR);
+          irecvParticles_finish(inBufferL, recvBufL);
+        }
+
+        // sort received particles to cells
+        if (appendParticles(recvBufL, 2 * coord) && (coord == 2)) finished = false;
+
+        if (appendParticles(recvBufR, 2 * coord + 1) && (coord == 2)) finished = false;
+
+        // reset send/recv buffers
+        sendBufL.resize(0);
+        sendBufR.resize(0);
+        recvBufL.resize(0);
+        recvBufR.resize(0);
+      } else {
+        /* Single node direction case (no communication)
+           Fold particles that have left the box */
+        for (std::vector<Cell *>::iterator it = realCells.begin(),
+            end = realCells.end(); it != end; ++it) {
+          Cell &cell = **it;
+
+          // do not use an iterator here, since we have need to take out particles during the loop
+          for (size_t p = 0; p < cell.particles.size(); ++p) {
+            Particle &part = cell.particles[p];
+
+            getSystem()->bc->foldCoordinate(part.position(), part.image(), coord);
+            LOG4ESPP_TRACE(logger, "folded coordinate " << coord << " of particle " << part.id());
+
+            if (coord == 2) {
+              Cell *sortCell = mapPositionToCellChecked(part.position());
+
+              if (sortCell != &cell) {
+                if (sortCell == 0) {
+                  LOG4ESPP_DEBUG(logger, "take another loop: particle " << part.id()
+                                                                        << " @ " << part.position()
+                                                                        <<
+                          " is not inside node domain after neighbor exchange");
+
+                  const Real3D &pos = part.position();
+
+                  // isnan function is C99 only, x != x is only true if x == nan
+                  if ((pos[0] != pos[0]) || (pos[1] != pos[1]) || (pos[2] != pos[2])) {
+                    LOG4ESPP_ERROR(logger, "particle " << part.id() <<
+                            " has moved to outer space (one or more coordinates are nan)");
+                  } else {
+                    // particle stays where it is, and will be sorted in the next round
+                    finished = false;
+                  }
+                } else {
+                  moveIndexedParticle(sortCell->particles, cell.particles, p);
+                  --p;
+                }
+              }
+            }
+          }
+        }
       }
 
-      // Communicate wether particle exchange is finished
-      mpi::all_reduce(*getSystem()->comm, finished, allFinished, std::logical_and<bool>());
-    } while (!allFinished);
+      LOG4ESPP_DEBUG(logger, "done with direction " << coord);
+    }
 
-    exchangeBufferSize = std::max(exchangeBufferSize,
-                  std::max(sendBufL.capacity(),
-                       std::max(sendBufR.capacity(),
-                            std::max(recvBufL.capacity(),
-                                 recvBufR.capacity()))));
+    // Communicate wether particle exchange is finished
+    mpi::all_reduce(*getSystem()->comm, finished, allFinished, std::logical_and<bool>());
+  } while (!allFinished);
 
-    LOG4ESPP_DEBUG(logger, "finished exchanging particles, new send/recv buffer size " << exchangeBufferSize);
+  exchangeBufferSize = std::max(exchangeBufferSize,
+    std::max(sendBufL.capacity(),
+    std::max(sendBufR.capacity(),
+    std::max(recvBufL.capacity(),
+    recvBufR.capacity()))));
 
-    LOG4ESPP_DEBUG(logger, "done");
-  }
+  LOG4ESPP_DEBUG(logger, "finished exchanging particles, new send/recv buffer size " <<
+          exchangeBufferSize);
 
-  void DomainDecompositionNonBlocking::
-  doGhostCommunication(bool sizesFirst, bool realToGhosts, int extradata) {
-    LOG4ESPP_DEBUG(logger, "do ghost communication " << (sizesFirst ? "with sizes " : "")
-           << (realToGhosts ? "reals to ghosts " : "ghosts to reals ") << extradata);
+  LOG4ESPP_DEBUG(logger, "done");
+}
 
-    /* direction loop: x, y, z.
-   Here we could in principle build in a one sided ghost
-   communication, simply by taking the lr loop only over one
-   value. */
-    for (int _coord = 0; _coord < 3; ++_coord) {
-      /* inverted processing order for ghost force communication,
-        since the corner ghosts have to be collected via several
-        nodes. We now add back the corner ghost forces first again
-        to ghost forces, which only eventually go back to the real
-        particle.
-      */
-      int coord = realToGhosts ? _coord : (2 - _coord);
-      real curCoordBoxL = getSystem()->bc->getBoxL()[coord];
+void DomainDecompositionNonBlocking::doGhostCommunication(bool sizesFirst, bool realToGhosts, int
+    extradata) {
+  LOG4ESPP_DEBUG(logger, "do ghost communication " << (sizesFirst ? "with sizes " : "")
+                                                   << (realToGhosts ? "reals to ghosts " :
+          "ghosts to reals ") << extradata);
 
-      // lr loop: left right
-      for (int lr = 0; lr < 2; ++lr) {
-        int dir         = 2 * coord + lr;
-        int oppositeDir = 2 * coord + (1 - lr);
+  /* direction loop: x, y, z.
+     Here we could in principle build in a one sided ghost
+     communication, simply by taking the lr loop only over one
+     value. */
+  for (int _coord = 0; _coord < 3; ++_coord) {
+    /* inverted processing order for ghost force communication,
+       since the corner ghosts have to be collected via several
+       nodes. We now add back the corner ghost forces first again
+       to ghost forces, which only eventually go back to the real
+       particle.
+     */
+    int coord = realToGhosts ? _coord : (2 - _coord);
+    real curCoordBoxL = getSystem()->bc->getBoxL()[coord];
 
-        Real3D shift(0, 0, 0);
+    // lr loop: left right
+    for (int lr = 0; lr < 2; ++lr) {
+      int dir         = 2 * coord + lr;
+      int oppositeDir = 2 * coord + (1 - lr);
 
-        shift[coord] = nodeGrid.getBoundary(dir) * curCoordBoxL;
+      Real3D shift(0, 0, 0);
 
-        LOG4ESPP_DEBUG(logger, "direction " << dir);
+      shift[coord] = nodeGrid.getBoundary(dir) * curCoordBoxL;
 
-        if (nodeGrid.getGridSize(coord) == 1) {
-          LOG4ESPP_DEBUG(logger, "local communication");
+      LOG4ESPP_DEBUG(logger, "direction " << dir);
 
-          // copy operation, we have to receive as many cells as we send
-          if (commCells[dir].ghosts.size() != commCells[dir].reals.size()) {
-            throw std::runtime_error("DomainDecomposition::doGhostCommunication: send/recv cell structure mismatch during local copy");
-          }
+      if (nodeGrid.getGridSize(coord) == 1) {
+        LOG4ESPP_DEBUG(logger, "local communication");
 
-          for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
-            if (realToGhosts) {
-              copyRealsToGhosts(*commCells[dir].reals[i], *commCells[dir].ghosts[i], extradata, shift);
-            } else {
-              addGhostForcesToReals(*commCells[dir].ghosts[i], *commCells[dir].reals[i]);
-            }
+        // copy operation, we have to receive as many cells as we send
+        if (commCells[dir].ghosts.size() != commCells[dir].reals.size()) {
+          throw std::runtime_error(
+            "DomainDecomposition::doGhostCommunication: send/recv cell structure mismatch during local copy");
+        }
+
+        for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
+          if (realToGhosts) {
+            copyRealsToGhosts(*commCells[dir].reals[i], *commCells[dir].ghosts[i], extradata,
+                shift);
+          } else {
+            addGhostForcesToReals(*commCells[dir].ghosts[i], *commCells[dir].reals[i]);
           }
         }
-        else {
-          // exchange size information, if necessary
-          if (sizesFirst) {
-            LOG4ESPP_DEBUG(logger, "exchanging ghost cell sizes");
+      } else {
+        // exchange size information, if necessary
+        if (sizesFirst) {
+          LOG4ESPP_DEBUG(logger, "exchanging ghost cell sizes");
 
-            // prepare buffers
-            std::vector<longint> sendSizes, recvSizes;
-            sendSizes.reserve(commCells[dir].reals.size());
-            for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
-              sendSizes.push_back(commCells[dir].reals[i]->particles.size());
-            }
-            recvSizes.resize(commCells[dir].ghosts.size());
+          // prepare buffers
+          std::vector<longint> sendSizes, recvSizes;
 
-            mpi::request reqs[2];
+          sendSizes.reserve(commCells[dir].reals.size());
 
-            // exchange sizes, odd-even rule
-            if (nodeGrid.getNodePosition(coord) % 2 == 0) {
-              LOG4ESPP_DEBUG(logger, "sending to node " << nodeGrid.getNodeNeighborIndex(dir)
-                        << ", then receiving from node " << nodeGrid.getNodeNeighborIndex(oppositeDir));
-              reqs[0]=getSystem()->comm->isend(nodeGrid.getNodeNeighborIndex(dir), DD_COMM_TAG, &(sendSizes[0]), sendSizes.size());
-              reqs[1]=getSystem()->comm->irecv(nodeGrid.getNodeNeighborIndex(oppositeDir), DD_COMM_TAG, &(recvSizes[0]), recvSizes.size());
-            }
-            else {
-              LOG4ESPP_DEBUG(logger, "receiving from node " << nodeGrid.getNodeNeighborIndex(oppositeDir)
-                        << ", then sending to node " << nodeGrid.getNodeNeighborIndex(dir));
-              reqs[0]=getSystem()->comm->irecv(nodeGrid.getNodeNeighborIndex(oppositeDir), DD_COMM_TAG, &(recvSizes[0]), recvSizes.size());
-              reqs[1]=getSystem()->comm->isend(nodeGrid.getNodeNeighborIndex(dir), DD_COMM_TAG, &(sendSizes[0]), sendSizes.size());
-            }
-
-            mpi::wait_all(reqs, reqs + 2);
-
-            // resize according to received information
-            for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
-              commCells[dir].ghosts[i]->particles.resize(recvSizes[i]);
-            }
-            LOG4ESPP_DEBUG(logger, "exchanging ghost cell sizes done");
+          for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
+            sendSizes.push_back(commCells[dir].reals[i]->particles.size());
           }
 
-          // prepare send and receive buffers
-          longint receiver, sender;
-          outBufferG.reset();
-          if (realToGhosts) {
-            receiver = nodeGrid.getNodeNeighborIndex(dir);
-            sender = nodeGrid.getNodeNeighborIndex(oppositeDir);
-            for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
-              packPositionsEtc(outBufferG, *commCells[dir].reals[i], extradata, shift);
-            }
-          }
-          else {
-            receiver = nodeGrid.getNodeNeighborIndex(oppositeDir);
-            sender = nodeGrid.getNodeNeighborIndex(dir);
-            for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
-              packForces(outBufferG, *commCells[dir].ghosts[i]);
-            }
-          }
+          recvSizes.resize(commCells[dir].ghosts.size());
 
           mpi::request reqs[2];
 
-          // exchange particles, odd-even rule
+          // exchange sizes, odd-even rule
           if (nodeGrid.getNodePosition(coord) % 2 == 0) {
-            reqs[0]=outBufferG.isend(receiver, DD_COMM_TAG);
-            reqs[1]=inBufferG.irecv(sender, DD_COMM_TAG);
+            LOG4ESPP_DEBUG(logger, "sending to node " << nodeGrid.getNodeNeighborIndex(dir)
+                                                      << ", then receiving from node " <<
+                    nodeGrid.getNodeNeighborIndex(oppositeDir));
+            reqs[0] = getSystem()->comm->isend(nodeGrid.getNodeNeighborIndex(dir), DD_COMM_TAG,
+              &(sendSizes[0]), sendSizes.size());
+            reqs[1] = getSystem()->comm->irecv(nodeGrid.getNodeNeighborIndex(oppositeDir),
+              DD_COMM_TAG, &(recvSizes[0]), recvSizes.size());
           } else {
-            reqs[0]=inBufferG.irecv(sender, DD_COMM_TAG);
-            reqs[1]=outBufferG.isend(receiver, DD_COMM_TAG);
+            LOG4ESPP_DEBUG(logger, "receiving from node " << nodeGrid.getNodeNeighborIndex(
+                    oppositeDir)
+                                                          << ", then sending to node " <<
+                    nodeGrid.getNodeNeighborIndex(dir));
+            reqs[0] = getSystem()->comm->irecv(nodeGrid.getNodeNeighborIndex(oppositeDir),
+              DD_COMM_TAG, &(recvSizes[0]), recvSizes.size());
+            reqs[1] = getSystem()->comm->isend(nodeGrid.getNodeNeighborIndex(dir), DD_COMM_TAG,
+              &(sendSizes[0]), sendSizes.size());
           }
 
           mpi::wait_all(reqs, reqs + 2);
 
-          // unpack received data
-          if (realToGhosts) {
-            for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
-              unpackPositionsEtc(*commCells[dir].ghosts[i], inBufferG, extradata);
-            }
+          // resize according to received information
+          for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
+            commCells[dir].ghosts[i]->particles.resize(recvSizes[i]);
           }
-          else {
-            for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
-              unpackAndAddForces(*commCells[dir].reals[i], inBufferG);
-            }
+
+          LOG4ESPP_DEBUG(logger, "exchanging ghost cell sizes done");
+        }
+
+        // prepare send and receive buffers
+        longint receiver, sender;
+
+        outBufferG.reset();
+
+        if (realToGhosts) {
+          receiver = nodeGrid.getNodeNeighborIndex(dir);
+          sender = nodeGrid.getNodeNeighborIndex(oppositeDir);
+
+          for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
+            packPositionsEtc(outBufferG, *commCells[dir].reals[i], extradata, shift);
+          }
+        } else {
+          receiver = nodeGrid.getNodeNeighborIndex(oppositeDir);
+          sender = nodeGrid.getNodeNeighborIndex(dir);
+
+          for (int i = 0, end = commCells[dir].ghosts.size(); i < end; ++i) {
+            packForces(outBufferG, *commCells[dir].ghosts[i]);
+          }
+        }
+
+        mpi::request reqs[2];
+
+        // exchange particles, odd-even rule
+        if (nodeGrid.getNodePosition(coord) % 2 == 0) {
+          reqs[0] = outBufferG.isend(receiver, DD_COMM_TAG);
+          reqs[1] = inBufferG.irecv(sender, DD_COMM_TAG);
+        } else {
+          reqs[0] = inBufferG.irecv(sender, DD_COMM_TAG);
+          reqs[1] = outBufferG.isend(receiver, DD_COMM_TAG);
+        }
+
+        mpi::wait_all(reqs, reqs + 2);
+
+        // unpack received data
+        if (realToGhosts) {
+          for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
+            unpackPositionsEtc(*commCells[dir].ghosts[i], inBufferG, extradata);
+          }
+        } else {
+          for (int i = 0, end = commCells[dir].reals.size(); i < end; ++i) {
+            unpackAndAddForces(*commCells[dir].reals[i], inBufferG);
           }
         }
       }
     }
-    LOG4ESPP_DEBUG(logger, "ghost communication finished");
   }
 
-  mpi::request DomainDecompositionNonBlocking::isendParticles(OutBuffer &data, ParticleList &list, longint node)
-  {
-    LOG4ESPP_DEBUG(logger, "initiate non blocking isend " << list.size() << " particles to " << node);
-    data.reset();
-    int size = list.size();
-    data.write(size);
-    for (ParticleList::Iterator it(list); it.isValid(); ++it) {
-        removeFromLocalParticles(&(*it));
-        data.write(*it);
-    }
-    beforeSendParticles(list, data); // this also takes care of AdResS AT Particles
-    list.clear();
-
-    // ... and send
-    return data.isend(node, DD_COMM_TAG);
-  }
-
-  mpi::request DomainDecompositionNonBlocking::irecvParticles_initiate(InBuffer& data, longint node)
-  {
-    LOG4ESPP_DEBUG(logger, "initiate non blocking irecv on " << node);
-    return data.irecv(node, DD_COMM_TAG);
-  }
-
-  void DomainDecompositionNonBlocking::irecvParticles_finish(InBuffer &data, ParticleList &list)
-  {
-    LOG4ESPP_DEBUG(logger, "finish non blocking irecv");
-    // ... and unpack
-    int size;
-    data.read(size);
-    int curSize = list.size();
-    LOG4ESPP_DEBUG(logger, "got " << size << " particles, have " << curSize);
-
-    if (size > 0) {
-      list.resize(curSize + size);
-
-      for (int i = 0; i < size; ++i) {
-        Particle *p = &list[curSize + i];
-        data.read(*p);
-        updateInLocalParticles(p);
-      }
-
-      afterRecvParticles(list, data); // this also takes care of AdResS AT Particles
-    }
-    LOG4ESPP_DEBUG(logger, "done");
-  }
-
-  //////////////////////////////////////////////////
-  // REGISTRATION WITH PYTHON
-  //////////////////////////////////////////////////
-  void DomainDecompositionNonBlocking::registerPython() {
-    using namespace espressopp::python;
-    class_< DomainDecompositionNonBlocking, bases< DomainDecomposition >, boost::noncopyable >
-    ("storage_DomainDecompositionNonBlocking", init< shared_ptr< System >, const Int3D&, const Int3D& >())
-    ;
-  }
-
-
-  }
+  LOG4ESPP_DEBUG(logger, "ghost communication finished");
 }
+
+mpi::request DomainDecompositionNonBlocking::isendParticles(OutBuffer &data, ParticleList &list,
+    longint node) {
+  LOG4ESPP_DEBUG(logger, "initiate non blocking isend " << list.size() << " particles to " << node);
+  data.reset();
+
+  int size = list.size();
+
+  data.write(size);
+
+  for (ParticleList::Iterator it(list); it.isValid(); ++it) {
+    removeFromLocalParticles(&(*it));
+    data.write(*it);
+  }
+
+  beforeSendParticles(list, data);   // this also takes care of AdResS AT Particles
+  list.clear();
+
+  // ... and send
+  return data.isend(node, DD_COMM_TAG);
+}
+
+mpi::request DomainDecompositionNonBlocking::irecvParticles_initiate(InBuffer &data, longint node) {
+  LOG4ESPP_DEBUG(logger, "initiate non blocking irecv on " << node);
+  return data.irecv(node, DD_COMM_TAG);
+}
+
+void DomainDecompositionNonBlocking::irecvParticles_finish(InBuffer &data, ParticleList &list) {
+  LOG4ESPP_DEBUG(logger, "finish non blocking irecv");
+
+  // ... and unpack
+  int size;
+
+  data.read(size);
+
+  int curSize = list.size();
+
+  LOG4ESPP_DEBUG(logger, "got " << size << " particles, have " << curSize);
+
+  if (size > 0) {
+    list.resize(curSize + size);
+
+    for (int i = 0; i < size; ++i) {
+      Particle *p = &list[curSize + i];
+
+      data.read(*p);
+      updateInLocalParticles(p);
+    }
+
+    afterRecvParticles(list, data);   // this also takes care of AdResS AT Particles
+  }
+
+  LOG4ESPP_DEBUG(logger, "done");
+}
+
+//////////////////////////////////////////////////
+// REGISTRATION WITH PYTHON
+//////////////////////////////////////////////////
+void DomainDecompositionNonBlocking::registerPython() {
+  using namespace espressopp::python;
+  class_<DomainDecompositionNonBlocking, bases<DomainDecomposition>, boost::noncopyable>
+    ("storage_DomainDecompositionNonBlocking", init<shared_ptr<System>, const Int3D &, const
+      Int3D &>())
+  ;
+}
+} // namespace storage
+} // namespace espressopp

--- a/src/storage/DomainDecompositionNonBlocking.hpp
+++ b/src/storage/DomainDecompositionNonBlocking.hpp
@@ -1,54 +1,60 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
+
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 // ESPP_CLASS
 #ifndef _STORAGE_DOMAINDECOMPOSITIONNONBLOCKING_HPP
 #define _STORAGE_DOMAINDECOMPOSITIONNONBLOCKING_HPP
 #include "DomainDecomposition.hpp"
+
 // #include "types.hpp"
 
 namespace espressopp {
-  namespace storage {
-    class DomainDecompositionNonBlocking: public DomainDecomposition {
-    public:
-      DomainDecompositionNonBlocking(shared_ptr< System > system,
-              const Int3D& _nodeGrid,
-			  const Int3D& _cellGrid);
-      virtual ~DomainDecompositionNonBlocking() {}
-      static void registerPython();
-    protected:
-      virtual void decomposeRealParticles();
-      virtual void doGhostCommunication(bool sizesFirst, bool realToGhosts, const int dataElements = 0);
-      mpi::request isendParticles(OutBuffer &data, ParticleList &list, longint node);
-      mpi::request irecvParticles_initiate(InBuffer &data, longint node);
-      void irecvParticles_finish(InBuffer &data, ParticleList &list);
-    private:
-      InBuffer inBufferL;
-      InBuffer inBufferR;
-      OutBuffer outBufferL;
-      OutBuffer outBufferR;
-      InBuffer inBufferG;   // used for ghost communication
-      OutBuffer outBufferG;  // used for ghost communication
-    };
-  }
+namespace storage {
+class DomainDecompositionNonBlocking : public DomainDecomposition {
+public:
+  DomainDecompositionNonBlocking(shared_ptr<System> system,const Int3D &_nodeGrid,const
+      Int3D &_cellGrid);
+  virtual ~DomainDecompositionNonBlocking() { }
+
+  static void registerPython();
+
+protected:
+
+  virtual void decomposeRealParticles();
+  virtual void doGhostCommunication(bool sizesFirst, bool realToGhosts, const int dataElements = 0);
+  mpi::request isendParticles(OutBuffer &data, ParticleList &list, longint node);
+  mpi::request irecvParticles_initiate(InBuffer &data, longint node);
+
+  void irecvParticles_finish(InBuffer &data, ParticleList &list);
+
+private:
+
+  InBuffer inBufferL;
+  InBuffer inBufferR;
+  OutBuffer outBufferL;
+  OutBuffer outBufferR;
+  InBuffer inBufferG;       // used for ghost communication
+  OutBuffer outBufferG;      // used for ghost communication
+};
+}
 }
 #endif

--- a/src/storage/NodeGrid.cpp
+++ b/src/storage/NodeGrid.cpp
@@ -1,24 +1,24 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
+
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "log4espp.hpp"
 
@@ -27,99 +27,97 @@
 #include "NodeGrid.hpp"
 
 namespace espressopp {
-  namespace storage {
-    LOG4ESPP_LOGGER(NodeGrid::logger, "DomainDecomposition.NodeGrid");
-  
-    NodeGridIllegal::NodeGridIllegal()
-      : std::invalid_argument("node grid dimensions have to be positive") {}
-  
-    NodeGrid::
-    NodeGrid(const Int3D& grid,
-	     const longint nodeId,
-	     const Real3D& domainSize)
-      : Grid(grid)
-    {
-      if (grid[0] <= 0 || grid[1] <= 0 || grid[2] <= 0) {
-        throw NodeGridIllegal();
-      }
+namespace storage {
+LOG4ESPP_LOGGER(NodeGrid::logger, "DomainDecomposition.NodeGrid");
 
-      for(int i = 0; i < 3; ++i) {
-        localBoxSize[i] = domainSize[i]/static_cast<real>(getGridSize(i));
-        invLocalBoxSize[i] = 1.0/localBoxSize[i];
-      }
-      smallestLocalBoxDiameter = std::min(std::min(localBoxSize[0], localBoxSize[1]), localBoxSize[2]);
+NodeGridIllegal::NodeGridIllegal()
+      :std::invalid_argument("node grid dimensions have to be positive") { }
 
-      calcNodeNeighbors(nodeId);
-    }
-
-    longint NodeGrid::
-    mapPositionToNodeClipped(const Real3D& pos) const
-    {
-      Int3D cpos;
-    
-      for (int i = 0; i < 3; ++i) {
-        cpos[i] = static_cast< int >(pos[i]*invLocalBoxSize[i]);
-        if (cpos[i] < 0) {
-          cpos[i] = 0;
-        }
-        else if (cpos[i] >= getGridSize(i)) {
-          cpos[i] = getGridSize(i) - 1;
-        }
-      }
-      return mapPositionToIndex(cpos);
-    }
-
-    void NodeGrid::calcNodeNeighbors(longint node)
-    {
-      Int3D nPos;
-  
-      mapIndexToPosition(nodePos, node);
-
-      LOG4ESPP_DEBUG(logger, "my position: "
-		     << node << " -> "
-		     << nodePos[0] << " "
-		     << nodePos[1] << " "
-		     << nodePos[2]);
-
-      for(int dir = 0; dir < 3; ++dir) {
-	for(int j = 0; j < 3; ++j) {
-	  nPos[j] = nodePos[j];
-	}
-
-	// left neighbor in direction dir
-	nPos[dir] = nodePos[dir] - 1;
-	if(nPos[dir] < 0) {
-	  nPos[dir] += getGridSize(dir);
-	}
-	nodeNeighbors[2*dir] = mapPositionToIndex(nPos);
-	LOG4ESPP_DEBUG(logger, "left neighbor in dir " << dir << ": "
-		       << getNodeNeighborIndex(2*dir) << " <-> "
-		       << nPos[0] << " "
-		       << nPos[1] << " "
-		       << nPos[2]);
-
-	// right neighbor in direction dir
-	nPos[dir] = nodePos[dir] + 1;
-	if(nPos[dir] >= getGridSize(dir)) {
-	  nPos[dir] -= getGridSize(dir);
-	}
-	nodeNeighbors[2*dir + 1] = mapPositionToIndex(nPos);
-
-	LOG4ESPP_DEBUG(logger, "right neighbor in dir " << dir << ": "
-		       << getNodeNeighborIndex(2*dir+1) << " <-> "
-		       << nPos[0] << " "
-		       << nPos[1] << " "
-		       << nPos[2]);
-
-	// left or right boundary ?
-	boundaries[2*dir] = (nodePos[dir] == 0) ? ToRight : 0;
-	boundaries[2*dir + 1] = (nodePos[dir] == getGridSize(dir) - 1) ? ToLeft : 0;
-
-	LOG4ESPP_DEBUG(logger, "boundaries in dir " << dir << ": "
-		       << getBoundary(2*dir) << " "
-		       << getBoundary(2*dir + 1));
-      }
-    }
-
+NodeGrid::NodeGrid(const Int3D &grid,const longint nodeId,const Real3D &domainSize)
+      :Grid(grid) {
+  if ((grid[0] <= 0) || (grid[1] <= 0) || (grid[2] <= 0)) {
+    throw NodeGridIllegal();
   }
+
+  for (int i = 0; i < 3; ++i) {
+    localBoxSize[i] = domainSize[i] / static_cast<real>(getGridSize(i));
+    invLocalBoxSize[i] = 1.0 / localBoxSize[i];
+  }
+
+  smallestLocalBoxDiameter = std::min(std::min(localBoxSize[0], localBoxSize[1]), localBoxSize[2]);
+
+  calcNodeNeighbors(nodeId);
+}
+
+longint NodeGrid::mapPositionToNodeClipped(const Real3D &pos) const {
+  Int3D cpos;
+
+  for (int i = 0; i < 3; ++i) {
+    cpos[i] = static_cast<int>(pos[i] * invLocalBoxSize[i]);
+
+    if (cpos[i] < 0) {
+      cpos[i] = 0;
+    } else if (cpos[i] >= getGridSize(i))   {
+      cpos[i] = getGridSize(i) - 1;
+    }
+  }
+
+  return mapPositionToIndex(cpos);
+}
+
+void NodeGrid::calcNodeNeighbors(longint node) {
+  Int3D nPos;
+
+  mapIndexToPosition(nodePos, node);
+
+  LOG4ESPP_DEBUG(logger, "my position: "
+          << node << " -> "
+          << nodePos[0] << " "
+          << nodePos[1] << " "
+          << nodePos[2]);
+
+  for (int dir = 0; dir < 3; ++dir) {
+    for (int j = 0; j < 3; ++j) {
+      nPos[j] = nodePos[j];
+    }
+
+    // left neighbor in direction dir
+    nPos[dir] = nodePos[dir] - 1;
+
+    if (nPos[dir] < 0) {
+      nPos[dir] += getGridSize(dir);
+    }
+
+    nodeNeighbors[2 * dir] = mapPositionToIndex(nPos);
+    LOG4ESPP_DEBUG(logger, "left neighbor in dir " << dir << ": "
+                                                   << getNodeNeighborIndex(2 * dir) << " <-> "
+                                                   << nPos[0] << " "
+                                                   << nPos[1] << " "
+                                                   << nPos[2]);
+
+    // right neighbor in direction dir
+    nPos[dir] = nodePos[dir] + 1;
+
+    if (nPos[dir] >= getGridSize(dir)) {
+      nPos[dir] -= getGridSize(dir);
+    }
+
+    nodeNeighbors[2 * dir + 1] = mapPositionToIndex(nPos);
+
+    LOG4ESPP_DEBUG(logger, "right neighbor in dir " << dir << ": "
+                                                    << getNodeNeighborIndex(2 * dir + 1) << " <-> "
+                                                    << nPos[0] << " "
+                                                    << nPos[1] << " "
+                                                    << nPos[2]);
+
+    // left or right boundary ?
+    boundaries[2 * dir] = (nodePos[dir] == 0) ? ToRight : 0;
+    boundaries[2 * dir + 1] = (nodePos[dir] == getGridSize(dir) - 1) ? ToLeft : 0;
+
+    LOG4ESPP_DEBUG(logger, "boundaries in dir " << dir << ": "
+                                                << getBoundary(2 * dir) << " "
+                                                << getBoundary(2 * dir + 1));
+  }
+}
+}
 }

--- a/src/storage/NodeGrid.hpp
+++ b/src/storage/NodeGrid.hpp
@@ -1,32 +1,32 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
+
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 // ESPP_CLASS
 #ifndef _STORAGE_NODEGRID_HPP
 #define _STORAGE_NODEGRID_HPP
 
 /*
-  local ghost cell grid representation. Taken from grid.c.
-*/
+   local ghost cell grid representation. Taken from grid.c.
+ */
 
 #include <stdexcept>
 #include "types.hpp"
@@ -35,135 +35,144 @@
 #include "Real3D.hpp"
 
 namespace espressopp {
-  namespace storage {
-    class NodeGridIllegal: public std::invalid_argument
-    {
-    public:
-      NodeGridIllegal();
-    };
+namespace storage {
+class NodeGridIllegal : public std::invalid_argument {
+public:
+  NodeGridIllegal();
+};
 
-    /** Node grid point. This represents the node grid of the domain
-	decomposition, as well as the location of this processor in the
-	grid.
-    */
-    class NodeGrid: public esutil::Grid
-    {
-    public:
-      NodeGrid() {}
+/** Node grid point. This represents the node grid of the domain
+   decomposition, as well as the location of this processor in the
+   grid.
+ */
+class NodeGrid : public esutil::Grid {
+public:
+  NodeGrid() { }
 
-      /// order of node neighbors
-      enum Directions {
-        Left = 0, Right,
-        Bottom,   Top,
-        Front,    Back
-      };
+  /// order of node neighbors
+  enum Directions {
+    Left = 0, Right,
+    Bottom,   Top,
+    Front,    Back
+  };
 
-      /// order coordinates
-      enum FoldDirections {
-        ToLeft = -1, ToRight = 1
-      };
+  /// order coordinates
+  enum FoldDirections {
+    ToLeft = -1, ToRight = 1
+  };
 
-      NodeGrid(const Int3D& grid,
-               const longint nodeId,
-               const Real3D& domainSize);
+  NodeGrid(const Int3D &grid,const longint nodeId,const Real3D &domainSize);
 
-      /// map coordinate to a node. Positions outside are clipped back
-      longint 
-      mapPositionToNodeClipped(const Real3D& pos) const;
+  /// map coordinate to a node. Positions outside are clipped back
+  longint mapPositionToNodeClipped(const Real3D &pos) const;
 
-      /// get this node's coordinates
-      longint getNodePosition(int axis) const { return nodePos[axis]; }
-      /// size of the local box
-      real getLocalBoxSize(int axis) const { return localBoxSize[axis]; }
-      /// inverse of the size of a cell
-      real getInverseLocalBoxSize(int axis) const { return invLocalBoxSize[axis]; }
+  /// get this node's coordinates
+  longint getNodePosition(int axis) const {return nodePos[axis]; }
 
-      /// calculate start of local box
-      real getMyLeft(int axis) const { return nodePos[axis]*localBoxSize[axis]; }
-      Real3D getMyLeft() const { 
-        return Real3D(getMyLeft(0), getMyLeft(1), getMyLeft(2));
-      }
+  /// size of the local box
+  real getLocalBoxSize(int axis) const {return localBoxSize[axis]; }
 
-      /// calculate end of local box
-      real getMyRight(int axis) const { return (nodePos[axis] + 1)*localBoxSize[axis]; }
-      Real3D getMyRight() const { 
-        return Real3D(getMyRight(0), getMyRight(1), getMyRight(2));
-      }
+  /// inverse of the size of a cell
+  real getInverseLocalBoxSize(int axis) const {return invLocalBoxSize[axis]; }
 
-      Real3D getMyCenter() const {
-        Real3D center = getMyLeft();
-        center += getMyRight();
-        center *= 0.5;
-        return center;
-      }
+  /// calculate start of local box
+  real getMyLeft(int axis) const {return nodePos[axis] * localBoxSize[axis]; }
 
-      longint getNodeNeighborIndex(int dir) const 
-      { return nodeNeighbors[dir]; }
-      longint getNodeNeighborIndex(Directions dir) const 
-      { return getNodeNeighborIndex(dir); }
-
-      /// where to fold particles that leave the box in direction i (ToRight, 0, ToLeft)
-      int getBoundary(int dir) const 
-      { return boundaries[dir]; }
-      int getBoundary(FoldDirections dir) const 
-      { return getBoundary(dir); }
-
-      /// get the coordinate of a direction  
-      static int 
-      convertDirToCoord(int dir) { return dir/2; }
-      static int 
-      convertDirToCoord(Directions dir) { return dir/2; }
-
-      static const int numNodeNeighbors = Back + 1;
-
-      void scaleVolume(real s) {
-        if (s > 0) {
-          for (int i=0; i<3; ++i) {
-            localBoxSize[i] *= s;
-            invLocalBoxSize[i] /= s;
-          }
-          smallestLocalBoxDiameter *= s;
-        }
-        else {
-            ;
-            // TODO: do nothing or throw error if s <= 0 ?
-        }
-      }
-      void scaleVolume(Real3D s) {
-        if (s[0]>0 && s[1]>0 && s[2]>0) {
-          for (int i=0; i<3; ++i) {
-            localBoxSize[i] *= s[i];
-            invLocalBoxSize[i] /= s[i];
-          }
-          smallestLocalBoxDiameter = std::min(std::min(localBoxSize[0], localBoxSize[1]), localBoxSize[2]);
-        }
-        else {
-            ;
-            // TODO: do nothing or throw error if s <= 0 ?
-        }
-      }
-      
-    private:
-      void calcNodeNeighbors(longint node);
-
-      /// position of this node in node grid
-      Int3D nodePos;
-      /// the six nearest neighbors of a node in the node grid
-      longint nodeNeighbors[6];
-      /// where to fold particles that leave local box in direction i
-      int boundaries[6];
-
-      /// cell size
-      Real3D localBoxSize;
-      /// inverse domain size
-      Real3D invLocalBoxSize;
-
-      /// smallest diameter of the local box
-      real smallestLocalBoxDiameter;
-
-      static LOG4ESPP_DECL_LOGGER(logger);
-    };
+  Real3D getMyLeft() const {
+    return Real3D(getMyLeft(0), getMyLeft(1), getMyLeft(2));
   }
+
+  /// calculate end of local box
+  real getMyRight(int axis) const {return (nodePos[axis] + 1) * localBoxSize[axis]; }
+
+  Real3D getMyRight() const {
+    return Real3D(getMyRight(0), getMyRight(1), getMyRight(2));
+  }
+
+  Real3D getMyCenter() const {
+    Real3D center = getMyLeft();
+
+
+    center += getMyRight();
+    center *= 0.5;
+    return center;
+  }
+
+  longint getNodeNeighborIndex(int dir) const
+  {return nodeNeighbors[dir]; }
+
+  longint getNodeNeighborIndex(Directions dir) const
+  {return getNodeNeighborIndex(dir); }
+
+  /// where to fold particles that leave the box in direction i (ToRight, 0, ToLeft)
+  int getBoundary(int dir) const
+  {return boundaries[dir]; }
+
+  int getBoundary(FoldDirections dir) const
+  {return getBoundary(dir); }
+
+  /// get the coordinate of a direction
+  static int convertDirToCoord(int dir) {return dir / 2; }
+
+  static int convertDirToCoord(Directions dir) {return dir / 2; }
+
+  static const int numNodeNeighbors = Back + 1;
+
+  void scaleVolume(real s) {
+    if (s > 0) {
+      for (int i = 0; i < 3; ++i) {
+        localBoxSize[i] *= s;
+        invLocalBoxSize[i] /= s;
+      }
+
+      smallestLocalBoxDiameter *= s;
+    } else {
+      ;
+
+      // TODO: do nothing or throw error if s <= 0 ?
+    }
+  }
+
+  void scaleVolume(Real3D s) {
+    if ((s[0] > 0) && (s[1] > 0) && (s[2] > 0)) {
+      for (int i = 0; i < 3; ++i) {
+        localBoxSize[i] *= s[i];
+        invLocalBoxSize[i] /= s[i];
+      }
+
+      smallestLocalBoxDiameter = std::min(std::min(localBoxSize[0], localBoxSize[1]),
+        localBoxSize[2]);
+    } else {
+      ;
+
+      // TODO: do nothing or throw error if s <= 0 ?
+    }
+  }
+
+private:
+  void calcNodeNeighbors(longint node);
+
+  /// position of this node in node grid
+  Int3D nodePos;
+
+  /// the six nearest neighbors of a node in the node grid
+  longint nodeNeighbors[6];
+
+  /// where to fold particles that leave local box in direction i
+  int boundaries[6];
+
+  /// cell size
+  Real3D localBoxSize;
+
+  /// inverse domain size
+  Real3D invLocalBoxSize;
+
+  /// smallest diameter of the local box
+  real smallestLocalBoxDiameter;
+
+  static LOG4ESPP_DECL_LOGGER(logger);
+};
+}
 }
 
 #endif

--- a/src/storage/Storage.cpp
+++ b/src/storage/Storage.cpp
@@ -1,28 +1,28 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
+
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "python.hpp"
 
-//#include <algorithm>
+// #include <algorithm>
 
 #include "log4espp.hpp"
 
@@ -44,728 +44,760 @@ using namespace boost;
 using namespace espressopp::iterator;
 
 namespace espressopp {
- 
-  namespace storage {
-    LOG4ESPP_LOGGER(Storage::logger, "Storage");
+namespace storage {
+LOG4ESPP_LOGGER(Storage::logger, "Storage");
 
-    const int STORAGE_COMM_TAG = 0xaa;
+const int STORAGE_COMM_TAG = 0xaa;
 
-    const int Storage::dataOfUpdateGhosts = 0;
-    const int Storage::dataOfExchangeGhosts = DATA_PROPERTIES;
+const int Storage::dataOfUpdateGhosts = 0;
+const int Storage::dataOfExchangeGhosts = DATA_PROPERTIES;
 
-    Storage::Storage(shared_ptr< System > system)
-      : SystemAccess(system),
-        inBuffer(*system->comm),
-        outBuffer(*system->comm)
-    {
-      //logger.setLevel(log4espp::Logger::TRACE);
-      LOG4ESPP_INFO(logger, "Created new storage object for a system, has buffers");
+Storage::Storage(shared_ptr<System> system)
+      :SystemAccess(system),
+          inBuffer(*system->comm),
+          outBuffer(*system->comm) {
+  // logger.setLevel(log4espp::Logger::TRACE);
+  LOG4ESPP_INFO(logger, "Created new storage object for a system, has buffers");
+}
+
+Storage::~Storage() { }
+
+longint Storage::getNRealParticles() const {
+  longint cnt = 0;
+
+
+  for (CellList::const_iterator it = realCells.begin(), end = realCells.end(); it != end; ++it) {
+    longint size = (*it)->particles.size();
+
+    if (size) {
+      LOG4ESPP_TRACE(logger, "cell " << ((*it) - getFirstCell()) << " size " << size);
     }
 
-    Storage::~Storage() {}
+    cnt += size;
+  }
 
-    longint Storage::getNRealParticles() const {
-      longint cnt = 0;
-      for (CellList::const_iterator it = realCells.begin(), end = realCells.end(); it != end; ++it) {
-        longint size = (*it)->particles.size();
-        if (size) {
-          LOG4ESPP_TRACE(logger, "cell " << ((*it) - getFirstCell()) << " size " << size);
+  return cnt;
+}
+
+longint Storage::getNLocalParticles() const {
+  longint cnt = 0;
+
+
+  for (CellList::const_iterator it = localCells.begin(), end = localCells.end(); it != end; ++it) {
+    longint size = (*it)->particles.size();
+
+    if (size) {
+      LOG4ESPP_TRACE(logger, "cell " << ((*it) - getFirstCell()) << " size " << size);
+    }
+
+    cnt += size;
+  }
+
+  return cnt;
+}
+
+longint Storage::getNGhostParticles() const {
+  longint cnt = 0;
+
+
+  for (CellList::const_iterator it = ghostCells.begin(), end = ghostCells.end(); it != end; ++it) {
+    longint size = (*it)->particles.size();
+
+    if (size) {
+      LOG4ESPP_TRACE(logger, "cell " << ((*it) - getFirstCell()) << " size " << size);
+    }
+
+    cnt += size;
+  }
+
+  return cnt;
+}
+
+longint Storage::getNAdressParticles() const {
+  longint cnt = 0;
+
+
+  return localAdrATParticles.size();
+}
+
+python::list Storage::getRealParticleIDs() {
+  python::list pids;
+
+
+  for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {
+    pids.append(cit->getId());
+  }
+
+  return pids;
+}
+
+// TODO find out why python crashes if inlined
+// inline
+void Storage::removeFromLocalParticles(Particle *p, bool weak) {
+  /* no pointer left, can happen for ghosts when the real particle
+     e has already been removed */
+  if (localParticles.find(p->id()) == localParticles.end()) {
+    return;
+  }
+
+  if (!weak || (localParticles[p->id()] == p)) {
+    LOG4ESPP_TRACE(logger, "removing local pointer for particle id="
+            << p->id() << " @ " << p);
+    localParticles.erase(p->id());
+  } else {
+    LOG4ESPP_TRACE(logger, "NOT removing local pointer for particle id="
+            << p->id() << " @ " << p << " since pointer is @ "
+            << localParticles[p->id()]);
+  }
+}
+
+/** Scale coordinates of all real particles by factor s */
+void Storage::scaleVolume(real s) {
+  for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {
+    Real3D pos = cit->getPos();
+
+    pos *= s;
+    cit->setPos(pos);
+  }
+}
+
+/** Scale coordinates of all real particles by factor s. Anisotropic case */
+void Storage::scaleVolume(Real3D s) {
+  for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {
+    Real3D pos = cit->getPos();
+
+    pos[0] *= s[0];
+    pos[1] *= s[1];
+    pos[2] *= s[2];
+    cit->setPos(pos);
+  }
+}
+
+void Storage::removeAdrATParticle(longint id) {
+  if (localAdrATParticles.find(id) == localAdrATParticles.end()) {
+    std::cout << "not removing AT particle " << id << ", since not found \n";
+
+    return;
+  }
+
+  // remove from ParticleList (vector)
+  Particle *dbegin = &AdrATParticles.front();       // see whether the array was moved
+  Particle *p = lookupAdrATParticle(id);
+  int i = p - &AdrATParticles[0];
+  int newSize = AdrATParticles.size() - 1;
+
+  if (i != newSize) {       // if we are not removing the particle in last place
+    AdrATParticles[i] = AdrATParticles.back();
+  }
+
+  AdrATParticles.resize(newSize);
+
+  // remove from particle map
+  localAdrATParticles.erase(id);
+
+  // update particle map with particle list
+  if (dbegin != &AdrATParticles.front()) {
+    updateLocalParticles(AdrATParticles, true);
+  } else if (i != newSize) {
+    Particle *np = &(AdrATParticles[i]);
+
+    updateInLocalAdrATParticles(np);
+  }
+}
+
+// TODO find out why python crashes if inlined
+// inline
+void Storage::updateInLocalParticles(Particle *p, bool weak) {
+  if (!weak || (localParticles.find(p->id()) == localParticles.end())) {
+    LOG4ESPP_TRACE(logger, "updating local pointer for particle id="
+            << p->id() << " @ " << p);
+
+    localParticles[p->id()] = p;
+
+    /*
+       // AdResS testing TODO
+       Particle* oldp = localParticles[p->id()];
+       Particle* newp = p;
+
+       localParticles[p->id()] = p;
+
+       //std::cout << "old *p " << oldp << "\n";
+       //std::cout << "new *p " << newp << "\n";
+
+       // TODO reorganize
+       if (oldp && fixedtupleList) {
+        FixedTupleList::iterator it;
+        it = fixedtupleList->find(oldp);
+        if (it != fixedtupleList->end()) {
+            std::vector<Particle*> tmp;
+            tmp = it->second;
+            fixedtupleList->insert(std::make_pair(newp, tmp));
+            fixedtupleList->erase(it);
         }
-        cnt += size;
-      }
-      return cnt;
-    }
-    
-    longint Storage::getNLocalParticles() const {
-      longint cnt = 0;
-      for (CellList::const_iterator it = localCells.begin(), end = localCells.end(); it != end; ++it) {
-        longint size = (*it)->particles.size();
-        if (size) {
-          LOG4ESPP_TRACE(logger, "cell " << ((*it) - getFirstCell()) << " size " << size);
+        else {
+            //std::cout << "updateInLocalParticles: Particle not found in tuples!\n";
         }
-        cnt += size;
-      }
-      return cnt;
+       }
+     */
+  } else {
+    LOG4ESPP_TRACE(logger, "NOT updating local pointer for particle id="
+            << p->id() << " @ " << p << " has already pointer @ "
+            << localParticles[p->id()]);
+  }
+}
+
+inline
+void Storage::updateInLocalAdrATParticles(Particle *p) {
+  localAdrATParticles[p->id()] = p;
+}
+
+void Storage::updateLocalParticles(ParticleList &list, bool adress) {
+  if (adress) {
+    for (ParticleList::Iterator it(list); it.isValid(); ++it) {
+      updateInLocalAdrATParticles(&(*it));
     }
-    longint Storage::getNGhostParticles() const {
-      longint cnt = 0;
-      for (CellList::const_iterator it = ghostCells.begin(), end = ghostCells.end(); it != end; ++it) {
-        longint size = (*it)->particles.size();
-        if (size) {
-          LOG4ESPP_TRACE(logger, "cell " << ((*it) - getFirstCell()) << " size " << size);
-        }
-        cnt += size;
-      }
-      return cnt;
-    }
-    longint Storage::getNAdressParticles() const {
-          longint cnt = 0;
-            return localAdrATParticles.size();
-    }
-
-    python::list Storage::getRealParticleIDs() {
-      python::list pids;
-      for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {
-    	pids.append(cit->getId());
-      }
-      return pids;
-    }
-
-    // TODO find out why python crashes if inlined
-    //inline
-    void Storage::removeFromLocalParticles(Particle *p, bool weak) {
-      /* no pointer left, can happen for ghosts when the real particle
-	 e has already been removed */
-      if (localParticles.find(p->id()) == localParticles.end()){
-        return;
-      }
-
-      if (!weak || localParticles[p->id()] == p) {
-        LOG4ESPP_TRACE(logger, "removing local pointer for particle id="
-                  << p->id() << " @ " << p);
-        localParticles.erase(p->id());
-      }
-      else {
-        LOG4ESPP_TRACE(logger, "NOT removing local pointer for particle id="
-                  << p->id() << " @ " << p << " since pointer is @ "
-                  << localParticles[p->id()]);
-      }
-    }
-
-    /** Scale coordinates of all real particles by factor s */
-    void Storage::scaleVolume(real s) {
-      for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {
-        Real3D pos = cit->getPos();
-        pos *= s;
-        cit->setPos(pos);
-      }
-    }
-    /** Scale coordinates of all real particles by factor s. Anisotropic case */
-    void Storage::scaleVolume(Real3D s) {
-      for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {
-        Real3D pos = cit->getPos();
-        pos[0] *= s[0];
-        pos[1] *= s[1];
-        pos[2] *= s[2];
-        cit->setPos(pos);
-      }
-    }
-
-    void Storage::removeAdrATParticle(longint id) {
-
-    	if (localAdrATParticles.find(id) == localAdrATParticles.end()) {
-    		std::cout << "not removing AT particle "<< id << ", since not found \n";
-    		return;
-    	}
-
-
-		// remove from ParticleList (vector)
-        Particle *dbegin = &AdrATParticles.front(); // see whether the array was moved
-    	Particle* p = lookupAdrATParticle(id);
-    	int i = p - &AdrATParticles[0];
-    	int newSize = AdrATParticles.size() - 1;
-    	if (i != newSize) { // if we are not removing the particle in last place
-    		AdrATParticles[i] = AdrATParticles.back();
-    	}
-    	AdrATParticles.resize(newSize);
-
-
-    	// remove from particle map
-    	localAdrATParticles.erase(id);
-
-
-    	// update particle map with particle list
-    	if (dbegin != &AdrATParticles.front()) {
-    		updateLocalParticles(AdrATParticles, true);
-    	}
-    	else if (i != newSize) {
-    		Particle *np = &(AdrATParticles[i]);
-    		updateInLocalAdrATParticles(np);
-    	}
-	}
-
-    // TODO find out why python crashes if inlined
-    //inline
-    void Storage::updateInLocalParticles(Particle *p, bool weak) {
-      if (!weak || localParticles.find(p->id()) == localParticles.end()) {
-          LOG4ESPP_TRACE(logger, "updating local pointer for particle id="
-		       << p->id() << " @ " << p);
-
-
-          localParticles[p->id()] = p;
-
-          /*
-          // AdResS testing TODO
-          Particle* oldp = localParticles[p->id()];
-          Particle* newp = p;
-
-          localParticles[p->id()] = p;
-
-          //std::cout << "old *p " << oldp << "\n";
-          //std::cout << "new *p " << newp << "\n";
-
-          // TODO reorganize
-          if (oldp && fixedtupleList) {
-              FixedTupleList::iterator it;
-              it = fixedtupleList->find(oldp);
-              if (it != fixedtupleList->end()) {
-                  std::vector<Particle*> tmp;
-                  tmp = it->second;
-                  fixedtupleList->insert(std::make_pair(newp, tmp));
-                  fixedtupleList->erase(it);
-              }
-              else {
-                  //std::cout << "updateInLocalParticles: Particle not found in tuples!\n";
-              }
-          }
-          */
-      }
-      else {
-          LOG4ESPP_TRACE(logger, "NOT updating local pointer for particle id="
-		       << p->id() << " @ " << p << " has already pointer @ "
-		       << localParticles[p->id()]);
-      }
-    }
-
-    inline
-    void Storage::updateInLocalAdrATParticles(Particle *p) {
-          localAdrATParticles[p->id()] = p;
-    }
-
-    void Storage::updateLocalParticles(ParticleList &list, bool adress) {
-      if (adress) {
-          for (ParticleList::Iterator it(list); it.isValid(); ++it) {
-              updateInLocalAdrATParticles(&(*it));
-          }
-      }
-      else {
-          for (ParticleList::Iterator it(list); it.isValid(); ++it) {
-              updateInLocalParticles(&(*it));
-          }
-      }
-    }
-
-    void Storage::resizeCells(longint nCells) {
-      cells.resize(nCells);
-      localCells.reserve(nCells);
-      for (LocalCellList::iterator it = cells.begin(), end = cells.end(); it != end; ++it) {
-        localCells.push_back(&(*it));
-      }
-    }
-
-    Particle* Storage::addParticle(longint id, const Real3D& p) {
-      if (!checkIsRealParticle(id, p)) {
-        return static_cast< Particle* >(0);
-      }
-
-      Cell *cell;
-
-      Particle n;
-      n.init();
-      n.id() = id;
-      n.position()= p;
-      n.image() = Int3D(0);
-      getSystem()->bc->foldPosition(n.position(), n.image());
-      cell = mapPositionToCellClipped(n.position());
-
-      //std::cout << "add particle: " << n.id() << " (" << n.position() << ")\n";
-
-      appendIndexedParticle(cell->particles, n);
-
-      LOG4ESPP_TRACE(logger, "got particle id ="
-		     << id << " @ " << p << " ; put it into cell " << cell - getFirstCell());
-      LOG4ESPP_TRACE(logger, "folded it to "
-		     << n.r.p[0] << " " << n.r.p[1] << " " << n.r.p[2] );
-      LOG4ESPP_TRACE(logger, "cell size is now " << cell->particles.size());
-
-      return &cell->particles.back();
-    }
-    
-    int Storage::removeParticle(longint id){
-      Particle* p = lookupRealParticle(id);
-      if(p){
-        Cell *cell = mapPositionToCellChecked(p->position());
-        
-        removeFromLocalParticles( p );
-
-        int rem_part_ind = p - &cell->particles[0];
-    	int newSize = cell->particles.size() - 1;
-    	if (rem_part_ind != newSize) {
-          cell->particles[rem_part_ind] = cell->particles.back();
-    	}
-        cell->particles.resize(newSize);
-        
-        updateLocalParticles( cell->particles );
-
-        onParticlesChanged();
-        Particle* p1 = lookupRealParticle(id);
-        if(p1){
-          // it should not be printed out
-          std::cout<< "Part still exst. pid: " << id << "  rpid: " << p1->id() << std::endl;
-        }
-        return 1;
-      }
-      else {
-        return 0;
-      }
-      // TODO particle should be removed from different particle groups and lists too
-      
-    }
-    
-    void Storage::removeAllParticles(){
-      localParticles.clear();
-      for (CellList::iterator it = localCells.begin(), end = localCells.end(); it != end; ++it) {
-        (*it)->particles.clear();
-      }
-      onParticlesChanged();
-    }
-    
-
-    Particle* Storage::addAdrATParticle(longint id, const Real3D& p, const Real3D& _vpp) {
-
-      if (!checkIsRealParticle(id, _vpp)) {
-    	return static_cast< Particle* >(0);
-      }
-
-      Particle n;
-      n.init();
-      n.id() = id;
-      n.position()= p;
-      n.image() = Int3D(0);
-
-      //std::cout << "add ATparticle: " << n.id() << " (" << n.position() << ")\n";
-
-      // fold AT particles for same amount as VP
-      Real3D vpp_old = _vpp;
-      Real3D vpp_new = _vpp;
-
-      getSystem()->bc->foldPosition(vpp_new);
-
-      if (vpp_old != vpp_new) {
-          //std::cout << "VP old pos (" << vpp_old << ") ";
-          //std::cout << "new pos (" << vpp_new << ")\n";
-
-          Real3D moved = vpp_old - vpp_new;
-          n.position() = n.position() - moved;
-
-          //std::cout << " Moved AT particle to " << n.position() << "\n";
-      }
-
-
-      // see whether the array was resized; STL hack
-      Particle *begin = &AdrATParticles.front();
-
-      AdrATParticles.push_back(n);
-      Particle* local = &AdrATParticles.back();
-
-      if (begin != &AdrATParticles.front()) {
-          updateLocalParticles(AdrATParticles, true);
-      }
-      else {
-          updateInLocalAdrATParticles(local);
-      }
-
-      return local;
-    }
-
-    // this is called from fixedtuplelist only!
-    Particle* Storage::addAdrATParticleFTPL(Particle n) {
-
-	  // see whether the array was resized; STL hack
-	  Particle *begin = &AdrATParticles.front();
-
-	  AdrATParticles.push_back(n);
-	  Particle* local = &AdrATParticles.back();
-
-	  if (begin != &AdrATParticles.front()) {
-		  updateLocalParticles(AdrATParticles, true);
-	  }
-	  else {
-		  updateInLocalAdrATParticles(local);
-	  }
-
-	  return local;
-	}
-
-
-    /*Particle* Storage::addParticle(longint id, const Real3D& p, int type) {
-        Particle* pt = addParticle(id, p);
-        pt->setType(type);
-        return pt;
-    }*/
-
-    Particle *Storage::appendUnindexedParticle(ParticleList &l, Particle &part)
-    {
-      l.push_back(part);
-      return &l.back();
-    }
-
-    //Particle *Storage::appendUnindexedAdrParticle(ParticleListAdr &l, Particle &part)
-    Particle *Storage::appendUnindexedAdrParticle(ParticleList &l, Particle &part) {
-      l.push_back(part);
-      return &l.back();
-    }
-
-    void Storage::appendParticleListToGhosts(ParticleList &l) {
-      AdrATParticlesG.push_back(l);
-    }
-
-
-
-
-    Particle *Storage::appendIndexedParticle(ParticleList &l, Particle &part)
-    {
-      // see whether the array was resized; STL hack
-      Particle *begin = &l.front();
-
-      l.push_back(part);
-      Particle *p = &l.back();
-
-      if (begin != &l.front()) {
-          updateLocalParticles(l);
-      }
-      else {
-          updateInLocalParticles(p);
-      }
-
-      return p;
-    }
-
-    Particle *Storage::moveIndexedParticle(ParticleList &dl, ParticleList &sl, int i)
-    {
-
-      // see whether the arrays were resized; STL hack
-      Particle *dbegin = &dl.front();
-      Particle *sbegin = &sl.front();
-
-      dl.push_back(sl[i]);
-      int newSize = sl.size() - 1;
-      if (i != newSize) {
-          sl[i] = sl.back();
-      }
-      sl.resize(newSize);
-
-      Particle *dst = &dl.back();
-      Particle *src = &(sl[i]);
-
-      // fix up destination list
-      if (dbegin != &dl.front()) {
-          updateLocalParticles(dl);
-      }
-      else {
-          updateInLocalParticles(dst);
-      }
-
-      // fix up resorted source list; due to moving, the last particle
-      // might have been moved to the position of the actually moved one
-      if (sbegin != &sl.front()) {
-          updateLocalParticles(sl);
-      }
-      else if (i != newSize) {
-          updateInLocalParticles(src);
-      }
-
-
-      return dst;
-    }
-
-    void Storage::fetchParticles(Storage &old)
-    {
-      LOG4ESPP_DEBUG(logger, "number of received cells = "
-		     << old.getRealCells().size());
-
-      for (CellListIterator it(old.getRealCells()); it.isValid(); ++it) {
-        Particle &part = *it;
-        Cell *nc = mapPositionToCellClipped(part.position());
-        appendUnindexedParticle(nc->particles, part);
-      }
-
-      // update localParticles
-      for(CellList::Iterator it(realCells); it.isValid(); ++it) {
-        updateLocalParticles((*it)->particles);
-      }
-    }
-
-    void Storage::sendParticles(ParticleList &list, longint node)
-    {
-      LOG4ESPP_DEBUG(logger, "send " << list.size() << " particles to " << node);
-
-      // pack for transport
-
-      OutBuffer& data = outBuffer;
-
-      data.reset();
-      int size = list.size();
-      data.write(size);
-      for (ParticleList::Iterator it(list); it.isValid(); ++it) {
-          removeFromLocalParticles(&(*it));
-          data.write(*it);
-      }
-
-      beforeSendParticles(list, data); // this also takes care of AdResS AT Particles
-
-      list.clear();
-
-      // ... and send
-      data.send(node, STORAGE_COMM_TAG);
-
-      LOG4ESPP_DEBUG(logger, "done");
-    }
-
-    void Storage::recvParticles(ParticleList &list, longint node)
-    {
-      LOG4ESPP_DEBUG(logger, "recv from " << node);
-
-      InBuffer& data = inBuffer;  // reuse storage buffer
-
-      data.recv(node, STORAGE_COMM_TAG);
-
-      // ... and unpack
-      int size;
-      data.read(size);
-      int curSize = list.size();
-      LOG4ESPP_DEBUG(logger, "got " << size << " particles, have " << curSize);
-
-      if (size > 0) {
-        list.resize(curSize + size);
-
-        for (int i = 0; i < size; ++i) {
-          Particle *p = &list[curSize + i];
-          data.read(*p);
-          updateInLocalParticles(p);
-        }
-
-        afterRecvParticles(list, data); // this also takes care of AdResS AT Particles
-      }
-
-      LOG4ESPP_DEBUG(logger, "done");
-    }
-
-    void Storage::invalidateGhosts() {
-      for(CellListIterator it(getGhostCells()); it.isValid(); ++it) {
-        /* remove only ghosts from the hash if the localParticles hash
-          actually points to the ghost.  If there are local ghost cells
-          to implement pbc, the real particle will be the one accessible
-          via localParticles.
-        */
-        removeFromLocalParticles(&(*it), true);
-      }
-    }
-
-    void Storage::decompose() {
-      invalidateGhosts();
-      decomposeRealParticles();
-      exchangeGhosts();
-      onParticlesChanged();
-    }
-
-    void Storage::packPositionsEtc(OutBuffer &buf,
-				   Cell &_reals, int extradata, const Real3D& shift) {
-      ParticleList &reals  = _reals.particles;
-
-      LOG4ESPP_DEBUG(logger, "pack data from reals in "
-		     << (&_reals - getFirstCell()));
-      LOG4ESPP_DEBUG(logger, "also packing "
-		     << ((extradata & DATA_PROPERTIES) ? "properties " : "")
-		     << ((extradata & DATA_MOMENTUM) ? "momentum " : "")
-		     << ((extradata & DATA_LOCAL) ? "local " : ""));
-      LOG4ESPP_DEBUG(logger, "positions are shifted by "
-		     << shift[0] << "," << shift[1] << "," << shift[2]);
-
-      for(ParticleList::iterator src = reals.begin(), end = reals.end(); src != end; ++src) {
-
-        buf.write(*src, extradata, shift);
-      }
-    }
-
-    void Storage::unpackPositionsEtc(Cell &_ghosts, InBuffer &buf, int extradata) {
-      ParticleList &ghosts  = _ghosts.particles;
-
-      LOG4ESPP_DEBUG(logger, "unpack data to ghosts in "
-		     << (&_ghosts - getFirstCell()));
-      LOG4ESPP_DEBUG(logger, "also unpacking "
-		     << ((extradata & DATA_PROPERTIES) ? "properties " : "")
-		     << ((extradata & DATA_MOMENTUM) ? "momentum " : "")
-		     << ((extradata & DATA_LOCAL) ? "local " : ""));
-
-      for(ParticleList::iterator dst = ghosts.begin(), end = ghosts.end(); dst != end; ++dst) {
-
-        buf.read(*dst, extradata);
-
-        if (extradata & DATA_PROPERTIES) {
-        	updateInLocalParticles(&(*dst), true);
-        }
-
-        dst->ghost() = 1;
-      }
-    }
-
-    void Storage::copyRealsToGhosts(Cell &_reals, Cell &_ghosts,
-				    int extradata,
-				    const Real3D& shift)
-    {
-      ParticleList &reals  = _reals.particles;
-      ParticleList &ghosts = _ghosts.particles;
-
-      LOG4ESPP_DEBUG(logger, "copy data from reals in "
-		     << (&_reals - getFirstCell()) << " to ghosts in "
-		     << (&_ghosts - getFirstCell()));
-      LOG4ESPP_DEBUG(logger, "also copying "
-		     << ((extradata & DATA_PROPERTIES) ? "properties " : "")
-		     << ((extradata & DATA_MOMENTUM) ? "momentum " : "")
-		     << ((extradata & DATA_LOCAL) ? "local " : ""));
-      LOG4ESPP_DEBUG(logger, "positions are shifted by "
-		     << shift[0] << "," << shift[1] << "," << shift[2]);
-
-      ghosts.resize(reals.size());
-
-      for(ParticleList::iterator src = reals.begin(), end = reals.end(), dst = ghosts.begin();
-              src != end; ++src, ++dst) {
-        dst->copyAsGhost(*src, extradata, shift);
-      }
-    }
-
-    void Storage::packForces(OutBuffer &buf, Cell &_ghosts)
-    {
-      LOG4ESPP_DEBUG(logger, "pack ghost forces to buffer from cell "
-		     << (&_ghosts - getFirstCell()));
-
-      ParticleList &ghosts = _ghosts.particles;
-  
-      for(ParticleList::iterator src = ghosts.begin(), end = ghosts.end(); src != end; ++src) {
-
-        buf.write(src->particleForce());
-
-        LOG4ESPP_TRACE(logger, "from particle " << src->id() << ": packing force " << src->force());
-      }
-    }
-
-    void Storage::unpackForces(Cell &_reals, InBuffer &buf)
-    {
-      LOG4ESPP_DEBUG(logger, "add forces from buffer to cell "
-		     << (&_reals - getFirstCell()));
-
-      ParticleList &reals = _reals.particles;
-
-      for(ParticleList::iterator dst = reals.begin(), end = reals.end(); dst != end; ++dst) {
-
-    	  ParticleForce f;
-    	  buf.read(f);
-    	  LOG4ESPP_TRACE(logger, "for particle " << dst->id() << ": unpacking force " << f.force());
-    	  dst->particleForce() = f;
-      }
-    }
-
-    void Storage::unpackAndAddForces(Cell &_reals, InBuffer &buf)
-    {
-      LOG4ESPP_DEBUG(logger, "add forces from buffer to cell "
-		     << (&_reals - getFirstCell()));
-
-      ParticleList &reals = _reals.particles;
-
-      for(ParticleList::iterator dst = reals.begin(), end = reals.end(); dst != end; ++dst) {
-    	  ParticleForce f;
-    	  buf.read(f);
-    	  LOG4ESPP_TRACE(logger, "for particle " << dst->id() << ": unpacking force "
-		       << f.f() << " and adding to " << dst->force());
-    	  dst->particleForce() += f;
-      }
-    }
-
-    void Storage::addGhostForcesToReals(Cell &_ghosts, Cell &_reals)
-    {
-      LOG4ESPP_DEBUG(logger, "add forces from ghosts in cell "
-		     << (&_ghosts - getFirstCell()) << " to reals in cell "
-		     << (&_reals - getFirstCell()));
-
-      ParticleList &reals  = _reals.particles;
-      ParticleList &ghosts = _ghosts.particles;
-
-      for(ParticleList::iterator dst = reals.begin(), end = reals.end(), src = ghosts.begin();
-              dst != end; ++dst, ++src) {
-          LOG4ESPP_TRACE(logger, "for particle " << dst->id() << ": adding force "
-		       << src->force() << " to " << dst->force());
-
-          dst->particleForce() += src->particleForce();
-      }
-    }
-    
-
-    void Storage::clearSavedPositions(){
-      savedRealPositions.clear();
-      savedImages.clear();
-    }
-    void Storage::savePosition(size_t id){
-      if( getSystemRef().comm->size()==1 ){
-        Particle* p = lookupRealParticle(id);
-        if(p){
-          savedRealPositions[id] = p->position();
-          savedImages[id] = p->image();
-        }
-      }
-      else{
-        esutil::Error err(getSystem()->comm);
-        stringstream msg;
-        msg<<" At the moment it works only for one CPU. One can not store old positions"
-                " for several CPUs";
-        err.setException( msg.str() );
-      }
-    }
-    
-    void Storage::restorePositions(){
-      int count = 0;
-      int totCount = 0;
-      if( !savedRealPositions.empty() ){
-        for (map<size_t,Real3D>::iterator itr=savedRealPositions.begin(); itr != savedRealPositions.end(); ++itr) {
-          size_t id = itr->first;
-          Particle* p = lookupRealParticle(id);
-          if(p){
-            p->position() = itr->second;
-          }
-        }
-        for (map<size_t,Int3D>::iterator itr=savedImages.begin(); itr != savedImages.end(); ++itr) {
-          size_t id = itr->first;
-          Particle* p = lookupRealParticle(id);
-          if(p){
-            p->image() = itr->second;
-          }
-        }
-        count++;
-      }
-      
-      mpi::all_reduce(*getSystem()->comm, count, totCount, std::plus<int>());
-      
-      if(totCount == 0){
-        esutil::Error err(getSystem()->comm);
-        stringstream msg;
-        msg<<" There is nothing to restore. Check whether you saved positions";
-        err.setException( msg.str() );
-      }
-    }
-    
-
-    //////////////////////////////////////////////////
-    // REGISTRATION WITH PYTHON
-    //////////////////////////////////////////////////
-    void
-    Storage::registerPython() {
-      using namespace espressopp::python;
-      class_< Storage, boost::noncopyable >("storage_Storage", no_init)
-	    .def("clearSavedPositions", &Storage::clearSavedPositions)
-	    .def("savePosition", &Storage::savePosition)
-	    .def("restorePositions", &Storage::restorePositions)
-	    .def("addParticle", &Storage::addParticle, return_value_policy< reference_existing_object >())
-	    .def("removeParticle", &Storage::removeParticle)
-	    .def("removeAllParticles", &Storage::removeAllParticles)
-        .def("addAdrATParticle", &Storage::addAdrATParticle, return_value_policy< reference_existing_object >())
-        .def("setFixedTuplesAdress", &Storage::setFixedTuplesAdress)
-        //.def("addParticle", &Storage::addParticle, return_value_policy< reference_existing_object >())
-	    .def("lookupLocalParticle", &Storage::lookupLocalParticle, return_value_policy< reference_existing_object >())
-	    .def("lookupRealParticle", &Storage::lookupRealParticle, return_value_policy< reference_existing_object >())
-	    .def("decompose", &Storage::decompose)
-	    .def("getRealParticleIDs", &Storage::getRealParticleIDs)
-        .add_property("system", &Storage::getSystem)
-	    ;
+  } else {
+    for (ParticleList::Iterator it(list); it.isValid(); ++it) {
+      updateInLocalParticles(&(*it));
     }
   }
 }
+
+void Storage::resizeCells(longint nCells) {
+  cells.resize(nCells);
+  localCells.reserve(nCells);
+
+  for (LocalCellList::iterator it = cells.begin(), end = cells.end(); it != end; ++it) {
+    localCells.push_back(&(*it));
+  }
+}
+
+Particle *Storage::addParticle(longint id, const Real3D &p) {
+  if (!checkIsRealParticle(id, p)) {
+    return static_cast<Particle *>(0);
+  }
+
+  Cell *cell;
+
+  Particle n;
+
+  n.init();
+  n.id() = id;
+  n.position() = p;
+  n.image() = Int3D(0);
+  getSystem()->bc->foldPosition(n.position(), n.image());
+  cell = mapPositionToCellClipped(n.position());
+
+  // std::cout << "add particle: " << n.id() << " (" << n.position() << ")\n";
+
+  appendIndexedParticle(cell->particles, n);
+
+  LOG4ESPP_TRACE(logger, "got particle id ="
+          << id << " @ " << p << " ; put it into cell " << cell - getFirstCell());
+  LOG4ESPP_TRACE(logger, "folded it to "
+          << n.r.p[0] << " " << n.r.p[1] << " " << n.r.p[2]);
+  LOG4ESPP_TRACE(logger, "cell size is now " << cell->particles.size());
+
+  return &cell->particles.back();
+}
+
+int Storage::removeParticle(longint id) {
+  Particle *p = lookupRealParticle(id);
+
+
+  if (p) {
+    Cell *cell = mapPositionToCellChecked(p->position());
+
+    removeFromLocalParticles(p);
+
+    int rem_part_ind = p - &cell->particles[0];
+    int newSize = cell->particles.size() - 1;
+
+    if (rem_part_ind != newSize) {
+      cell->particles[rem_part_ind] = cell->particles.back();
+    }
+
+    cell->particles.resize(newSize);
+
+    updateLocalParticles(cell->particles);
+
+    onParticlesChanged();
+
+    Particle *p1 = lookupRealParticle(id);
+
+    if (p1) {
+      // it should not be printed out
+      std::cout << "Part still exst. pid: " << id << "  rpid: " << p1->id() << std::endl;
+    }
+
+    return 1;
+  } else {
+    return 0;
+  }
+
+  // TODO particle should be removed from different particle groups and lists too
+}
+
+void Storage::removeAllParticles() {
+  localParticles.clear();
+
+  for (CellList::iterator it = localCells.begin(), end = localCells.end(); it != end; ++it) {
+    (*it)->particles.clear();
+  }
+
+  onParticlesChanged();
+}
+
+Particle *Storage::addAdrATParticle(longint id, const Real3D &p, const Real3D &_vpp) {
+  if (!checkIsRealParticle(id, _vpp)) {
+    return static_cast<Particle *>(0);
+  }
+
+  Particle n;
+
+  n.init();
+  n.id() = id;
+  n.position() = p;
+  n.image() = Int3D(0);
+
+  // std::cout << "add ATparticle: " << n.id() << " (" << n.position() << ")\n";
+
+  // fold AT particles for same amount as VP
+  Real3D vpp_old = _vpp;
+  Real3D vpp_new = _vpp;
+
+  getSystem()->bc->foldPosition(vpp_new);
+
+  if (vpp_old != vpp_new) {
+    // std::cout << "VP old pos (" << vpp_old << ") ";
+    // std::cout << "new pos (" << vpp_new << ")\n";
+
+    Real3D moved = vpp_old - vpp_new;
+
+    n.position() = n.position() - moved;
+
+    // std::cout << " Moved AT particle to " << n.position() << "\n";
+  }
+
+  // see whether the array was resized; STL hack
+  Particle *begin = &AdrATParticles.front();
+
+  AdrATParticles.push_back(n);
+
+  Particle *local = &AdrATParticles.back();
+
+  if (begin != &AdrATParticles.front()) {
+    updateLocalParticles(AdrATParticles, true);
+  } else {
+    updateInLocalAdrATParticles(local);
+  }
+
+  return local;
+}
+
+// this is called from fixedtuplelist only!
+Particle *Storage::addAdrATParticleFTPL(Particle n) {
+  // see whether the array was resized; STL hack
+  Particle *begin = &AdrATParticles.front();
+
+
+  AdrATParticles.push_back(n);
+
+  Particle *local = &AdrATParticles.back();
+
+  if (begin != &AdrATParticles.front()) {
+    updateLocalParticles(AdrATParticles, true);
+  } else {
+    updateInLocalAdrATParticles(local);
+  }
+
+  return local;
+}
+
+/*Particle* Storage::addParticle(longint id, const Real3D& p, int type) {
+    Particle* pt = addParticle(id, p);
+    pt->setType(type);
+    return pt;
+   }*/
+
+Particle *Storage::appendUnindexedParticle(ParticleList &l, Particle &part) {
+  l.push_back(part);
+  return &l.back();
+}
+
+// Particle *Storage::appendUnindexedAdrParticle(ParticleListAdr &l, Particle &part)
+Particle *Storage::appendUnindexedAdrParticle(ParticleList &l, Particle &part) {
+  l.push_back(part);
+  return &l.back();
+}
+
+void Storage::appendParticleListToGhosts(ParticleList &l) {
+  AdrATParticlesG.push_back(l);
+}
+
+Particle *Storage::appendIndexedParticle(ParticleList &l, Particle &part) {
+  // see whether the array was resized; STL hack
+  Particle *begin = &l.front();
+
+
+  l.push_back(part);
+
+  Particle *p = &l.back();
+
+  if (begin != &l.front()) {
+    updateLocalParticles(l);
+  } else {
+    updateInLocalParticles(p);
+  }
+
+  return p;
+}
+
+Particle *Storage::moveIndexedParticle(ParticleList &dl, ParticleList &sl, int i) {
+  // see whether the arrays were resized; STL hack
+  Particle *dbegin = &dl.front();
+  Particle *sbegin = &sl.front();
+
+
+  dl.push_back(sl[i]);
+
+  int newSize = sl.size() - 1;
+
+  if (i != newSize) {
+    sl[i] = sl.back();
+  }
+
+  sl.resize(newSize);
+
+  Particle *dst = &dl.back();
+  Particle *src = &(sl[i]);
+
+  // fix up destination list
+  if (dbegin != &dl.front()) {
+    updateLocalParticles(dl);
+  } else {
+    updateInLocalParticles(dst);
+  }
+
+  // fix up resorted source list; due to moving, the last particle
+  // might have been moved to the position of the actually moved one
+  if (sbegin != &sl.front()) {
+    updateLocalParticles(sl);
+  } else if (i != newSize) {
+    updateInLocalParticles(src);
+  }
+
+  return dst;
+}
+
+void Storage::fetchParticles(Storage &old) {
+  LOG4ESPP_DEBUG(logger, "number of received cells = "
+          << old.getRealCells().size());
+
+  for (CellListIterator it(old.getRealCells()); it.isValid(); ++it) {
+    Particle &part = *it;
+    Cell *nc = mapPositionToCellClipped(part.position());
+
+    appendUnindexedParticle(nc->particles, part);
+  }
+
+  // update localParticles
+  for (CellList::Iterator it(realCells); it.isValid(); ++it) {
+    updateLocalParticles((*it)->particles);
+  }
+}
+
+void Storage::sendParticles(ParticleList &list, longint node) {
+  LOG4ESPP_DEBUG(logger, "send " << list.size() << " particles to " << node);
+
+  // pack for transport
+
+  OutBuffer &data = outBuffer;
+
+  data.reset();
+
+  int size = list.size();
+
+  data.write(size);
+
+  for (ParticleList::Iterator it(list); it.isValid(); ++it) {
+    removeFromLocalParticles(&(*it));
+    data.write(*it);
+  }
+
+  beforeSendParticles(list, data);     // this also takes care of AdResS AT Particles
+
+  list.clear();
+
+  // ... and send
+  data.send(node, STORAGE_COMM_TAG);
+
+  LOG4ESPP_DEBUG(logger, "done");
+}
+
+void Storage::recvParticles(ParticleList &list, longint node) {
+  LOG4ESPP_DEBUG(logger, "recv from " << node);
+
+  InBuffer &data = inBuffer;      // reuse storage buffer
+
+  data.recv(node, STORAGE_COMM_TAG);
+
+  // ... and unpack
+  int size;
+
+  data.read(size);
+
+  int curSize = list.size();
+
+  LOG4ESPP_DEBUG(logger, "got " << size << " particles, have " << curSize);
+
+  if (size > 0) {
+    list.resize(curSize + size);
+
+    for (int i = 0; i < size; ++i) {
+      Particle *p = &list[curSize + i];
+
+      data.read(*p);
+      updateInLocalParticles(p);
+    }
+
+    afterRecvParticles(list, data);     // this also takes care of AdResS AT Particles
+  }
+
+  LOG4ESPP_DEBUG(logger, "done");
+}
+
+void Storage::invalidateGhosts() {
+  for (CellListIterator it(getGhostCells()); it.isValid(); ++it) {
+    /* remove only ghosts from the hash if the localParticles hash
+       actually points to the ghost.  If there are local ghost cells
+       to implement pbc, the real particle will be the one accessible
+       via localParticles.
+     */
+    removeFromLocalParticles(&(*it), true);
+  }
+}
+
+void Storage::decompose() {
+  invalidateGhosts();
+  decomposeRealParticles();
+  exchangeGhosts();
+  onParticlesChanged();
+}
+
+void Storage::packPositionsEtc(OutBuffer &buf,Cell &_reals, int extradata, const
+    Real3D &shift) {
+  ParticleList &reals  = _reals.particles;
+
+
+  LOG4ESPP_DEBUG(logger, "pack data from reals in "
+          << (&_reals - getFirstCell()));
+  LOG4ESPP_DEBUG(logger, "also packing "
+          << ((extradata & DATA_PROPERTIES) ? "properties " : "")
+          << ((extradata & DATA_MOMENTUM) ? "momentum " : "")
+          << ((extradata & DATA_LOCAL) ? "local " : ""));
+  LOG4ESPP_DEBUG(logger, "positions are shifted by "
+          << shift[0] << "," << shift[1] << "," << shift[2]);
+
+  for (ParticleList::iterator src = reals.begin(), end = reals.end(); src != end; ++src) {
+    buf.write(*src, extradata, shift);
+  }
+}
+
+void Storage::unpackPositionsEtc(Cell &_ghosts, InBuffer &buf, int extradata) {
+  ParticleList &ghosts  = _ghosts.particles;
+
+
+  LOG4ESPP_DEBUG(logger, "unpack data to ghosts in "
+          << (&_ghosts - getFirstCell()));
+  LOG4ESPP_DEBUG(logger, "also unpacking "
+          << ((extradata & DATA_PROPERTIES) ? "properties " : "")
+          << ((extradata & DATA_MOMENTUM) ? "momentum " : "")
+          << ((extradata & DATA_LOCAL) ? "local " : ""));
+
+  for (ParticleList::iterator dst = ghosts.begin(), end = ghosts.end(); dst != end; ++dst) {
+    buf.read(*dst, extradata);
+
+    if (extradata & DATA_PROPERTIES) {
+      updateInLocalParticles(&(*dst), true);
+    }
+
+    dst->ghost() = 1;
+  }
+}
+
+void Storage::copyRealsToGhosts(Cell &_reals, Cell &_ghosts,int extradata,const
+    Real3D &shift) {
+  ParticleList &reals  = _reals.particles;
+  ParticleList &ghosts = _ghosts.particles;
+
+
+  LOG4ESPP_DEBUG(logger, "copy data from reals in "
+          << (&_reals - getFirstCell()) << " to ghosts in "
+          << (&_ghosts - getFirstCell()));
+  LOG4ESPP_DEBUG(logger, "also copying "
+          << ((extradata & DATA_PROPERTIES) ? "properties " : "")
+          << ((extradata & DATA_MOMENTUM) ? "momentum " : "")
+          << ((extradata & DATA_LOCAL) ? "local " : ""));
+  LOG4ESPP_DEBUG(logger, "positions are shifted by "
+          << shift[0] << "," << shift[1] << "," << shift[2]);
+
+  ghosts.resize(reals.size());
+
+  for (ParticleList::iterator src = reals.begin(), end = reals.end(), dst = ghosts.begin();
+      src != end; ++src, ++dst) {
+    dst->copyAsGhost(*src, extradata, shift);
+  }
+}
+
+void Storage::packForces(OutBuffer &buf, Cell &_ghosts) {
+  LOG4ESPP_DEBUG(logger, "pack ghost forces to buffer from cell "
+          << (&_ghosts - getFirstCell()));
+
+  ParticleList &ghosts = _ghosts.particles;
+
+  for (ParticleList::iterator src = ghosts.begin(), end = ghosts.end(); src != end; ++src) {
+    buf.write(src->particleForce());
+
+    LOG4ESPP_TRACE(logger, "from particle " << src->id() << ": packing force " << src->force());
+  }
+}
+
+void Storage::unpackForces(Cell &_reals, InBuffer &buf) {
+  LOG4ESPP_DEBUG(logger, "add forces from buffer to cell "
+          << (&_reals - getFirstCell()));
+
+  ParticleList &reals = _reals.particles;
+
+  for (ParticleList::iterator dst = reals.begin(), end = reals.end(); dst != end; ++dst) {
+    ParticleForce f;
+
+    buf.read(f);
+    LOG4ESPP_TRACE(logger, "for particle " << dst->id() << ": unpacking force " << f.force());
+    dst->particleForce() = f;
+  }
+}
+
+void Storage::unpackAndAddForces(Cell &_reals, InBuffer &buf) {
+  LOG4ESPP_DEBUG(logger, "add forces from buffer to cell "
+          << (&_reals - getFirstCell()));
+
+  ParticleList &reals = _reals.particles;
+
+  for (ParticleList::iterator dst = reals.begin(), end = reals.end(); dst != end; ++dst) {
+    ParticleForce f;
+
+    buf.read(f);
+    LOG4ESPP_TRACE(logger, "for particle " << dst->id() << ": unpacking force "
+                                           << f.f() << " and adding to " << dst->force());
+    dst->particleForce() += f;
+  }
+}
+
+void Storage::addGhostForcesToReals(Cell &_ghosts, Cell &_reals) {
+  LOG4ESPP_DEBUG(logger, "add forces from ghosts in cell "
+          << (&_ghosts - getFirstCell()) << " to reals in cell "
+          << (&_reals - getFirstCell()));
+
+  ParticleList &reals  = _reals.particles;
+  ParticleList &ghosts = _ghosts.particles;
+
+  for (ParticleList::iterator dst = reals.begin(), end = reals.end(), src = ghosts.begin();
+      dst != end; ++dst, ++src) {
+    LOG4ESPP_TRACE(logger, "for particle " << dst->id() << ": adding force "
+                                           << src->force() << " to " << dst->force());
+
+    dst->particleForce() += src->particleForce();
+  }
+}
+
+void Storage::clearSavedPositions() {
+  savedRealPositions.clear();
+  savedImages.clear();
+}
+
+void Storage::savePosition(size_t id) {
+  if (getSystemRef().comm->size() == 1) {
+    Particle *p = lookupRealParticle(id);
+
+    if (p) {
+      savedRealPositions[id] = p->position();
+      savedImages[id] = p->image();
+    }
+  } else {
+    esutil::Error err(getSystem()->comm);
+    stringstream msg;
+
+    msg << " At the moment it works only for one CPU. One can not store old positions"
+        " for several CPUs";
+    err.setException(msg.str());
+  }
+}
+
+void Storage::restorePositions() {
+  int count = 0;
+  int totCount = 0;
+
+
+  if (!savedRealPositions.empty()) {
+    for (map<size_t,Real3D>::iterator itr = savedRealPositions.begin(); itr !=
+        savedRealPositions.end(); ++itr) {
+      size_t id = itr->first;
+      Particle *p = lookupRealParticle(id);
+
+      if (p) {
+        p->position() = itr->second;
+      }
+    }
+
+    for (map<size_t,Int3D>::iterator itr = savedImages.begin(); itr != savedImages.end(); ++itr) {
+      size_t id = itr->first;
+      Particle *p = lookupRealParticle(id);
+
+      if (p) {
+        p->image() = itr->second;
+      }
+    }
+
+    count++;
+  }
+
+  mpi::all_reduce(*getSystem()->comm, count, totCount, std::plus<int>());
+
+  if (totCount == 0) {
+    esutil::Error err(getSystem()->comm);
+    stringstream msg;
+
+    msg << " There is nothing to restore. Check whether you saved positions";
+    err.setException(msg.str());
+  }
+}
+
+//////////////////////////////////////////////////
+// REGISTRATION WITH PYTHON
+//////////////////////////////////////////////////
+void Storage::registerPython() {
+  using namespace espressopp::python;
+  class_<Storage, boost::noncopyable>("storage_Storage", no_init)
+    .def("clearSavedPositions", &Storage::clearSavedPositions)
+    .def("savePosition", &Storage::savePosition)
+    .def("restorePositions", &Storage::restorePositions)
+    .def("addParticle", &Storage::addParticle, return_value_policy<reference_existing_object>())
+    .def("removeParticle", &Storage::removeParticle)
+    .def("removeAllParticles", &Storage::removeAllParticles)
+    .def("addAdrATParticle", &Storage::addAdrATParticle,
+      return_value_policy<reference_existing_object>())
+    .def("setFixedTuplesAdress", &Storage::setFixedTuplesAdress)
+
+  // .def("addParticle", &Storage::addParticle, return_value_policy< reference_existing_object >())
+    .def("lookupLocalParticle", &Storage::lookupLocalParticle,
+      return_value_policy<reference_existing_object>())
+    .def("lookupRealParticle", &Storage::lookupRealParticle,
+      return_value_policy<reference_existing_object>())
+    .def("decompose", &Storage::decompose)
+    .def("getRealParticleIDs", &Storage::getRealParticleIDs)
+    .add_property("system", &Storage::getSystem)
+  ;
+}
+} // namespace storage
+} // namespace espressopp

--- a/src/storage/Storage.hpp
+++ b/src/storage/Storage.hpp
@@ -1,24 +1,24 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
+
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 // ESPP_CLASS
 #ifndef _STORAGE_STORAGE_HPP
@@ -26,7 +26,8 @@
 #include "python.hpp"
 #include "SystemAccess.hpp"
 #include "mpi.hpp"
-//#include <vector>
+
+// #include <vector>
 #include <boost/unordered_map.hpp>
 #include <boost/signals2.hpp>
 #include <list>
@@ -37,401 +38,400 @@
 #include "types.hpp"
 
 namespace espressopp {
+namespace storage {
+/** represents the particle storage of one system. */
+class Storage : public SystemAccess {
+public:
+  typedef boost::unordered_map<longint, Particle *> IdParticleMap;
+  typedef std::list<Particle> ParticleListAdr;
 
-  namespace storage {
-    /** represents the particle storage of one system. */
-    class Storage : public SystemAccess {
-    public:
-      typedef boost::unordered_map <longint, Particle*> IdParticleMap;
-      typedef std::list<Particle> ParticleListAdr;
-
-      Storage(shared_ptr<class System> system);
-      virtual ~Storage();
-
-      /** Scale Volume, only for Storage. It scales only the particle coord. */
-      void scaleVolume(real s);
-      /** Scale Volume, only for Storage. It scales only the particle coord. Anisotropic case */
-      void scaleVolume(Real3D s);
-      
-      /** Scale Volume for derived classes, pS define the particle coordinates scaling*/
-      virtual void scaleVolume(real s, bool pS) = 0;
-      /** Scale Volume for derived classes, pS define the particle coordinates scaling.
-       *  Anisotropic case */
-      virtual void scaleVolume(Real3D s, bool pS) = 0;
-      
-      /** It should be used at the place where is the possibility of cell size<cutoff+skin*/
-      virtual void cellAdjust() = 0;
-      
-      /** It should return cell grid as an integer vector*/
-      virtual Int3D getInt3DCellGrid() =0;
-
-      virtual real getLocalBoxXMin() =0;
-      virtual real getLocalBoxYMin() =0;
-      virtual real getLocalBoxZMin() =0;
-      virtual real getLocalBoxXMax() =0;
-      virtual real getLocalBoxYMax() =0;
-      virtual real getLocalBoxZMax() =0;
-
-      /** add a particle with given id and position. Note that this is a
-	  local operation, and therefore cannot check whether a particle
-	  with the given id already exists.  This is left to the parallel
-	  front end.
-      */
-      Particle* addParticle(longint id, const Real3D& pos);
-
-      // remove particle from the system
-      int removeParticle(longint id);
-      
-      void removeAllParticles();
-      
-      /* add an adress AT particle with given id, position and it's VP position.
-      Adress AT paticles are located only in localAdrATParticles map.
-      Note that this is a local operation, and therefore cannot check whether a particle
-      with the given id already exists.  This is left to the parallel
-      front end.
-      */
-      Particle* addAdrATParticle(longint id, const Real3D& pos, const Real3D& VPpos);
-
-      // similar as above, but only called from fixedtuplelist when rebuilding the tuples
-      Particle* addAdrATParticleFTPL(Particle n);
-
-      // remove an AdResS AT particle - it is removed from the vector and from the map
-      // called from FTPL
-      void removeAdrATParticle(longint id);
-
-
-      //Particle* addParticle(longint id, const Real3D& pos, int type);
-
-      /** lookup whether data for a given particle is available on this node,
-	  either as real or as ghost particle. */
-      Particle* lookupLocalParticle(longint id) {
-        IdParticleMap::iterator it = localParticles.find(id);
-        return (it != localParticles.end()) ? it->second : 0;
-      }
-
-      Particle* lookupGhostParticle(longint id) {
-        IdParticleMap::iterator it = localParticles.find(id);
-        return (it != localParticles.end() && it->second->ghost() ) ? it->second : 0;
-      }
-
-      /** Lookup whether data for a given particle is available on this node. 
-       \return 0 if the particle wasn't available, the pointer to the Particle, if it was. */
-      /*
-      Particle* lookupRealParticle(longint id) {
-        IdParticleMap::iterator it = localParticles.find(id);
-        return (it != localParticles.end() && !(it->second->ghost())) ? it->second : 0;
-      }*/
-
-
-      // same as above, used to make PDBs with adress particles
-      // TODO find another solution
-      /** Lookup whether data for a given particle is available on this node.
-      \return 0 if the particle wasn't available, the pointer to the Particle, if it was. */
-      Particle* lookupRealParticle(longint id) {
-        IdParticleMap::iterator it = localParticles.find(id);
-
-        // for AdResS
-        if (it != localParticles.end() && !(it->second->ghost())) {
-            return it->second;
-        }
-        else {
-            return lookupAdrATParticle(id);
-        }
-      }
-
-
-      /** Lookup whether data for a given adress real AT particle is available on this node.
-      \return 0 if the particle wasn't available, the pointer to the Particle, if it was. */
-      Particle* lookupAdrATParticle(longint id) {
-        IdParticleMap::iterator it = localAdrATParticles.find(id);
-        return (it != localAdrATParticles.end()) ? it->second : 0;
-      }
-
-
-
-      /// get number of real particles on this node
-      longint getNRealParticles() const;
-      
-    // returns number of all particles real and ghost
-      longint getNLocalParticles() const;
-    // returns number of ghosts
-      longint getNGhostParticles() const;
-      //returns number of atomistic adress particles
-      longint getNAdressParticles() const;
-
-      /** insert the particles in the given storage into the current one.
-	  This is mainly used to switch from one storage to another.
-      */
-      void fetchParticles(Storage &);
-
-      CellList &getLocalCells() { return localCells; }
-      CellList &getRealCells()  { return realCells;  }
-      CellList &getGhostCells() { return ghostCells; }
-
-      python::list getRealParticleIDs();
-
-      const Cell* getFirstCell() const { return &(cells[0]); }
-
-      /** map a position to a valid cell on this node. Used for AdResS */
-      virtual Cell* mapPositionToCell(const Real3D& pos) = 0;
-
-      /** map a position to a valid cell on this node.  If the position
-	  is outside the domain of this node, return the cell inside the
-	  domain that is closest to the position. */
-      virtual Cell* mapPositionToCellClipped(const Real3D& pos) = 0;
-
-      /** map a position to a cell on this node.  If the position is
-	  outside the domain of this node, return 0. */
-      virtual Cell* mapPositionToCellChecked(const Real3D& pos) = 0;
-
-      /** (Re-)Decompose the system, i.e. redistribute the particles
-	  to the correct processors.
-
-	  This should be called by any parallel algorithm that works
-	  with the particle data at the beggining of the
-	  algorithm. Otherwise, it is not guaranteed that the
-	  particles are at the correct processor.
-
-	  This should be called by the integrator instead of
-	  updateGhosts() whenever a particle might have moved more
-	  than a given skin. The skin is not an issue of the storage,
-	  but all algorithms using the particle data need to be aware
-	  that particles might be located up to skin away from their
-	  current cell.
-      */
-      virtual void decompose();
-
-      /** copy minimal information from the real to the ghost
-	  particles.  Typically this copies the positions and maybe the
-	  velocities from real to ghost particles. Particle order is
-	  unaffected by this method.
-	
-	  Storage implementations should exchange particle positions,
-	  plus data fields as indicated by dataOfUpdateGhosts.
-      */
-      virtual void updateGhosts() = 0;
-
-
-      /**
-       * Copies just velocites of real particles to their ghosts.
-       * Needed for DPD thermostat for example.
-       */
-      virtual void updateGhostsV() = 0;
-
-      /** read back forces from ghost particles by two-sided
-	  communication.
-
-	  Storage implementations should only gather forces here.
-	  Note that forces are not stored back, but are additive!
-      */
-      virtual void collectGhostForces() = 0;
-
-      /** Ths signal will be called whenever the storage was modified
-	  such that particle pointers have become invalid, e.g. at the
-	  end of decompose().  Classes that connect to this signal can
-	  update pointers to the particles in the call via
-	  lookupLocalParticle() and lookupRealParticle().
-       */
-      boost::signals2::signal0 <void> onParticlesChanged;
-      boost::signals2::signal2 <void, ParticleList&, class OutBuffer&> 
-        beforeSendParticles;
-      boost::signals2::signal2 <void, ParticleList&, class InBuffer&> 
-        afterRecvParticles;
-
-
-      // for AdResS
-      // this is exactly the same as onParticlesChanged, but only used to rebuild tuples
-      boost::signals2::signal0 <void> onTuplesChanged;
-
-
-      // for AdResS
-      void setFixedTuplesAdress(shared_ptr<FixedTupleListAdress> _fixedtupleList){
-          fixedtupleList = _fixedtupleList;
-      }
-      shared_ptr<FixedTupleListAdress> getFixedTuples() { return fixedtupleList; }
-      ParticleList&    getAdrATParticles()  { return AdrATParticles; }
-      //ParticleListAdr& getAdrATParticlesG() { return AdrATParticlesG; }
-      std::list<ParticleList>& getAdrATParticlesG() { return AdrATParticlesG; }
-
-
-      /* variant for python that ignores the return value */
-      bool pyAddParticle(longint id, const Real3D& pos);
-
-      static void registerPython();
-
-    protected:
-      /** Check whether a particle belongs to this node. */
-      virtual bool checkIsRealParticle(longint id, 
-				       const Real3D& pos) = 0;
-
-      /** Decompose the real particles such that they are at the
-	  correct processor. This should _not_ touch the ghosts.
-	  Called by decompose.
-      */
-      virtual void decomposeRealParticles() = 0;
-
-      /** used by the Storage to initiate the exchange of the full ghost
-	  information after decomposition.
-
-	  Storage implementations should exchange particle positions,
-	  plus data fields as indicated by dataOfExchangeGhosts.
-      */
-      virtual void exchangeGhosts() = 0;
-
-      /** bitmask: which extra data elements to in- or exclude from
-	  ghost sending
-      */
-      enum ExtraDataElements {
-        DATA_PROPERTIES=1,
-        DATA_MOMENTUM=2,
-        DATA_LOCAL=4
-      };
-
-      /** for the moment, these are constants, defining what to transfer
-	  during ghost communications.
-      */
-      static const int dataOfUpdateGhosts;
-      static const int dataOfExchangeGhosts;
-
-      /// remove ghost particles from the localParticles index
-      virtual void invalidateGhosts();
-
-      /** pack real particle data for sending. At least positions, maybe
-	  shifted, and possibly additional data according to extradata.
-
-	  @param shift how to adjust the positions of the particles when sending
-      */
-      virtual void packPositionsEtc(class OutBuffer& buf,
-			    Cell &reals, int extradata, const Real3D& shift);
-
- 
-      /** unpack received data for ghosts. */
-      virtual void unpackPositionsEtc(Cell &ghosts, class InBuffer &buf, int extradata);
-
-      /** copy specified data elements between a real cell and one of its ghosts
-
-	  @param shift how to adjust the positions of the particles when sending
-      */
-      virtual void copyRealsToGhosts(Cell &reals, Cell &ghosts,
-			     int extradata,
-			     const Real3D& shift);
-
-      //void copyGhostTuples(Particle& src, Particle& dst, int extradata, const Real3D& shift);
-
-      /** pack ghost forces for sending. */
-      virtual void packForces(OutBuffer& buf, Cell &ghosts);
-      /** unpack received ghost forces. This one ADDS, and is most likely, what you need. */
-      virtual void unpackAndAddForces(Cell &reals, class InBuffer &buf);
-      /** unpack received ghost forces. This one OVERWRITES, and is probably what you don't need. */
-      void unpackForces(Cell &reals, class InBuffer &buf);
-      virtual void addGhostForcesToReals(Cell &ghosts, Cell &reals);
-
-      /** send particles of a cell to another node, and empty the cell
-	  locally. The operation is blocking: the operation
-	  will wait until the particles really have been received.
-
-	  The particles are not removed from localParticles!
-      */
-      void sendParticles(ParticleList &, longint node);
-
-      /** receive particles from another node. The particles are added
-	  to the given cell. The operation is blocking: the
-	  operation will wait until the particles have been received.
-
-	  The particles are not added to localParticles! Moreover, the
-	  cell might be resized, invalidating all particles
-	  localParticles entries. Therefore, if the receiving cell is
-	  the final destination of the particles, call
-	  updateLocalParticles after recvParticles.
-      */
-      void recvParticles(ParticleList &, longint node);
-
-      // update the id->local particle map for the given cell
-      void updateLocalParticles(ParticleList &, bool adress = false);
-
-      /* remove this particle from local particles.  If weak is true,
-	 the information is only removed if the pointer is actually at
-	 the current position. This is used for ghosts, which should
-	 not overwrite real particle pointers.
-       */
-      void removeFromLocalParticles(Particle*, bool weak = false);
-
-
-      /* update information for this particle from local particles. If weak is true,
-	 the information is only updated if no information is present yet. This is used
-	 for ghosts, which should not overwrite real particle pointers.
-       */
-      void updateInLocalParticles(Particle*, bool weak = false);
-
-      void updateInLocalAdrATParticles(Particle *);
-
-      // reserve space for nCells cells
-      void resizeCells(longint nCells);
-
-      // append a particle to a list, without updating localParticles
-      Particle* appendUnindexedParticle(ParticleList &, Particle &);
-
-      // append a ghost AT adress particle to a list, without updating AdrATParticles
-      //Particle* appendUnindexedAdrParticle(ParticleListAdr &, Particle &);
-      Particle* appendUnindexedAdrParticle(ParticleList &, Particle &);
-
-
-      void appendParticleListToGhosts(ParticleList &l);
-
-
-      // append a particle to a list, updating localParticles
-      Particle* appendIndexedParticle(ParticleList &, Particle &);
-
-      // move a particle from one list to another, updating localParticles
-      Particle* moveIndexedParticle(ParticleList &dst, ParticleList &src, int srcpos);
-
-      /** here the local particles are actually stored */
-      LocalCellList cells;
-
-      /** list of real cells */
-      CellList realCells;
-      /** list of ghost cells */
-      CellList ghostCells;
-      /** all cells on this CPU. Just an index of the cells */
-      CellList localCells;
-
-      static LOG4ESPP_DECL_LOGGER(logger);
-
-      InBuffer inBuffer;
-      OutBuffer outBuffer;
-
-
-      // used for AdResS
-      shared_ptr<FixedTupleListAdress> fixedtupleList;
-      void clearAdrATParticlesG() {
-          //std::cout << "size of AdrATParticlesG: " << AdrATParticlesG.size() << ", clearing... \n";
-          AdrATParticlesG.clear();
-          //std::cout << " new size of AdrATParticlesG: " << AdrATParticlesG.size() << "\n";
-
-      }
-      
-      void savePosition(size_t id);
-      void restorePositions();
-      void clearSavedPositions();
-
-    private:
-      // map particle id to Particle * for all particles on this node
-      boost::unordered_map<longint, Particle*> localParticles;
-
-
-      // AdResS atomistic particles (they are not stored in cells!)
-      ParticleList AdrATParticles; // local atomistic real adress particles
-      //ParticleListAdr AdrATParticlesG; // ghosts, use list instead of vector to avoid memory reallocation
-      std::list<ParticleList> AdrATParticlesG;
-
-
-      // map particle id to Particle * for all adress real AT particles on this node
-      boost::unordered_map<longint, Particle*> localAdrATParticles;
-      
-      // we need to snap shot the particle coordinates
-      std::map< size_t, Real3D > savedRealPositions;
-      std::map< size_t, Int3D > savedImages;
-    };
+  Storage(shared_ptr<class System> system);
+
+  virtual ~Storage();
+
+  /** Scale Volume, only for Storage. It scales only the particle coord. */
+  void scaleVolume(real s);
+
+  /** Scale Volume, only for Storage. It scales only the particle coord. Anisotropic case */
+  void scaleVolume(Real3D s);
+
+  /** Scale Volume for derived classes, pS define the particle coordinates scaling*/
+  virtual void scaleVolume(real s, bool pS) = 0;
+
+  /** Scale Volume for derived classes, pS define the particle coordinates scaling.
+   *  Anisotropic case */
+  virtual void scaleVolume(Real3D s, bool pS) = 0;
+
+  /** It should be used at the place where is the possibility of cell size<cutoff+skin*/
+  virtual void cellAdjust() = 0;
+
+  /** It should return cell grid as an integer vector*/
+  virtual Int3D getInt3DCellGrid() = 0;
+
+  virtual real getLocalBoxXMin() = 0;
+  virtual real getLocalBoxYMin() = 0;
+  virtual real getLocalBoxZMin() = 0;
+  virtual real getLocalBoxXMax() = 0;
+  virtual real getLocalBoxYMax() = 0;
+  virtual real getLocalBoxZMax() = 0;
+
+  /** add a particle with given id and position. Note that this is a
+     local operation, and therefore cannot check whether a particle
+     with the given id already exists.  This is left to the parallel
+     front end.
+   */
+  Particle *addParticle(longint id, const Real3D &pos);
+
+  // remove particle from the system
+  int removeParticle(longint id);
+
+  void removeAllParticles();
+
+  /* add an adress AT particle with given id, position and it's VP position.
+     Adress AT paticles are located only in localAdrATParticles map.
+     Note that this is a local operation, and therefore cannot check whether a particle
+     with the given id already exists.  This is left to the parallel
+     front end.
+   */
+  Particle *addAdrATParticle(longint id, const Real3D &pos, const Real3D &VPpos);
+
+  // similar as above, but only called from fixedtuplelist when rebuilding the tuples
+  Particle *addAdrATParticleFTPL(Particle n);
+
+  // remove an AdResS AT particle - it is removed from the vector and from the map
+  // called from FTPL
+  void removeAdrATParticle(longint id);
+
+  // Particle* addParticle(longint id, const Real3D& pos, int type);
+
+  /** lookup whether data for a given particle is available on this node,
+     either as real or as ghost particle. */
+  Particle *lookupLocalParticle(longint id) {
+    IdParticleMap::iterator it = localParticles.find(id);
+
+    return (it != localParticles.end()) ? it->second : 0;
   }
-}
+
+  Particle *lookupGhostParticle(longint id) {
+    IdParticleMap::iterator it = localParticles.find(id);
+
+    return (it != localParticles.end() && it->second->ghost()) ? it->second : 0;
+  }
+
+  /** Lookup whether data for a given particle is available on this node.
+     \return 0 if the particle wasn't available, the pointer to the Particle, if it was. */
+
+  /*
+     Particle* lookupRealParticle(longint id) {
+     IdParticleMap::iterator it = localParticles.find(id);
+     return (it != localParticles.end() && !(it->second->ghost())) ? it->second : 0;
+     }*/
+
+  // same as above, used to make PDBs with adress particles
+  // TODO find another solution
+
+  /** Lookup whether data for a given particle is available on this node.
+     \return 0 if the particle wasn't available, the pointer to the Particle, if it was. */
+  Particle *lookupRealParticle(longint id) {
+    IdParticleMap::iterator it = localParticles.find(id);
+
+    // for AdResS
+    if ((it != localParticles.end()) && !(it->second->ghost())) {
+      return it->second;
+    } else   {
+      return lookupAdrATParticle(id);
+    }
+  }
+
+  /** Lookup whether data for a given adress real AT particle is available on this node.
+     \return 0 if the particle wasn't available, the pointer to the Particle, if it was. */
+  Particle *lookupAdrATParticle(longint id) {
+    IdParticleMap::iterator it = localAdrATParticles.find(id);
+
+    return (it != localAdrATParticles.end()) ? it->second : 0;
+  }
+
+  /// get number of real particles on this node
+  longint getNRealParticles() const;
+
+  // returns number of all particles real and ghost
+  longint getNLocalParticles() const;
+
+  // returns number of ghosts
+  longint getNGhostParticles() const;
+
+  // returns number of atomistic adress particles
+  longint getNAdressParticles() const;
+
+  /** insert the particles in the given storage into the current one.
+     This is mainly used to switch from one storage to another.
+   */
+  void fetchParticles(Storage &);
+
+  CellList &getLocalCells() {return localCells; }
+
+  CellList &getRealCells()  {return realCells;  }
+
+  CellList &getGhostCells() {return ghostCells; }
+
+  python::list getRealParticleIDs();
+
+  const Cell *getFirstCell() const {return &(cells[0]); }
+
+  /** map a position to a valid cell on this node. Used for AdResS */
+  virtual Cell *mapPositionToCell(const Real3D &pos) = 0;
+
+  /** map a position to a valid cell on this node.  If the position
+     is outside the domain of this node, return the cell inside the
+     domain that is closest to the position. */
+  virtual Cell *mapPositionToCellClipped(const Real3D &pos) = 0;
+
+  /** map a position to a cell on this node.  If the position is
+     outside the domain of this node, return 0. */
+  virtual Cell *mapPositionToCellChecked(const Real3D &pos) = 0;
+
+  /** (Re-)Decompose the system, i.e. redistribute the particles
+     to the correct processors.
+
+     This should be called by any parallel algorithm that works
+     with the particle data at the beggining of the
+     algorithm. Otherwise, it is not guaranteed that the
+     particles are at the correct processor.
+
+     This should be called by the integrator instead of
+     updateGhosts() whenever a particle might have moved more
+     than a given skin. The skin is not an issue of the storage,
+     but all algorithms using the particle data need to be aware
+     that particles might be located up to skin away from their
+     current cell.
+   */
+  virtual void decompose();
+
+  /** copy minimal information from the real to the ghost
+     particles.  Typically this copies the positions and maybe the
+     velocities from real to ghost particles. Particle order is
+     unaffected by this method.
+
+     Storage implementations should exchange particle positions,
+     plus data fields as indicated by dataOfUpdateGhosts.
+   */
+  virtual void updateGhosts() = 0;
+
+  /**
+   * Copies just velocites of real particles to their ghosts.
+   * Needed for DPD thermostat for example.
+   */
+  virtual void updateGhostsV() = 0;
+
+  /** read back forces from ghost particles by two-sided
+     communication.
+
+     Storage implementations should only gather forces here.
+     Note that forces are not stored back, but are additive!
+   */
+  virtual void collectGhostForces() = 0;
+
+  /** Ths signal will be called whenever the storage was modified
+     such that particle pointers have become invalid, e.g. at the
+     end of decompose().  Classes that connect to this signal can
+     update pointers to the particles in the call via
+     lookupLocalParticle() and lookupRealParticle().
+   */
+  boost::signals2::signal0<void> onParticlesChanged;
+  boost::signals2::signal2<void, ParticleList &, class OutBuffer &>
+  beforeSendParticles;
+  boost::signals2::signal2<void, ParticleList &, class InBuffer &>
+  afterRecvParticles;
+
+  // for AdResS
+  // this is exactly the same as onParticlesChanged, but only used to rebuild tuples
+  boost::signals2::signal0<void> onTuplesChanged;
+
+  // for AdResS
+  void setFixedTuplesAdress(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+    fixedtupleList = _fixedtupleList;
+  }
+
+  shared_ptr<FixedTupleListAdress> getFixedTuples() {return fixedtupleList; }
+
+  ParticleList &getAdrATParticles()  {return AdrATParticles; }
+
+  // ParticleListAdr& getAdrATParticlesG() { return AdrATParticlesG; }
+  std::list<ParticleList> &getAdrATParticlesG() {return AdrATParticlesG; }
+
+  /* variant for python that ignores the return value */
+  bool pyAddParticle(longint id, const Real3D &pos);
+
+  static void registerPython();
+
+protected:
+  /** Check whether a particle belongs to this node. */
+  virtual bool checkIsRealParticle(longint id,const Real3D &pos) = 0;
+
+  /** Decompose the real particles such that they are at the
+     correct processor. This should _not_ touch the ghosts.
+     Called by decompose.
+   */
+  virtual void decomposeRealParticles() = 0;
+
+  /** used by the Storage to initiate the exchange of the full ghost
+     information after decomposition.
+
+     Storage implementations should exchange particle positions,
+     plus data fields as indicated by dataOfExchangeGhosts.
+   */
+  virtual void exchangeGhosts() = 0;
+
+  /** bitmask: which extra data elements to in- or exclude from
+     ghost sending
+   */
+  enum ExtraDataElements {
+    DATA_PROPERTIES = 1,
+    DATA_MOMENTUM = 2,
+    DATA_LOCAL = 4
+  };
+
+  /** for the moment, these are constants, defining what to transfer
+     during ghost communications.
+   */
+  static const int dataOfUpdateGhosts;
+  static const int dataOfExchangeGhosts;
+
+  /// remove ghost particles from the localParticles index
+  virtual void invalidateGhosts();
+
+  /** pack real particle data for sending. At least positions, maybe
+     shifted, and possibly additional data according to extradata.
+
+     @param shift how to adjust the positions of the particles when sending
+   */
+  virtual void packPositionsEtc(class OutBuffer &buf,
+        Cell &reals, int extradata, const Real3D &shift);
+
+  /** unpack received data for ghosts. */
+  virtual void unpackPositionsEtc(Cell & ghosts, class InBuffer & buf, int extradata);
+
+  /** copy specified data elements between a real cell and one of its ghosts
+
+     @param shift how to adjust the positions of the particles when sending
+   */
+  virtual void copyRealsToGhosts(Cell &reals, Cell &ghosts,int extradata,const Real3D &shift);
+
+  // void copyGhostTuples(Particle& src, Particle& dst, int extradata, const Real3D& shift);
+
+  /** pack ghost forces for sending. */
+  virtual void packForces(OutBuffer &buf, Cell &ghosts);
+
+  /** unpack received ghost forces. This one ADDS, and is most likely, what you need. */
+  virtual void unpackAndAddForces(Cell & reals, class InBuffer & buf);
+
+  /** unpack received ghost forces. This one OVERWRITES, and is probably what you don't need. */
+  void unpackForces(Cell & reals, class InBuffer & buf);
+  virtual void addGhostForcesToReals(Cell &ghosts, Cell &reals);
+
+  /** send particles of a cell to another node, and empty the cell
+     locally. The operation is blocking: the operation
+     will wait until the particles really have been received.
+
+     The particles are not removed from localParticles!
+   */
+  void sendParticles(ParticleList &, longint node);
+
+  /** receive particles from another node. The particles are added
+     to the given cell. The operation is blocking: the
+     operation will wait until the particles have been received.
+
+     The particles are not added to localParticles! Moreover, the
+     cell might be resized, invalidating all particles
+     localParticles entries. Therefore, if the receiving cell is
+     the final destination of the particles, call
+     updateLocalParticles after recvParticles.
+   */
+  void recvParticles(ParticleList &, longint node);
+
+  // update the id->local particle map for the given cell
+  void updateLocalParticles(ParticleList &, bool adress = false);
+
+  /* remove this particle from local particles.  If weak is true,
+     the information is only removed if the pointer is actually at
+     the current position. This is used for ghosts, which should
+     not overwrite real particle pointers.
+   */
+  void removeFromLocalParticles(Particle *, bool weak = false);
+
+  /* update information for this particle from local particles. If weak is true,
+     the information is only updated if no information is present yet. This is used
+     for ghosts, which should not overwrite real particle pointers.
+   */
+  void updateInLocalParticles(Particle *, bool weak = false);
+
+  void updateInLocalAdrATParticles(Particle *);
+
+  // reserve space for nCells cells
+  void resizeCells(longint nCells);
+
+  // append a particle to a list, without updating localParticles
+  Particle *appendUnindexedParticle(ParticleList &, Particle &);
+
+  // append a ghost AT adress particle to a list, without updating AdrATParticles
+  // Particle* appendUnindexedAdrParticle(ParticleListAdr &, Particle &);
+  Particle *appendUnindexedAdrParticle(ParticleList &, Particle &);
+
+  void appendParticleListToGhosts(ParticleList &l);
+
+  // append a particle to a list, updating localParticles
+  Particle *appendIndexedParticle(ParticleList &, Particle &);
+
+  // move a particle from one list to another, updating localParticles
+  Particle *moveIndexedParticle(ParticleList &dst, ParticleList &src, int srcpos);
+
+  /** here the local particles are actually stored */
+  LocalCellList cells;
+
+  /** list of real cells */
+  CellList realCells;
+
+  /** list of ghost cells */
+  CellList ghostCells;
+
+  /** all cells on this CPU. Just an index of the cells */
+  CellList localCells;
+
+  static LOG4ESPP_DECL_LOGGER(logger);
+
+  InBuffer inBuffer;
+  OutBuffer outBuffer;
+
+  // used for AdResS
+  shared_ptr<FixedTupleListAdress> fixedtupleList;
+  void clearAdrATParticlesG() {
+    // std::cout << "size of AdrATParticlesG: " << AdrATParticlesG.size() << ", clearing... \n";
+    AdrATParticlesG.clear();
+
+    // std::cout << " new size of AdrATParticlesG: " << AdrATParticlesG.size() << "\n";
+  }
+
+  void savePosition(size_t id);
+  void restorePositions();
+  void clearSavedPositions();
+
+private:
+  // map particle id to Particle * for all particles on this node
+  boost::unordered_map<longint, Particle *> localParticles;
+
+  // AdResS atomistic particles (they are not stored in cells!)
+  ParticleList AdrATParticles;     // local atomistic real adress particles
+  // ParticleListAdr AdrATParticlesG; // ghosts, use list instead of vector to avoid memory
+  // reallocation
+  std::list<ParticleList> AdrATParticlesG;
+
+  // map particle id to Particle * for all adress real AT particles on this node
+  boost::unordered_map<longint, Particle *> localAdrATParticles;
+
+  // we need to snap shot the particle coordinates
+  std::map<size_t, Real3D> savedRealPositions;
+  std::map<size_t, Int3D> savedImages;
+};
+} // namespace storage
+} // namespace espressopp
 #endif

--- a/src/storage/bindings.cpp
+++ b/src/storage/bindings.cpp
@@ -1,24 +1,24 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
+
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "DomainDecompositionNonBlocking.hpp"
 #include "DomainDecompositionAdress.hpp"
@@ -27,12 +27,12 @@
 #include "bindings.hpp"
 
 namespace espressopp {
-  namespace storage {
-    void registerPython() {
-      Storage::registerPython();
-      DomainDecomposition::registerPython();
-      DomainDecompositionNonBlocking::registerPython();
-      DomainDecompositionAdress::registerPython();
-    }
-  }
+namespace storage {
+void registerPython() {
+  Storage::registerPython();
+  DomainDecomposition::registerPython();
+  DomainDecompositionNonBlocking::registerPython();
+  DomainDecompositionAdress::registerPython();
+}
+}
 }

--- a/src/storage/bindings.hpp
+++ b/src/storage/bindings.hpp
@@ -1,30 +1,30 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
+
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef _STORAGE_BINDINGS_HPP
 #define _STORAGE_BINDINGS_HPP
 namespace espressopp {
-  namespace storage {
-    void registerPython();
-  }
+namespace storage {
+void registerPython();
+}
 }
 #endif

--- a/src/storage/unittest/PTestDomainDecomposition.cpp
+++ b/src/storage/unittest/PTestDomainDecomposition.cpp
@@ -1,24 +1,24 @@
 /*
-  Copyright (C) 2012,2013
+   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
-  Copyright (C) 2008,2009,2010,2011
+   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
-  This file is part of ESPResSo++.
-  
-  ESPResSo++ is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-  
-  ESPResSo++ is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-  
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
-*/
+
+   This file is part of ESPResSo++.
+
+   ESPResSo++ is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ESPResSo++ is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #define PARALLEL_TEST_MODULE DomainDecomposition
 #include "ut.hpp"
@@ -39,9 +39,10 @@ using namespace espressopp::esutil;
 using namespace espressopp::storage;
 using namespace espressopp::iterator;
 
-struct LoggingFixture {  
-  LoggingFixture() { 
+struct LoggingFixture {
+  LoggingFixture() {
     LOG4ESPP_CONFIGURE();
+
     //    log4espp::Logger::getRoot().setLevel(log4espp::Logger::TRACE);
   }
 };
@@ -49,50 +50,53 @@ struct LoggingFixture {
 BOOST_GLOBAL_FIXTURE(LoggingFixture);
 
 struct Fixture {
-  shared_ptr< DomainDecomposition > domdec;
-  shared_ptr< System > system;
+  shared_ptr<DomainDecomposition> domdec;
+  shared_ptr<System> system;
 
   Fixture() {
     Real3D boxL(1.0, 2.0, 3.0);
     Int3D nodeGrid;
     int nodes = mpiWorld->size();
+
+
     for (int i = 0; i < 3; ++i) {
       // try to get 3 or 2 CPUs per column
       // otherwise take all nodes that are left
       if (nodes % 3 == 0) {
-	nodes /= 3; nodeGrid[i] = 3;
+        nodes /= 3; nodeGrid[i] = 3;
       } else if  (nodes % 2 == 0) {
-	nodes /= 2; nodeGrid[i] = 2;
+        nodes /= 2; nodeGrid[i] = 2;
       } else {
-	nodeGrid[i] = nodes; nodes = 1;
+        nodeGrid[i] = nodes; nodes = 1;
       }
     }
+
     Int3D cellGrid(1, 2, 3);
-    system = make_shared< System >();
-    system->rng = make_shared< esutil::RNG >();
-    system->bc = make_shared< bc::OrthorhombicBC >(system->rng, boxL);
-    domdec = make_shared< DomainDecomposition >(system,
-    						nodeGrid,
-    						cellGrid);
+
+    system = make_shared<System>();
+    system->rng = make_shared<esutil::RNG>();
+    system->bc = make_shared<bc::OrthorhombicBC>(system->rng, boxL);
+    domdec = make_shared<DomainDecomposition>(system,
+      nodeGrid,
+      cellGrid);
   }
 };
 
 BOOST_AUTO_TEST_CASE(addAndLookup) {
-  shared_ptr< DomainDecomposition > domdec;
-  shared_ptr< System > system;
+  shared_ptr<DomainDecomposition> domdec;
+  shared_ptr<System> system;
 
   Real3D boxL(1.0);
   Int3D nodeGrid(mpiWorld->size(), 1, 1);
   Int3D cellGrid(1);
 
-  system = make_shared< System >();
-  system->rng = make_shared< esutil::RNG >();
-  system->bc = make_shared< bc::OrthorhombicBC >(system->rng, boxL);
-  domdec = make_shared< DomainDecomposition >(system,
-					      nodeGrid,
-					      cellGrid);
+  system = make_shared<System>();
+  system->rng = make_shared<esutil::RNG>();
+  system->bc = make_shared<bc::OrthorhombicBC>(system->rng, boxL);
+  domdec = make_shared<DomainDecomposition>(system,
+    nodeGrid,
+    cellGrid);
 
-  
   // create a single particle
   Real3D pos(0.5, 0.5, 0.5);
   Particle *p = domdec->addParticle(0, pos);
@@ -101,119 +105,134 @@ BOOST_AUTO_TEST_CASE(addAndLookup) {
   BOOST_CHECK_EQUAL(domdec->lookupRealParticle(0), p);
 }
 
-BOOST_AUTO_TEST_CASE(constructDomainDecomposition) 
-{
+BOOST_AUTO_TEST_CASE(constructDomainDecomposition) {
   Real3D boxL(1.0, 2.0, 3.0);
-  shared_ptr< System > system;
-  system = make_shared< System >();
-  system->rng = make_shared< esutil::RNG >();
-  system->bc = make_shared< bc::OrthorhombicBC >(system->rng, boxL);
 
- for(int i = 0; i < 3; ++i) {
+
+  shared_ptr<System> system;
+  system = make_shared<System>();
+  system->rng = make_shared<esutil::RNG>();
+  system->bc = make_shared<bc::OrthorhombicBC>(system->rng, boxL);
+
+  for (int i = 0; i < 3; ++i) {
     Int3D nodeGrid(1);
     Int3D cellGrid(1);
+
     nodeGrid[i] = 0;
     BOOST_CHECK_THROW(DomainDecomposition
-		      (system, nodeGrid, cellGrid),
-		      NodeGridIllegal);
+          (system, nodeGrid, cellGrid),
+        NodeGridIllegal);
   }
 
-  for(int i = 0; i < 3; ++i) {
+  for (int i = 0; i < 3; ++i) {
     Int3D nodeGrid(mpiWorld->size(), 1, 1);
     Int3D cellGrid(1);
+
     cellGrid[i] = 0;
     BOOST_CHECK_THROW(DomainDecomposition
-		      (system, nodeGrid, cellGrid),
-		      CellGridIllegal);
+          (system, nodeGrid, cellGrid),
+        CellGridIllegal);
   }
 
   {
     Int3D nodeGrid(mpiWorld->size(), 2, 1);
     Int3D cellGrid(1);
+
     BOOST_CHECK_THROW(DomainDecomposition(system,
-					  nodeGrid,
-					  cellGrid),
-		      NodeGridMismatch);
+        nodeGrid,
+        cellGrid),
+        NodeGridMismatch);
   }
 
   Int3D nodeGrid(mpiWorld->size(), 1, 1);
   Int3D cellGrid(1, 2, 3);
 
   DomainDecomposition domdec(system,
-			     nodeGrid,
-			     cellGrid);
+      nodeGrid,
+      cellGrid);
 
   const CellGrid &cGrid = domdec.getCellGrid();
 
   {
     int cnt = 0;
-    for(std::vector<Cell *>::const_iterator
-	  it  = domdec.getRealCells().begin(),
-	  end = domdec.getRealCells().end();
-	it != end; ++it, ++cnt) {
+
+    for (std::vector<Cell *>::const_iterator
+        it  = domdec.getRealCells().begin(),
+        end = domdec.getRealCells().end();
+        it != end; ++it, ++cnt) {
       int m, n, o;
+
       cGrid.mapIndexToPosition(m, n, o, (*it) - domdec.getFirstCell());
       BOOST_CHECK(cGrid.isInnerCell(m, n, o));
     }
+
     BOOST_CHECK_EQUAL(cnt, int(6));
   }
   {
     int cnt = 0;
-    for(std::vector<Cell *>::const_iterator
-	  it  = domdec.getGhostCells().begin(),
-	  end = domdec.getGhostCells().end();
-	it != end; ++it, ++cnt) {
+
+    for (std::vector<Cell *>::const_iterator
+        it  = domdec.getGhostCells().begin(),
+        end = domdec.getGhostCells().end();
+        it != end; ++it, ++cnt) {
       int m, n, o;
+
       cGrid.mapIndexToPosition(m, n, o, (*it) - domdec.getFirstCell());
       BOOST_CHECK(!cGrid.isInnerCell(m, n, o));
     }
-    BOOST_CHECK_EQUAL(cnt, int(3*4*5 - 6));
+
+    BOOST_CHECK_EQUAL(cnt, int(3 * 4 * 5 - 6));
   }
 }
 
-BOOST_FIXTURE_TEST_CASE(cellNeighbors, Fixture)
-{
+BOOST_FIXTURE_TEST_CASE(cellNeighbors, Fixture) {
   {
     // minimal test: inner cells have 26 neighbors
-    for(std::vector<Cell *>::const_iterator
-	  it  = domdec->getRealCells().begin(),
-	  end = domdec->getRealCells().end();
-	it != end; ++it) {
+    for (std::vector<Cell *>::const_iterator
+        it  = domdec->getRealCells().begin(),
+        end = domdec->getRealCells().end();
+        it != end; ++it) {
       BOOST_CHECK_EQUAL((*it)->neighborCells.size(), size_t(26));
     }
   }
   {
     // minimal test: ghost cells have no neighbors
-    for(std::vector<Cell *>::const_iterator
-	  it  = domdec->getGhostCells().begin(),
-	  end = domdec->getGhostCells().end();
-	it != end; ++it) {
+    for (std::vector<Cell *>::const_iterator
+        it  = domdec->getGhostCells().begin(),
+        end = domdec->getGhostCells().end();
+        it != end; ++it) {
       BOOST_CHECK_EQUAL((*it)->neighborCells.size(), size_t(0));
     }
-  }  
+  }
 }
 
-BOOST_FIXTURE_TEST_CASE(decompose, Fixture) 
-{
+BOOST_FIXTURE_TEST_CASE(decompose, Fixture) {
   int numRealParticles = 0;
   longint myCount;
   longint total;
   esutil::RNG rng;
 
   longint count = 0;
-  for (real x = 0.01; x < 1.0; x += 1.0/5)
-    for (real y = 0.01; y < 2.0; y += 2.0/3)
-      for (real z = 0.01; z < 3.0; z += 3.0/9) {
-	Real3D pos(x, y, z);
-	if (domdec->addParticle(count, pos) != static_cast<Particle*>(0))
-	  numRealParticles++;
-	++count;
+
+
+  for (real x = 0.01; x < 1.0; x += 1.0 / 5)
+    for (real y = 0.01; y < 2.0; y += 2.0 / 3)
+      for (real z = 0.01; z < 3.0; z += 3.0 / 9) {
+        Real3D pos(x, y, z);
+
+        if (domdec->addParticle(count, pos) != static_cast<Particle *>(0))
+          numRealParticles++;
+
+        ++count;
       }
+
+
 
   myCount = domdec->getNRealParticles();
   BOOST_CHECK_EQUAL(myCount, numRealParticles);
 
   boost::mpi::all_reduce(*mpiWorld, myCount, total, std::plus<int>());
+
   BOOST_CHECK_EQUAL(total, count);
 
   BOOST_TEST_MESSAGE("starting to exchange and sort");
@@ -223,34 +242,41 @@ BOOST_FIXTURE_TEST_CASE(decompose, Fixture)
   BOOST_TEST_MESSAGE("still alive after exchange");
 
   myCount = domdec->getNRealParticles();
+
   boost::mpi::all_reduce(*mpiWorld, myCount, total, std::plus<int>());
 
   BOOST_CHECK_EQUAL(total, count);
- }
+}
 
-BOOST_FIXTURE_TEST_CASE(fetchParticles, Fixture) 
-{
+BOOST_FIXTURE_TEST_CASE(fetchParticles, Fixture) {
   esutil::RNG rng;
   int numRealParticles = 0;
-  
+
   longint count = 0;
-  for (real x = 0.01; x < 1.0; x += 1.0/5)
-    for (real y = 0.01; y < 2.0; y += 2.0/3)
-      for (real z = 0.01; z < 3.0; z += 3.0/9) {
-	Real3D pos(x, y, z );
-	if (domdec->addParticle(count, pos) != static_cast<Particle*>(0))
-	  numRealParticles++;
-	++count;
+
+
+  for (real x = 0.01; x < 1.0; x += 1.0 / 5)
+    for (real y = 0.01; y < 2.0; y += 2.0 / 3)
+      for (real z = 0.01; z < 3.0; z += 3.0 / 9) {
+        Real3D pos(x, y, z);
+
+        if (domdec->addParticle(count, pos) != static_cast<Particle *>(0))
+          numRealParticles++;
+
+        ++count;
       }
+
+
 
   BOOST_CHECK_EQUAL(domdec->getNRealParticles(), numRealParticles);
 
-  Int3D nodeGrid(1, mpiWorld->size(), 1 );
+  Int3D nodeGrid(1, mpiWorld->size(), 1);
   Int3D cellGrid(10, 5, 4);
 
   DomainDecomposition domdec2(system,
-                              nodeGrid,
-                              cellGrid);
+      nodeGrid,
+      cellGrid);
+
   domdec2.fetchParticles(*domdec);
 
   int total;
@@ -260,35 +286,39 @@ BOOST_FIXTURE_TEST_CASE(fetchParticles, Fixture)
   BOOST_CHECK_EQUAL(total, count);
 }
 
-
-BOOST_FIXTURE_TEST_CASE(checkGhosts, Fixture) 
-{
+BOOST_FIXTURE_TEST_CASE(checkGhosts, Fixture) {
   /* create particles in a regular grid on the world,
      one per inner cell on each node */
   CellGrid cGrid = domdec->getCellGrid();
   NodeGrid nGrid = domdec->getNodeGrid();
+
   // global number of cells per dimension (counted over all nodes)
   int totalCells[3];
+
+
   for (int i = 0; i < 3; ++i) {
-    totalCells[i] = cGrid.getGridSize(i)*nGrid.getGridSize(i);
+    totalCells[i] = cGrid.getGridSize(i) * nGrid.getGridSize(i);
   }
 
   int c = 0;
-  for(int x = 0; x < cGrid.getGridSize(0); ++x) {
-    for(int y = 0; y < cGrid.getGridSize(1); ++y) {
-      for(int z = 0; z < cGrid.getGridSize(2); ++z) {
-	Int3D ipos(x, y, z);
-	// center particle in cell's global position
-	Real3D pos;
-	for (int i = 0; i < 3; ++i) {
-	  ipos[i] += nGrid.getNodePosition(i)*cGrid.getGridSize(i);
-	  pos[i] = (0.5 + ipos[i])*cGrid.getCellSize(i);
-	}
-	
-	Particle *p = domdec->addParticle(c++, pos);
 
-	p->type() = 10000*ipos[0] + 100*ipos[1] + ipos[2];
-	BOOST_TEST_MESSAGE("generated particle with type " << p->type());
+  for (int x = 0; x < cGrid.getGridSize(0); ++x) {
+    for (int y = 0; y < cGrid.getGridSize(1); ++y) {
+      for (int z = 0; z < cGrid.getGridSize(2); ++z) {
+        Int3D ipos(x, y, z);
+
+        // center particle in cell's global position
+        Real3D pos;
+
+        for (int i = 0; i < 3; ++i) {
+          ipos[i] += nGrid.getNodePosition(i) * cGrid.getGridSize(i);
+          pos[i] = (0.5 + ipos[i]) * cGrid.getCellSize(i);
+        }
+
+        Particle *p = domdec->addParticle(c++, pos);
+
+        p->type() = 10000 * ipos[0] + 100 * ipos[1] + ipos[2];
+        BOOST_TEST_MESSAGE("generated particle with type " << p->type());
       }
     }
   }
@@ -299,63 +329,74 @@ BOOST_FIXTURE_TEST_CASE(checkGhosts, Fixture)
 
   BOOST_TEST_MESSAGE("done with resort particles");
 
-  /* now check that each cell has one particle, and at the proper position */  
-  for(ESPPIterator<CellList> it(domdec->getLocalCells()); it.isValid(); ++it) {
+  /* now check that each cell has one particle, and at the proper position */
+  for (ESPPIterator<CellList> it(domdec->getLocalCells()); it.isValid(); ++it) {
     bool failed = true;
     ParticleList &pl = (*it)->particles;
     int cnt = pl.size();
+
     // map back cell to coordinates
     Int3D ipos;
+
     cGrid.mapIndexToPosition(ipos, *it - domdec->getFirstCell());
 
     BOOST_CHECK_EQUAL(cnt, 1);
 
     if (cnt == 1) {
       /* recalculate expected particles position. Remember that this time ipos is
-	 a ghost frame position, not a inner position. Shift accordingly */
+         a ghost frame position, not a inner position. Shift accordingly */
       Real3D pos;
+
       /* for checking the encoded type, we need the original cell */
       int origcpos[3];
+
       for (int i = 0; i < 3; ++i) {
-	/* absolute cell location. Since coordinates should get folded, also the ghost
-	   particles should have their positions in the center of their cell */
-	int ip =  ipos[i] - cGrid.getFrameWidth() + nGrid.getNodePosition(i)*cGrid.getGridSize(i);
-	pos[i] = (0.5 + ip)*cGrid.getCellSize(i);
+        /* absolute cell location. Since coordinates should get folded, also the ghost
+           particles should have their positions in the center of their cell */
+        int ip =  ipos[i] - cGrid.getFrameWidth() + nGrid.getNodePosition(i) * cGrid.getGridSize(i);
 
-	// now backfold for type encoding
-	if (ip < 0) {
-	  ip += totalCells[i];
-	} else if (ip >= totalCells[i]) {
-	  ip -= totalCells[i];
-	}
-	origcpos[i] = ip;
+        pos[i] = (0.5 + ip) * cGrid.getCellSize(i);
 
-	/* for the force test, set force according to original's
-	   absolute position that means that the forces on any ghost
-	   should always be the same as for its real particle. */
-	pl[0].force()[i] = origcpos[i];
+        // now backfold for type encoding
+        if (ip < 0) {
+          ip += totalCells[i];
+        } else if (ip >= totalCells[i]) {
+          ip -= totalCells[i];
+        }
+
+        origcpos[i] = ip;
+
+        /* for the force test, set force according to original's
+           absolute position that means that the forces on any ghost
+           should always be the same as for its real particle. */
+        pl[0].force()[i] = origcpos[i];
       }
-      size_t type = 10000*origcpos[0] + 100*origcpos[1] + origcpos[2];
+
+      size_t type = 10000 * origcpos[0] + 100 * origcpos[1] + origcpos[2];
+
       BOOST_CHECK_EQUAL(pl[0].type(), type);
       failed = pl[0].type() != type;
 
       Real3D delta = pos - pl[0].position();
 
       real dst = delta * delta;
+
       failed |= dst > 1e-10;
       BOOST_CHECK_SMALL(dst, 1e-10);
 
       if (failed) {
-	BOOST_TEST_MESSAGE("error at particle: expected "
-			   << pos << " type " << type
-			   << ", got "
-			   << pl[0].position() << " type " << pl[0].type());
+        BOOST_TEST_MESSAGE("error at particle: expected "
+                << pos << " type " << type
+                << ", got "
+                << pl[0].position() << " type " << pl[0].type());
       }
     }
+
     if (failed) {
       BOOST_TEST_MESSAGE("error at cell: " << ipos
-			 << " on node " << nGrid.getNodePosition(0) << " "
-			 << nGrid.getNodePosition(1) << " " << nGrid.getNodePosition(2));
+                                           << " on node " << nGrid.getNodePosition(0) << " "
+                                           << nGrid.getNodePosition(1) << " " <<
+          nGrid.getNodePosition(2));
     }
   }
 
@@ -363,51 +404,63 @@ BOOST_FIXTURE_TEST_CASE(checkGhosts, Fixture)
 
   domdec->collectGhostForces();
 
-  /* now check that the forces on the particles are correct */  
-  for(ESPPIterator<CellList> it(domdec->getRealCells()); it.isValid(); ++it) {
+  /* now check that the forces on the particles are correct */
+  for (ESPPIterator<CellList> it(domdec->getRealCells()); it.isValid(); ++it) {
     ParticleList &pl = (*it)->particles;
     int cnt = pl.size();
+
     // map back cell to coordinates
     Int3D ipos;
+
     cGrid.mapIndexToPosition(ipos, *it - domdec->getFirstCell());
 
     if (cnt == 1) {
       // see which how many ghosts should be there
       int ghostCnt = 0;
+
       for (int nx = -1; nx <= +1; ++nx) {
-	if (nx == -1 && ipos[0] != cGrid.getInnerCellsBegin(0)) continue;
-	if (nx == +1 && ipos[0] != cGrid.getInnerCellsEnd(0) - 1) continue;
+        if ((nx == -1) && (ipos[0] != cGrid.getInnerCellsBegin(0))) continue;
 
-	for (int ny = -1; ny <= +1; ++ny) {
-	  if (ny == -1 && ipos[1] != cGrid.getInnerCellsBegin(1)) continue;
-	  if (ny == +1 && ipos[1] != cGrid.getInnerCellsEnd(1) - 1) continue;
-	  
-	  for (int nz = -1; nz <= +1; ++nz) {
-	    if (nz == -1 && ipos[2] != cGrid.getInnerCellsBegin(2)) continue;
-	    if (nz == +1 && ipos[2] != cGrid.getInnerCellsEnd(2) - 1) continue;
+        if ((nx == +1) && (ipos[0] != cGrid.getInnerCellsEnd(0) - 1)) continue;
 
-	    ghostCnt++;
-	  }
-	}
+        for (int ny = -1; ny <= +1; ++ny) {
+          if ((ny == -1) && (ipos[1] != cGrid.getInnerCellsBegin(1))) continue;
+
+          if ((ny == +1) && (ipos[1] != cGrid.getInnerCellsEnd(1) - 1)) continue;
+
+          for (int nz = -1; nz <= +1; ++nz) {
+            if ((nz == -1) && (ipos[2] != cGrid.getInnerCellsBegin(2))) continue;
+
+            if ((nz == +1) && (ipos[2] != cGrid.getInnerCellsEnd(2) - 1)) continue;
+
+            ghostCnt++;
+          }
+        }
       }
+
       BOOST_TEST_MESSAGE("expect " << ghostCnt << " ghosts for particle at " << ipos);
-      
+
       // calculate expected force from absolute cell location
       Real3D force;
+
       for (int i = 0; i < 3; ++i) {
-	real ap = ipos[i] - cGrid.getFrameWidth() + nGrid.getNodePosition(i)*cGrid.getGridSize(i);
-	force[i] = ap*ghostCnt;
+        real ap = ipos[i] - cGrid.getFrameWidth() + nGrid.getNodePosition(i) * cGrid.getGridSize(i);
+
+        force[i] = ap * ghostCnt;
       }
-      
+
       Real3D delta = force - pl[0].force();
       real dst = delta * delta;
+
       BOOST_CHECK_SMALL(dst, 1e-10);
+
       if (dst > 1e-10) {
-	BOOST_TEST_MESSAGE("error at cell: " << ipos
-			   << " on node " << nGrid.getNodePosition(0) << " "
-			   << nGrid.getNodePosition(1) << " " << nGrid.getNodePosition(2)
-			   << " expect force " << force
-			   << " got force " << pl[0].force());
+        BOOST_TEST_MESSAGE("error at cell: " << ipos
+                                             << " on node " << nGrid.getNodePosition(0) << " "
+                                             << nGrid.getNodePosition(1) << " " <<
+            nGrid.getNodePosition(2)
+                                             << " expect force " << force
+                                             << " got force " << pl[0].force());
       }
     }
   }
@@ -418,44 +471,46 @@ BOOST_FIXTURE_TEST_CASE(checkGhosts, Fixture)
 bool afterResortCalled = false;
 bool beforeResortCalled = false;
 
-void beforeResort(ParticleList &pl, OutBuffer& out) {
+void beforeResort(ParticleList &pl, OutBuffer &out) {
   if (pl.size() == 1) {
     beforeResortCalled = true;
+
     int res = 42;
+
     out.write(res);
   }
 }
 
-void afterResort(ParticleList &pl, InBuffer& inbuf) {
+void afterResort(ParticleList &pl, InBuffer &inbuf) {
   if (pl.size() == 1) {
     afterResortCalled = true;
+
     int res;
+
     inbuf.read(res);
     BOOST_CHECK_EQUAL(res, 42);
   }
 }
 
-BOOST_AUTO_TEST_CASE(migrateParticle) 
-{
+BOOST_AUTO_TEST_CASE(migrateParticle) {
   // check whether a particle is migrated from one node to the other
   // and whether it takes all data with it
-  shared_ptr< DomainDecomposition > domdec;
-  shared_ptr< System > system;
+  shared_ptr<DomainDecomposition> domdec;
+  shared_ptr<System> system;
 
   int nodes = mpiWorld->size();
-  int lastnode = nodes-1;
-  Real3D boxL(nodes*1.0, 1.0, 1.0);
+  int lastnode = nodes - 1;
+  Real3D boxL(nodes * 1.0, 1.0, 1.0);
   Int3D nodeGrid(nodes, 1, 1);
   Int3D cellGrid(1);
 
-  system = make_shared< System >();
-  system->rng = make_shared< esutil::RNG >();
-  system->bc = make_shared< bc::OrthorhombicBC >(system->rng, boxL);
-  domdec = make_shared< DomainDecomposition >(system,
-					      nodeGrid,
-					      cellGrid);
+  system = make_shared<System>();
+  system->rng = make_shared<esutil::RNG>();
+  system->bc = make_shared<bc::OrthorhombicBC>(system->rng, boxL);
+  domdec = make_shared<DomainDecomposition>(system,
+    nodeGrid,
+    cellGrid);
 
-  
   BOOST_TEST_MESSAGE("Setting up system...");
 
   // connect test functions to domdec
@@ -463,9 +518,11 @@ BOOST_AUTO_TEST_CASE(migrateParticle)
   domdec->afterRecvParticles.connect(afterResort);
 
   // create a single particle on node 0 that really belongs to the last node
-  Real3D pos(nodes*1.0 - 0.5, 0.5, 0.5);
+  Real3D pos(nodes * 1.0 - 0.5, 0.5, 0.5);
+
   if (mpiWorld->rank() == 0) {
     Particle *p = domdec->addParticle(0, pos);
+
     BOOST_CHECK_EQUAL(domdec->lookupRealParticle(0), p);
   }
 
@@ -476,9 +533,9 @@ BOOST_AUTO_TEST_CASE(migrateParticle)
 
   // now the particle should be on the the last node
   if (mpiWorld->rank() == lastnode) {
-    BOOST_CHECK_NE(domdec->lookupRealParticle(0), static_cast<Particle*>(0));
+    BOOST_CHECK_NE(domdec->lookupRealParticle(0), static_cast<Particle *>(0));
   } else {
-    BOOST_CHECK_EQUAL(domdec->lookupRealParticle(0), static_cast<Particle*>(0));
+    BOOST_CHECK_EQUAL(domdec->lookupRealParticle(0), static_cast<Particle *>(0));
   }
 
   if (mpiWorld->rank() == 0)

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,0 +1,1752 @@
+# Uncrustify 0.62
+
+#
+# General options
+#
+
+# The type of line endings
+newlines                                  = auto     # auto/lf/crlf/cr
+
+# The original size of tabs in the input
+input_tab_size                            = 4        # number
+
+# The size of tabs in the output (only used if align_with_tabs=true)
+output_tab_size                           = 4        # number
+
+# The ASCII value of the string escape char, usually 92 (\) or 94 (^). (Pawn)
+string_escape_char                        = 92       # number
+
+# Alternate string escape char for Pawn. Only works right before the quote char.
+string_escape_char2                       = 0        # number
+
+# Replace tab characters found in string literals with the escape sequence \t instead.
+string_replace_tab_chars                  = false    # false/true
+
+# Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.
+# If true (default), 'assert(x<0 && y>=3)' will be broken.
+# Improvements to template detection may make this option obsolete.
+tok_split_gte                             = false    # false/true
+
+# Override the default ' *INDENT-OFF*' in comments for disabling processing of part of the file.
+disable_processing_cmt                    = ""         # string
+
+# Override the default ' *INDENT-ON*' in comments for enabling processing of part of the file.
+enable_processing_cmt                     = ""         # string
+
+# Enable parsing of digraphs. Default=false
+enable_digraphs                           = false    # false/true
+
+# Control what to do with the UTF-8 BOM (recommend 'remove')
+utf8_bom                                  = ignore   # ignore/add/remove/force
+
+# If the file contains bytes with values between 128 and 255, but is not UTF-8, then output as UTF-8
+utf8_byte                                 = false    # false/true
+
+# Force the output encoding to UTF-8
+utf8_force                                = false    # false/true
+
+#
+# Indenting
+#
+
+# The number of columns to indent per level.
+# Usually 2, 3, 4, or 8.
+indent_columns                            = 2        # number
+
+# The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
+# For FreeBSD, this is set to 4. Negative value is absolute and not increased for each ( level
+indent_continue                           = 4        # number
+
+# How to use tabs when indenting code
+# 0=spaces only
+# 1=indent with tabs to brace level, align with spaces
+# 2=indent and align with tabs, using spaces when not on a tabstop
+indent_with_tabs                          = 0        # number
+
+# Comments that are not a brace level are indented with tabs on a tabstop.
+# Requires indent_with_tabs=2. If false, will use spaces.
+indent_cmt_with_tabs                      = false    # false/true
+
+# Whether to indent strings broken by '\' so that they line up
+indent_align_string                       = true    # false/true
+
+# The number of spaces to indent multi-line XML strings.
+# Requires indent_align_string=True
+indent_xml_string                         = 0        # number
+
+# Spaces to indent '{' from level
+indent_brace                              = 0        # number
+
+# Whether braces are indented to the body level
+indent_braces                             = false    # false/true
+
+# Disabled indenting function braces if indent_braces is true
+indent_braces_no_func                     = false   # false/true
+
+# Disabled indenting class braces if indent_braces is true
+indent_braces_no_class                    = false   # false/true
+
+# Disabled indenting struct braces if indent_braces is true
+indent_braces_no_struct                   = false    # false/true
+
+# Indent based on the size of the brace parent, i.e. 'if' => 3 spaces, 'for' => 4 spaces, etc.
+indent_brace_parent                       = false    # false/true
+
+# Indent based on the paren open instead of the brace open in '({\n', default is to indent by brace.
+indent_paren_open_brace                   = false  # false/true
+
+# Whether the 'namespace' body is indented
+indent_namespace                          = false    # false/true
+
+# Only indent one namespace and no sub-namespaces.
+# Requires indent_namespace=true.
+indent_namespace_single_indent            = false    # false/true
+
+# The number of spaces to indent a namespace block
+indent_namespace_level                    = 0        # number
+
+# If the body of the namespace is longer than this number, it won't be indented.
+# Requires indent_namespace=true. Default=0 (no limit)
+indent_namespace_limit                    = 0        # number
+
+# Whether the 'extern "C"' body is indented
+indent_extern                             = false    # false/true
+
+# Whether the 'class' body is indented
+indent_class                              = true    # false/true
+
+# Whether to indent the stuff after a leading base class colon
+indent_class_colon                        = true    # false/true
+
+# Indent based on a class colon instead of the stuff after the colon.
+# Requires indent_class_colon=true. Default=false
+indent_class_on_colon                     = true    # false/true
+
+# Whether to indent the stuff after a leading class initializer colon
+indent_constr_colon                       = true    # false/true
+
+# Virtual indent from the ':' for member initializers. Default is 2
+indent_ctor_init_leading                  = 4        # number
+
+# Additional indenting for constructor initializer list
+indent_ctor_init                          = 4        # number
+
+# False=treat 'else\nif' as 'else if' for indenting purposes
+# True=indent the 'if' one level
+indent_else_if                            = true    # false/true
+
+# Amount to indent variable declarations after a open brace. neg=relative, pos=absolute
+indent_var_def_blk                        = 0        # number
+
+# Indent continued variable declarations instead of aligning.
+indent_var_def_cont                       = true    # false/true
+
+# Indent continued shift expressions ('<<' and '>>') instead of aligning.
+# Turn align_left_shift off when enabling this.
+indent_shift                              = true    # false/true
+
+# True:  force indentation of function definition to start in column 1
+# False: use the default behavior
+indent_func_def_force_col1                = false    # fase/true
+
+# True:  indent continued function call parameters one indent level
+# False: align parameters under the open paren
+indent_func_call_param                    = true    # false/true
+
+# Same as indent_func_call_param, but for function defs
+indent_func_def_param                     = true    # false/true
+
+# Same as indent_func_call_param, but for function protos
+indent_func_proto_param                   = true    # false/true
+
+# Same as indent_func_call_param, but for class declarations
+indent_func_class_param                   = false    # false/true
+
+# Same as indent_func_call_param, but for class variable constructors
+indent_func_ctor_var_param                = false    # false/true
+
+# Same as indent_func_call_param, but for templates
+indent_template_param                     = false    # false/true
+
+# Double the indent for indent_func_xxx_param options
+indent_func_param_double                  = false    # false/true
+
+# Indentation column for standalone 'const' function decl/proto qualifier
+indent_func_const                         = 0        # number
+
+# Indentation column for standalone 'throw' function decl/proto qualifier
+indent_func_throw                         = 0        # number
+
+# The number of spaces to indent a continued '->' or '.'
+# Usually set to 0, 1, or indent_columns.
+indent_member                             = 2        # number
+
+# Spaces to indent single line ('//') comments on lines before code
+indent_sing_line_comments                 = 0        # number
+
+# If set, will indent trailing single line ('//') comments relative
+# to the code instead of trying to keep the same absolute column
+indent_relative_single_line_comments      = false    # false/true
+
+# Spaces to indent 'case' from 'switch'
+# Usually 0 or indent_columns.
+indent_switch_case                        = 2        # number
+
+# Spaces to shift the 'case' line, without affecting any other lines
+# Usually 0.
+indent_case_shift                         = 0        # number
+
+# Spaces to indent '{' from 'case'.
+# By default, the brace will appear under the 'c' in case.
+# Usually set to 0 or indent_columns.
+indent_case_brace                         = 0        # number
+
+# Whether to indent comments found in first column
+indent_col1_comment                       = false    # false/true
+
+# How to indent goto labels
+#  >0 : absolute column where 1 is the leftmost column
+#  <=0 : subtract from brace indent
+indent_label                              = 1        # number
+
+# Same as indent_label, but for access specifiers that are followed by a colon
+indent_access_spec                        = 1        # number
+
+# Indent the code after an access specifier by one level.
+# If set, this option forces 'indent_access_spec=0'
+indent_access_spec_body                   = false    # false/true
+
+# If an open paren is followed by a newline, indent the next line so that it lines up after the open paren (not recommended)
+indent_paren_nl                           = false    # false/true
+
+# Controls the indent of a close paren after a newline.
+# 0: Indent to body level
+# 1: Align under the open paren
+# 2: Indent to the brace level
+indent_paren_close                        = 2        # number
+
+# Controls the indent of a comma when inside a paren.If TRUE, aligns under the open paren
+indent_comma_paren                        = true    # false/true
+
+# Controls the indent of a BOOL operator when inside a paren.If TRUE, aligns under the open paren
+indent_bool_paren                         = true    # false/true
+
+# If 'indent_bool_paren' is true, controls the indent of the first expression. If TRUE, aligns the first expression to the following ones
+indent_first_bool_expr                    = true    # false/true
+
+# If an open square is followed by a newline, indent the next line so that it lines up after the open square (not recommended)
+indent_square_nl                          = false    # false/true
+
+# Don't change the relative indent of ESQL/C 'EXEC SQL' bodies
+indent_preserve_sql                       = false    # false/true
+
+# Align continued statements at the '='. Default=True
+# If FALSE or the '=' is followed by a newline, the next line is indent one tab.
+indent_align_assign                       = false     # false/true
+
+# Indent OC blocks at brace level instead of usual rules.
+indent_oc_block                           = false    # false/true
+
+# Indent OC blocks in a message relative to the parameter name.
+# 0=use indent_oc_block rules, 1+=spaces to indent
+indent_oc_block_msg                       = 0        # number
+
+# Minimum indent for subsequent parameters
+indent_oc_msg_colon                       = 0        # number
+
+# If true, prioritize aligning with initial colon (and stripping spaces from lines, if necessary).
+# Default is true.
+indent_oc_msg_prioritize_first_colon      = true     # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented the way that Xcode does by default (from keyword if the parameter is on its own line; otherwise, from the previous indentation level).
+indent_oc_block_msg_xcode_style           = false    # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg keyword.
+indent_oc_block_msg_from_keyword          = false    # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg colon.
+indent_oc_block_msg_from_colon            = false    # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the block caret is.
+indent_oc_block_msg_from_caret            = false    # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is.
+indent_oc_block_msg_from_brace            = false    # false/true
+
+# When identing after virtual brace open and newline add further spaces to reach this min. indent.
+indent_min_vbrace_open                    = 0        # number
+
+# TRUE: When identing after virtual brace open and newline add further spaces after regular indent to reach next tabstop.
+indent_vbrace_open_on_tabstop             = false    # false/true
+
+#
+# Spacing options
+#
+
+# Add or remove space around arithmetic operator '+', '-', '/', '*', etc
+sp_arith                                  = add   # ignore/add/remove/force
+
+# Add or remove space around assignment operator '=', '+=', etc
+sp_assign                                 = add   # ignore/add/remove/force
+
+# Add or remove space around '=' in C++11 lambda capture specifications. Overrides sp_assign
+sp_cpp_lambda_assign                      = add   # ignore/add/remove/force
+
+# Add or remove space after the capture specification in C++11 lambda.
+sp_cpp_lambda_paren                       = add   # ignore/add/remove/force
+
+# Add or remove space around assignment operator '=' in a prototype
+sp_assign_default                         = add   # ignore/add/remove/force
+
+# Add or remove space before assignment operator '=', '+=', etc. Overrides sp_assign.
+sp_before_assign                          = ignore   # ignore/add/remove/force
+
+# Add or remove space after assignment operator '=', '+=', etc. Overrides sp_assign.
+sp_after_assign                           = ignore   # ignore/add/remove/force
+
+# Add or remove space in 'NS_ENUM ('
+sp_enum_paren                             = add   # ignore/add/remove/force
+
+# Add or remove space around assignment '=' in enum
+sp_enum_assign                            = add   # ignore/add/remove/force
+
+# Add or remove space before assignment '=' in enum. Overrides sp_enum_assign.
+sp_enum_before_assign                     = ignore   # ignore/add/remove/force
+
+# Add or remove space after assignment '=' in enum. Overrides sp_enum_assign.
+sp_enum_after_assign                      = ignore   # ignore/add/remove/force
+
+# Add or remove space around preprocessor '##' concatenation operator. Default=Add
+sp_pp_concat                              = add      # ignore/add/remove/force
+
+# Add or remove space after preprocessor '#' stringify operator. Also affects the '#@' charizing operator.
+sp_pp_stringify                           = ignore   # ignore/add/remove/force
+
+# Add or remove space before preprocessor '#' stringify operator as in '#define x(y) L#y'.
+sp_before_pp_stringify                    = ignore   # ignore/add/remove/force
+
+# Add or remove space around boolean operators '&&' and '||'
+sp_bool                                   = add   # ignore/add/remove/force
+
+# Add or remove space around compare operator '<', '>', '==', etc
+sp_compare                                = add   # ignore/add/remove/force
+
+# Add or remove space inside '(' and ')'
+sp_inside_paren                           = remove   # ignore/add/remove/force
+
+# Add or remove space between nested parens: '((' vs ') )'
+sp_paren_paren                            = remove   # ignore/add/remove/force
+
+# Add or remove space between back-to-back parens: ')(' vs ') ('
+sp_cparen_oparen                          = remove   # ignore/add/remove/force
+
+# Whether to balance spaces inside nested parens
+sp_balance_nested_parens                  = false    # false/true
+
+# Add or remove space between ')' and '{'
+sp_paren_brace                            = add   # ignore/add/remove/force
+
+# Add or remove space before pointer star '*'
+sp_before_ptr_star                        = add   # ignore/add/remove/force
+
+# Add or remove space before pointer star '*' that isn't followed by a variable name
+# If set to 'ignore', sp_before_ptr_star is used instead.
+sp_before_unnamed_ptr_star                = add   # ignore/add/remove/force
+
+# Add or remove space between pointer stars '*'
+sp_between_ptr_star                       = remove   # ignore/add/remove/force
+
+# Add or remove space after pointer star '*', if followed by a word.
+sp_after_ptr_star                         = remove   # ignore/add/remove/force
+
+# Add or remove space after pointer star '*', if followed by a qualifier.
+sp_after_ptr_star_qualifier               = remove   # ignore/add/remove/force
+
+# Add or remove space after a pointer star '*', if followed by a func proto/def.
+sp_after_ptr_star_func                    = remove   # ignore/add/remove/force
+
+# Add or remove space after a pointer star '*', if followed by an open paren (function types).
+sp_ptr_star_paren                         = remove   # ignore/add/remove/force
+
+# Add or remove space before a pointer star '*', if followed by a func proto/def.
+sp_before_ptr_star_func                   = add   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&'
+sp_before_byref                           = add   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&' that isn't followed by a variable name
+# If set to 'ignore', sp_before_byref is used instead.
+sp_before_unnamed_byref                   = add   # ignore/add/remove/force
+
+# Add or remove space after reference sign '&', if followed by a word.
+sp_after_byref                            = remove   # ignore/add/remove/force
+
+# Add or remove space after a reference sign '&', if followed by a func proto/def.
+sp_after_byref_func                       = remove   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&', if followed by a func proto/def.
+sp_before_byref_func                      = add   # ignore/add/remove/force
+
+# Add or remove space between type and word. Default=Force
+sp_after_type                             = force    # ignore/add/remove/force
+
+# Add or remove space before the paren in the D constructs 'template Foo(' and 'class Foo('.
+sp_before_template_paren                  = remove   # ignore/add/remove/force
+
+# Add or remove space in 'template <' vs 'template<'.
+# If set to ignore, sp_before_angle is used.
+sp_template_angle                         = remove   # ignore/add/remove/force
+
+# Add or remove space before '<>'
+sp_before_angle                           = remove   # ignore/add/remove/force
+
+# Add or remove space inside '<' and '>'
+sp_inside_angle                           = remove   # ignore/add/remove/force
+
+# Add or remove space after '<>'
+sp_after_angle                            = remove   # ignore/add/remove/force
+
+# Add or remove space between '<>' and '(' as found in 'new List<byte>();'
+sp_angle_paren                            = remove   # ignore/add/remove/force
+
+# Add or remove space between '<>' and a word as in 'List<byte> m;'
+sp_angle_word                             = add   # ignore/add/remove/force
+
+# Add or remove space between '>' and '>' in '>>' (template stuff C++/C# only). Default=Add
+sp_angle_shift                            = add      # ignore/add/remove/force
+
+# Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False
+# sp_angle_shift cannot remove the space without this option.
+sp_permit_cpp11_shift                     = false    # false/true
+
+# Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc.
+sp_before_sparen                          = add   # ignore/add/remove/force
+
+# Add or remove space inside if-condition '(' and ')'
+sp_inside_sparen                          = remove   # ignore/add/remove/force
+
+# Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
+sp_inside_sparen_close                    = remove   # ignore/add/remove/force
+
+# Add or remove space after if-condition '('. Overrides sp_inside_sparen.
+sp_inside_sparen_open                     = remove   # ignore/add/remove/force
+
+# Add or remove space after ')' of 'if', 'for', 'switch', and 'while', etc.
+sp_after_sparen                           = ignore   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of 'if', 'for', 'switch', and 'while', etc.
+sp_sparen_brace                           = add   # ignore/add/remove/force
+
+# Add or remove space between 'invariant' and '(' in the D language.
+sp_invariant_paren                        = ignore   # ignore/add/remove/force
+
+# Add or remove space after the ')' in 'invariant (C) c' in the D language.
+sp_after_invariant_paren                  = ignore   # ignore/add/remove/force
+
+# Add or remove space before empty statement ';' on 'if', 'for' and 'while'
+sp_special_semi                           = remove   # ignore/add/remove/force
+
+# Add or remove space before ';'. Default=Remove
+sp_before_semi                            = remove   # ignore/add/remove/force
+
+# Add or remove space before ';' in non-empty 'for' statements
+sp_before_semi_for                        = remove   # ignore/add/remove/force
+
+# Add or remove space before a semicolon of an empty part of a for statement.
+sp_before_semi_for_empty                  = remove   # ignore/add/remove/force
+
+# Add or remove space after ';', except when followed by a comment. Default=Add
+sp_after_semi                             = add   # ignore/add/remove/force
+
+# Add or remove space after ';' in non-empty 'for' statements. Default=Force
+sp_after_semi_for                         = add    # ignore/add/remove/force
+
+# Add or remove space after the final semicolon of an empty part of a for statement: for ( ; ; <here> ).
+sp_after_semi_for_empty                   = remove   # ignore/add/remove/force
+
+# Add or remove space before '[' (except '[]')
+sp_before_square                          = remove   # ignore/add/remove/force
+
+# Add or remove space before '[]'
+sp_before_squares                         = remove   # ignore/add/remove/force
+
+# Add or remove space inside a non-empty '[' and ']'
+sp_inside_square                          = remove   # ignore/add/remove/force
+
+# Add or remove space after ','
+sp_after_comma                            = ignore   # ignore/add/remove/force
+
+# Add or remove space before ','
+sp_before_comma                           = remove   # ignore/add/remove/force
+
+# Add or remove space between ',' and ']' in multidimensional array type 'int[,,]'
+sp_after_mdatype_commas                   = remove   # ignore/add/remove/force
+
+# Add or remove space between '[' and ',' in multidimensional array type 'int[,,]'
+sp_before_mdatype_commas                  = remove   # ignore/add/remove/force
+
+# Add or remove space between ',' in multidimensional array type 'int[,,]'
+sp_between_mdatype_commas                 = remove   # ignore/add/remove/force
+
+# Add or remove space between an open paren and comma: '(,' vs '( ,'
+sp_paren_comma                            = remove   # ignore/add/remove/force
+
+# Add or remove space before the variadic '...' when preceded by a non-punctuator
+sp_before_ellipsis                        = remove   # ignore/add/remove/force
+
+# Add or remove space after class ':'
+sp_after_class_colon                      = add   # ignore/add/remove/force
+
+# Add or remove space before class ':'
+sp_before_class_colon                     = add   # ignore/add/remove/force
+
+# Add or remove space after class constructor ':'
+sp_after_constr_colon                     = remove   # ignore/add/remove/force
+
+# Add or remove space before class constructor ':'
+sp_before_constr_colon                    = remove   # ignore/add/remove/force
+
+# Add or remove space before case ':'. Default=Remove
+sp_before_case_colon                      = remove   # ignore/add/remove/force
+
+# Add or remove space between 'operator' and operator sign
+sp_after_operator                         = remove   # ignore/add/remove/force
+
+# Add or remove space between the operator symbol and the open paren, as in 'operator ++('
+sp_after_operator_sym                     = remove   # ignore/add/remove/force
+
+# Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'
+sp_after_cast                             = remove   # ignore/add/remove/force
+
+# Add or remove spaces inside cast parens
+sp_inside_paren_cast                      = remove   # ignore/add/remove/force
+
+# Add or remove space between the type and open paren in a C++ cast, i.e. 'int(exp)' vs 'int (exp)'
+sp_cpp_cast_paren                         = remove   # ignore/add/remove/force
+
+# Add or remove space between 'sizeof' and '('
+sp_sizeof_paren                           = remove   # ignore/add/remove/force
+
+# Add or remove space after the tag keyword (Pawn)
+sp_after_tag                              = ignore   # ignore/add/remove/force
+
+# Add or remove space inside enum '{' and '}'
+sp_inside_braces_enum                     = remove   # ignore/add/remove/force
+
+# Add or remove space inside struct/union '{' and '}'
+sp_inside_braces_struct                   = remove   # ignore/add/remove/force
+
+# Add or remove space inside '{' and '}'
+sp_inside_braces                          = remove   # ignore/add/remove/force
+
+# Add or remove space inside '{}'
+sp_inside_braces_empty                    = add   # ignore/add/remove/force
+
+# Add or remove space between return type and function name
+# A minimum of 1 is forced except for pointer return types.
+sp_type_func                              = add   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function declaration
+sp_func_proto_paren                       = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function definition
+sp_func_def_paren                         = remove   # ignore/add/remove/force
+
+# Add or remove space inside empty function '()'
+sp_inside_fparens                         = remove   # ignore/add/remove/force
+
+# Add or remove space inside function '(' and ')'
+sp_inside_fparen                          = remove   # ignore/add/remove/force
+
+# Add or remove space inside the first parens in the function type: 'void (*x)(...)'
+sp_inside_tparen                          = remove   # ignore/add/remove/force
+
+# Add or remove between the parens in the function type: 'void (*x)(...)'
+sp_after_tparen_close                     = remove   # ignore/add/remove/force
+
+# Add or remove space between ']' and '(' when part of a function call.
+sp_square_fparen                          = remove   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of function
+sp_fparen_brace                           = add   # ignore/add/remove/force
+
+# Java: Add or remove space between ')' and '{{' of double brace initializer.
+sp_fparen_dbrace                          = add   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function calls
+sp_func_call_paren                        = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function calls without parameters.
+# If set to 'ignore' (the default), sp_func_call_paren is used.
+sp_func_call_paren_empty                  = remove   # ignore/add/remove/force
+
+# Add or remove space between the user function name and '(' on function calls
+# You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
+sp_func_call_user_paren                   = ignore   # ignore/add/remove/force
+
+# Add or remove space between a constructor/destructor and the open paren
+sp_func_class_paren                       = remove   # ignore/add/remove/force
+
+# Add or remove space between 'return' and '('
+sp_return_paren                           = ignore   # ignore/add/remove/force
+
+# Add or remove space between '__attribute__' and '('
+sp_attribute_paren                        = remove   # ignore/add/remove/force
+
+# Add or remove space between 'defined' and '(' in '#if defined (FOO)'
+sp_defined_paren                          = add   # ignore/add/remove/force
+
+# Add or remove space between 'throw' and '(' in 'throw (something)'
+sp_throw_paren                            = add   # ignore/add/remove/force
+
+# Add or remove space between 'throw' and anything other than '(' as in '@throw [...];'
+sp_after_throw                            = add  # ignore/add/remove/force
+
+# Add or remove space between 'catch' and '(' in 'catch (something) { }'
+# If set to ignore, sp_before_sparen is used.
+sp_catch_paren                            = add   # ignore/add/remove/force
+
+# Add or remove space between 'version' and '(' in 'version (something) { }' (D language)
+# If set to ignore, sp_before_sparen is used.
+sp_version_paren                          = add   # ignore/add/remove/force
+
+# Add or remove space between 'scope' and '(' in 'scope (something) { }' (D language)
+# If set to ignore, sp_before_sparen is used.
+sp_scope_paren                            = ignore   # ignore/add/remove/force
+
+# Add or remove space between macro and value
+sp_macro                                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between macro function ')' and value
+sp_macro_func                             = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'else' and '{' if on the same line
+sp_else_brace                             = add   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'else' if on the same line
+sp_brace_else                             = add  # ignore/add/remove/force
+
+# Add or remove space between '}' and the name of a typedef on the same line
+sp_brace_typedef                          = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'catch' and '{' if on the same line
+sp_catch_brace                            = add   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'catch' if on the same line
+sp_brace_catch                            = add   # ignore/add/remove/force
+
+# Add or remove space between 'finally' and '{' if on the same line
+sp_finally_brace                          = add   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'finally' if on the same line
+sp_brace_finally                          = add   # ignore/add/remove/force
+
+# Add or remove space between 'try' and '{' if on the same line
+sp_try_brace                              = add   # ignore/add/remove/force
+
+# Add or remove space between get/set and '{' if on the same line
+sp_getset_brace                           = add   # ignore/add/remove/force
+
+# Add or remove space between a variable and '{' for C++ uniform initialization
+sp_word_brace                             = add      # ignore/add/remove/force
+
+# Add or remove space between a variable and '{' for a namespace
+sp_word_brace_ns                          = add      # ignore/add/remove/force
+
+# Add or remove space before the '::' operator
+sp_before_dc                              = remove   # ignore/add/remove/force
+
+# Add or remove space after the '::' operator
+sp_after_dc                               = remove   # ignore/add/remove/force
+
+# Add or remove around the D named array initializer ':' operator
+sp_d_array_colon                          = ignore   # ignore/add/remove/force
+
+# Add or remove space after the '!' (not) operator. Default=Remove
+sp_not                                    = remove   # ignore/add/remove/force
+
+# Add or remove space after the '~' (invert) operator. Default=Remove
+sp_inv                                    = remove   # ignore/add/remove/force
+
+# Add or remove space after the '&' (address-of) operator. Default=Remove
+# This does not affect the spacing after a '&' that is part of a type.
+sp_addr                                   = remove   # ignore/add/remove/force
+
+# Add or remove space around the '.' or '->' operators. Default=Remove
+sp_member                                 = remove   # ignore/add/remove/force
+
+# Add or remove space after the '*' (dereference) operator. Default=Remove
+# This does not affect the spacing after a '*' that is part of a type.
+sp_deref                                  = remove   # ignore/add/remove/force
+
+# Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'. Default=Remove
+sp_sign                                   = remove   # ignore/add/remove/force
+
+# Add or remove space before or after '++' and '--', as in '(--x)' or 'y++;'. Default=Remove
+sp_incdec                                 = remove   # ignore/add/remove/force
+
+# Add or remove space before a backslash-newline at the end of a line. Default=Add
+sp_before_nl_cont                         = add      # ignore/add/remove/force
+
+# Add or remove space after the scope '+' or '-', as in '-(void) foo;' or '+(int) bar;'
+sp_after_oc_scope                         = remove   # ignore/add/remove/force
+
+# Add or remove space after the colon in message specs
+# '-(int) f:(int) x;' vs '-(int) f: (int) x;'
+sp_after_oc_colon                         = add   # ignore/add/remove/force
+
+# Add or remove space before the colon in message specs
+# '-(int) f: (int) x;' vs '-(int) f : (int) x;'
+sp_before_oc_colon                        = remove   # ignore/add/remove/force
+
+# Add or remove space after the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'
+sp_after_oc_dict_colon                    = ignore   # ignore/add/remove/force
+
+# Add or remove space before the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'
+sp_before_oc_dict_colon                   = ignore   # ignore/add/remove/force
+
+# Add or remove space after the colon in message specs
+# '[object setValue:1];' vs '[object setValue: 1];'
+sp_after_send_oc_colon                    = remove   # ignore/add/remove/force
+
+# Add or remove space before the colon in message specs
+# '[object setValue:1];' vs '[object setValue :1];'
+sp_before_send_oc_colon                   = remove   # ignore/add/remove/force
+
+# Add or remove space after the (type) in message specs
+# '-(int)f: (int) x;' vs '-(int)f: (int)x;'
+sp_after_oc_type                          = remove   # ignore/add/remove/force
+
+# Add or remove space after the first (type) in message specs
+# '-(int) f:(int)x;' vs '-(int)f:(int)x;'
+sp_after_oc_return_type                   = remove   # ignore/add/remove/force
+
+# Add or remove space between '@selector' and '('
+# '@selector(msgName)' vs '@selector (msgName)'
+# Also applies to @protocol() constructs
+sp_after_oc_at_sel                        = ignore   # ignore/add/remove/force
+
+# Add or remove space between '@selector(x)' and the following word
+# '@selector(foo) a:' vs '@selector(foo)a:'
+sp_after_oc_at_sel_parens                 = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '@selector' parens
+# '@selector(foo)' vs '@selector( foo )'
+# Also applies to @protocol() constructs
+sp_inside_oc_at_sel_parens                = ignore   # ignore/add/remove/force
+
+# Add or remove space before a block pointer caret
+# '^int (int arg){...}' vs. ' ^int (int arg){...}'
+sp_before_oc_block_caret                  = ignore   # ignore/add/remove/force
+
+# Add or remove space after a block pointer caret
+# '^int (int arg){...}' vs. '^ int (int arg){...}'
+sp_after_oc_block_caret                   = ignore   # ignore/add/remove/force
+
+# Add or remove space between the receiver and selector in a message.
+# '[receiver selector ...]'
+sp_after_oc_msg_receiver                  = ignore   # ignore/add/remove/force
+
+# Add or remove space after @property.
+sp_after_oc_property                      = ignore   # ignore/add/remove/force
+
+# Add or remove space around the ':' in 'b ? t : f'
+sp_cond_colon                             = add   # ignore/add/remove/force
+
+# Add or remove space before the ':' in 'b ? t : f'. Overrides sp_cond_colon.
+sp_cond_colon_before                      = ignore   # ignore/add/remove/force
+
+# Add or remove space after the ':' in 'b ? t : f'. Overrides sp_cond_colon.
+sp_cond_colon_after                       = ignore   # ignore/add/remove/force
+
+# Add or remove space around the '?' in 'b ? t : f'
+sp_cond_question                          = add   # ignore/add/remove/force
+
+# Add or remove space before the '?' in 'b ? t : f'. Overrides sp_cond_question.
+sp_cond_question_before                   = ignore   # ignore/add/remove/force
+
+# Add or remove space after the '?' in 'b ? t : f'. Overrides sp_cond_question.
+sp_cond_question_after                    = ignore   # ignore/add/remove/force
+
+# In the abbreviated ternary form (a ?: b), add/remove space between ? and :.'. Overrides all other sp_cond_* options.
+sp_cond_ternary_short                     = add   # ignore/add/remove/force
+
+# Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make sense here.
+sp_case_label                             = force   # ignore/add/remove/force
+
+# Control the space around the D '..' operator.
+sp_range                                  = ignore   # ignore/add/remove/force
+
+# Control the spacing after ':' in 'for (TYPE VAR : EXPR)' (Java)
+sp_after_for_colon                        = ignore   # ignore/add/remove/force
+
+# Control the spacing before ':' in 'for (TYPE VAR : EXPR)' (Java)
+sp_before_for_colon                       = ignore   # ignore/add/remove/force
+
+# Control the spacing in 'extern (C)' (D)
+sp_extern_paren                           = ignore   # ignore/add/remove/force
+
+# Control the space after the opening of a C++ comment '// A' vs '//A'
+sp_cmt_cpp_start                          = add  # ignore/add/remove/force
+
+# TRUE: If space is added with sp_cmt_cpp_start, do it after doxygen sequences like '///', '///<', '//!' and '//!<'.
+sp_cmt_cpp_doxygen                        = true    # false/true
+
+# TRUE: If space is added with sp_cmt_cpp_start, do it after Qt translator or meta-data comments like '//:', '//=', and '//~'.
+sp_cmt_cpp_qttr                           = true    # false/true
+
+# Controls the spaces between #else or #endif and a trailing comment
+sp_endif_cmt                              = ignore   # ignore/add/remove/force
+
+# Controls the spaces after 'new', 'delete', and 'delete[]'
+sp_after_new                              = add   # ignore/add/remove/force
+
+# Controls the spaces between new and '(' in 'new()'
+sp_between_new_paren                      = remove   # ignore/add/remove/force
+
+# Controls the spaces before a trailing or embedded comment
+sp_before_tr_emb_cmt                      = remove   # ignore/add/remove/force
+
+# Number of spaces before a trailing or embedded comment
+sp_num_before_tr_emb_cmt                  = 0        # number
+
+# Control space between a Java annotation and the open paren.
+sp_annotation_paren                       = ignore   # ignore/add/remove/force
+
+#
+# Code alignment (not left column spaces/tabs)
+#
+
+# Whether to keep non-indenting tabs
+align_keep_tabs                           = false    # false/true
+
+# Whether to use tabs for aligning
+align_with_tabs                           = false    # false/true
+
+# Whether to bump out to the next tab when aligning
+align_on_tabstop                          = false    # false/true
+
+# Whether to left-align numbers
+align_number_left                         = false    # false/true
+
+# Whether to keep whitespace not required for alignment.
+align_keep_extra_space                    = false    # flladzie o Rojaalse/true
+
+# Align variable definitions in prototypes and functions
+align_func_params                         = true    # false/true
+
+# Align parameters in single-line functions that have the same name.
+# The function names must already be aligned with each other.
+align_same_func_call_params               = false    # false/true
+
+# The span for aligning variable definitions (0=don't align)
+align_var_def_span                        = 0        # number
+
+# How to align the star in variable definitions.
+#  0=Part of the type     'void *   foo;'
+#  1=Part of the variable 'void     *foo;'
+#  2=Dangling             'void    *foo;'
+align_var_def_star_style                  = 2        # number
+
+# How to align the '&' in variable definitions.
+#  0=Part of the type
+#  1=Part of the variable
+#  2=Dangling
+align_var_def_amp_style                   = 2        # number
+
+# The threshold for aligning variable definitions (0=no limit)
+align_var_def_thresh                      = 0        # number
+
+# The gap for aligning variable definitions
+align_var_def_gap                         = 0        # number
+
+# Whether to align the colon in struct bit fields
+align_var_def_colon                       = false    # false/true
+
+# Whether to align any attribute after the variable name
+align_var_def_attribute                   = false    # false/true
+
+# Whether to align inline struct/enum/union variable definitions
+align_var_def_inline                      = true    # false/true
+
+# The span for aligning on '=' in assignments (0=don't align)
+align_assign_span                         = 0        # number
+
+# The threshold for aligning on '=' in assignments (0=no limit)
+align_assign_thresh                       = 0        # number
+
+# The span for aligning on '=' in enums (0=don't align)
+align_enum_equ_span                       = 0        # number
+
+# The threshold for aligning on '=' in enums (0=no limit)
+align_enum_equ_thresh                     = 0        # number
+
+# The span for aligning struct/union (0=don't align)
+align_var_struct_span                     = 0        # number
+
+# The threshold for aligning struct/union member definitions (0=no limit)
+align_var_struct_thresh                   = 0        # number
+
+# The gap for aligning struct/union member definitions
+align_var_struct_gap                      = 0        # number
+
+# The span for aligning struct initializer values (0=don't align)
+align_struct_init_span                    = 0        # number
+
+# The minimum space between the type and the synonym of a typedef
+align_typedef_gap                         = 0        # number
+
+# The span for aligning single-line typedefs (0=don't align)
+align_typedef_span                        = 0        # number
+
+# How to align typedef'd functions with other typedefs
+# 0: Don't mix them at all
+# 1: align the open paren with the types
+# 2: align the function type name with the other type names
+align_typedef_func                        = 0        # number
+
+# Controls the positioning of the '*' in typedefs. Just try it.
+# 0: Align on typedef type, ignore '*'
+# 1: The '*' is part of type name: typedef int  *pint;
+# 2: The '*' is part of the type, but dangling: typedef int *pint;
+align_typedef_star_style                  = 0        # number
+
+# Controls the positioning of the '&' in typedefs. Just try it.
+# 0: Align on typedef type, ignore '&'
+# 1: The '&' is part of type name: typedef int  &pint;
+# 2: The '&' is part of the type, but dangling: typedef int &pint;
+align_typedef_amp_style                   = 0        # number
+
+# The span for aligning comments that end lines (0=don't align)
+align_right_cmt_span                      = 0        # number
+
+# If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment
+align_right_cmt_mix                       = false    # false/true
+
+# If a trailing comment is more than this number of columns away from the text it follows,
+# it will qualify for being aligned. This has to be > 0 to do anything.
+align_right_cmt_gap                       = 0        # number
+
+# Align trailing comment at or beyond column N; 'pulls in' comments as a bonus side effect (0=ignore)
+align_right_cmt_at_col                    = 0        # number
+
+# The span for aligning function prototypes (0=don't align)
+align_func_proto_span                     = 0        # number
+
+# Minimum gap between the return type and the function name.
+align_func_proto_gap                      = 1        # number
+
+# Align function protos on the 'operator' keyword instead of what follows
+align_on_operator                         = false    # false/true
+
+# Whether to mix aligning prototype and variable declarations.
+# If true, align_var_def_XXX options are used instead of align_func_proto_XXX options.
+align_mix_var_proto                       = false    # false/true
+
+# Align single-line functions with function prototypes, uses align_func_proto_span
+align_single_line_func                    = false    # false/true
+
+# Aligning the open brace of single-line functions.
+# Requires align_single_line_func=true, uses align_func_proto_span
+align_single_line_brace                   = false    # false/true
+
+# Gap for align_single_line_brace.
+align_single_line_brace_gap               = 0        # number
+
+# The span for aligning ObjC msg spec (0=don't align)
+align_oc_msg_spec_span                    = 0        # number
+
+# Whether to align macros wrapped with a backslash and a newline.
+# This will not work right if the macro contains a multi-line comment.
+align_nl_cont                             = false    # false/true
+
+# # Align macro functions and variables together
+align_pp_define_together                  = false    # false/true
+
+# The minimum space between label and value of a preprocessor define
+align_pp_define_gap                       = 0        # number
+
+# The span for aligning on '#define' bodies (0=don't align, other=number of lines including comments between blocks)
+align_pp_define_span                      = 0        # number
+
+# Align lines that start with '<<' with previous '<<'. Default=true
+align_left_shift                          = true     # false/true
+
+# Span for aligning parameters in an Obj-C message call on the ':' (0=don't align)
+align_oc_msg_colon_span                   = 0        # number
+
+# If true, always align with the first parameter, even if it is too short.
+align_oc_msg_colon_first                  = false    # false/true
+
+# Aligning parameters in an Obj-C '+' or '-' declaration on the ':'
+align_oc_decl_colon                       = false    # false/true
+
+#
+# Newline adding and removing options
+#
+
+# Whether to collapse empty blocks between '{' and '}'
+nl_collapse_empty_body                    = true    # false/true
+
+# Don't split one-line braced assignments - 'foo_t f = { 1, 2 };'
+nl_assign_leave_one_liners                = true    # false/true
+
+# Don't split one-line braced statements inside a class xx { } body
+nl_class_leave_one_liners                 = true    # false/true
+
+# Don't split one-line enums: 'enum foo { BAR = 15 };'
+nl_enum_leave_one_liners                  = true    # false/true
+
+# Don't split one-line get or set functions
+nl_getset_leave_one_liners                = true    # false/true
+
+# Don't split one-line function definitions - 'int foo() { return 0; }'
+nl_func_leave_one_liners                  = true    # false/true
+
+# Don't split one-line C++11 lambdas - '[]() { return 0; }'
+nl_cpp_lambda_leave_one_liners            = true    # false/true
+
+# Don't split one-line if/else statements - 'if(a) b++;'
+nl_if_leave_one_liners                    = false    # false/true
+
+# Don't split one-line while statements - 'while(a) b++;'
+nl_while_leave_one_liners                 = false    # false/true
+
+# Don't split one-line OC messages
+nl_oc_msg_leave_one_liner                 = false    # false/true
+
+# Add or remove newlines at the start of the file
+nl_start_of_file                          = remove   # ignore/add/remove/force
+
+# The number of newlines at the start of the file (only used if nl_start_of_file is 'add' or 'force'
+nl_start_of_file_min                      = 0        # number
+
+# Add or remove newline at the end of the file
+nl_end_of_file                            = remove   # ignore/add/remove/force
+
+# The number of newlines at the end of the file (only used if nl_end_of_file is 'add' or 'force')
+nl_end_of_file_min                        = 0        # number
+
+# Add or remove newline between '=' and '{'
+nl_assign_brace                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between '=' and '[' (D only)
+nl_assign_square                          = ignore   # ignore/add/remove/force
+
+# Add or remove newline after '= [' (D only). Will also affect the newline before the ']'
+nl_after_square_assign                    = ignore   # ignore/add/remove/force
+
+# The number of blank lines after a block of variable definitions at the top of a function body
+# 0 = No change (default)
+nl_func_var_def_blk                       = 2        # number
+
+# The number of newlines before a block of typedefs
+# 0 = No change (default)
+nl_typedef_blk_start                      = 2        # number
+
+# The number of newlines after a block of typedefs
+# 0 = No change (default)
+nl_typedef_blk_end                        = 2        # number
+
+# The maximum consecutive newlines within a block of typedefs
+# 0 = No change (default)
+nl_typedef_blk_in                         = 2        # number
+
+# The number of newlines before a block of variable definitions not at the top of a function body
+# 0 = No change (default)
+nl_var_def_blk_start                      = 2        # number
+
+# The number of newlines after a block of variable definitions not at the top of a function body
+# 0 = No change (default)
+nl_var_def_blk_end                        = 2        # number
+
+# The maximum consecutive newlines within a block of variable definitions
+# 0 = No change (default)
+nl_var_def_blk_in                         = 2        # number
+
+# Add or remove newline between a function call's ')' and '{', as in:
+# list_for_each(item, &list) { }
+nl_fcall_brace                            = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'enum' and '{'
+nl_enum_brace                             = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'struct and '{'
+nl_struct_brace                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'union' and '{'
+nl_union_brace                            = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'if' and '{'
+nl_if_brace                               = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'else'
+nl_brace_else                             = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'else if' and '{'
+# If set to ignore, nl_if_brace is used instead
+nl_elseif_brace                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'else' and '{'
+nl_else_brace                             = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'else' and 'if'
+nl_else_if                                = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'finally'
+nl_brace_finally                          = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'finally' and '{'
+nl_finally_brace                          = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'try' and '{'
+nl_try_brace                              = remove   # ignore/add/remove/force
+
+# Add or remove newline between get/set and '{'
+nl_getset_brace                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'for' and '{'
+nl_for_brace                              = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'catch' and '{'
+nl_catch_brace                            = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'catch'
+nl_brace_catch                            = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and ']'
+nl_brace_square                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and ')' in a function invocation
+nl_brace_fparen                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'while' and '{'
+nl_while_brace                            = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'scope (x)' and '{' (D)
+nl_scope_brace                            = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'unittest' and '{' (D)
+nl_unittest_brace                         = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'version (x)' and '{' (D)
+nl_version_brace                          = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'using' and '{'
+nl_using_brace                            = remove   # ignore/add/remove/force
+
+# Add or remove newline between two open or close braces.
+# Due to general newline/brace handling, REMOVE may not work.
+nl_brace_brace                            = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'do' and '{'
+nl_do_brace                               = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'while' of 'do' statement
+nl_brace_while                            = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'switch' and '{'
+nl_switch_brace                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'synchronized' and '{'
+nl_synchronized_brace                     = remove   # ignore/add/remove/force
+
+# Add a newline between ')' and '{' if the ')' is on a different line than the if/for/etc.
+# Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch, and nl_catch_brace.
+nl_multi_line_cond                        = false    # false/true
+
+# Force a newline in a define after the macro name for multi-line defines.
+nl_multi_line_define                      = false    # false/true
+
+# Whether to put a newline before 'case' statement
+nl_before_case                            = false    # false/true
+
+# Add or remove newline between ')' and 'throw'
+nl_before_throw                           = add   # ignore/add/remove/force
+
+# Whether to put a newline after 'case' statement
+nl_after_case                             = true    # false/true
+
+# Add or remove a newline between a case ':' and '{'. Overrides nl_after_case.
+nl_case_colon_brace                       = ignore   # ignore/add/remove/force
+
+# Newline between namespace and {
+nl_namespace_brace                        = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'template<>' and whatever follows.
+nl_template_class                         = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'class' and '{'
+nl_class_brace                            = remove   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in the class base list
+nl_class_init_args                        = remove   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in the constructor member initialization
+nl_constr_init_args                       = ignore   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name in a function definition
+nl_func_type_name                         = remove   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name inside a class {}
+# Uses nl_func_type_name or nl_func_proto_type_name if set to ignore.
+nl_func_type_name_class                   = remove   # ignore/add/remove/force
+
+# Add or remove newline between function scope and name in a definition
+# Controls the newline after '::' in 'void A::f() { }'
+nl_func_scope_name                        = remove   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name in a prototype
+nl_func_proto_type_name                   = remove   # ignore/add/remove/force
+
+# Add or remove newline between a function name and the opening '('
+nl_func_paren                             = remove   # ignore/add/remove/force
+
+# Add or remove newline between a function name and the opening '(' in the definition
+nl_func_def_paren                         = remove   # ignore/add/remove/force
+
+# Add or remove newline after '(' in a function declaration
+nl_func_decl_start                        = remove   # ignore/add/remove/force
+
+# Add or remove newline after '(' in a function definition
+nl_func_def_start                         = remove   # ignore/add/remove/force
+
+# Overrides nl_func_decl_start when there is only one parameter.
+nl_func_decl_start_single                 = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_def_start when there is only one parameter.
+nl_func_def_start_single                  = ignore   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in a function declaration
+nl_func_decl_args                         = remove   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in a function definition
+nl_func_def_args                          = remove   # ignore/add/remove/force
+
+# Add or remove newline before the ')' in a function declaration
+nl_func_decl_end                          = remove   # ignore/add/remove/force
+
+# Add or remove newline before the ')' in a function definition
+nl_func_def_end                           = remove   # ignore/add/remove/force
+
+# Overrides nl_func_decl_end when there is only one parameter.
+nl_func_decl_end_single                   = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_def_end when there is only one parameter.
+nl_func_def_end_single                    = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '()' in a function declaration.
+nl_func_decl_empty                        = remove   # ignore/add/remove/force
+
+# Add or remove newline between '()' in a function definition.
+nl_func_def_empty                         = remove   # ignore/add/remove/force
+
+# Whether to put each OC message parameter on a separate line
+# See nl_oc_msg_leave_one_liner
+nl_oc_msg_args                            = false    # false/true
+
+# Add or remove newline between function signature and '{'
+nl_fdef_brace                             = remove   # ignore/add/remove/force
+
+# Add or remove newline between C++11 lambda signature and '{'
+nl_cpp_ldef_brace                         = remove   # ignore/add/remove/force
+
+# Add or remove a newline between the return keyword and return expression.
+nl_return_expr                            = ignore   # ignore/add/remove/force
+
+# Whether to put a newline after semicolons, except in 'for' statements
+nl_after_semicolon                        = false    # false/true
+
+# Java: Control the newline between the ')' and '{{' of the double brace initializer.
+nl_paren_dbrace_open                      = ignore   # ignore/add/remove/force
+
+# Whether to put a newline after brace open.
+# This also adds a newline before the matching brace close.
+nl_after_brace_open                       = false    # false/true
+
+# If nl_after_brace_open and nl_after_brace_open_cmt are true, a newline is
+# placed between the open brace and a trailing single-line comment.
+nl_after_brace_open_cmt                   = false    # false/true
+
+# Whether to put a newline after a virtual brace open with a non-empty body.
+# These occur in un-braced if/while/do/for statement bodies.
+nl_after_vbrace_open                      = false    # false/true
+
+# Whether to put a newline after a virtual brace open with an empty body.
+# These occur in un-braced if/while/do/for statement bodies.
+nl_after_vbrace_open_empty                = false    # false/true
+
+# Whether to put a newline after a brace close.
+# Does not apply if followed by a necessary ';'.
+nl_after_brace_close                      = false    # false/true
+
+# Whether to put a newline after a virtual brace close.
+# Would add a newline before return in: 'if (foo) a++; return;'
+nl_after_vbrace_close                     = true    # false/true
+
+# Control the newline between the close brace and 'b' in: 'struct { int a; } b;'
+# Affects enums, unions, and structures. If set to ignore, uses nl_after_brace_close
+nl_brace_struct_var                       = remove   # ignore/add/remove/force
+
+# Whether to alter newlines in '#define' macros
+nl_define_macro                           = false    # false/true
+
+# Whether to not put blanks after '#ifxx', '#elxx', or before '#endif'. Does not affect the whole-file #ifdef.
+nl_squeeze_ifdef                          = false    # false/true
+
+# Add or remove blank line before 'if'
+nl_before_if                              = add   # ignore/add/remove/force
+
+# Add or remove blank line after 'if' statement
+nl_after_if                               = add   # ignore/add/remove/force
+
+# Add or remove blank line before 'for'
+nl_before_for                             = add   # ignore/add/remove/force
+
+# Add or remove blank line after 'for' statement
+nl_after_for                              = add   # ignore/add/remove/force
+
+# Add or remove blank line before 'while'
+nl_before_while                           = remove   # ignore/add/remove/force
+
+# Add or remove blank line after 'while' statement
+nl_after_while                            = remove   # ignore/add/remove/force
+
+# Add or remove blank line before 'switch'
+nl_before_switch                          = add   # ignore/add/remove/force
+
+# Add or remove blank line after 'switch' statement
+nl_after_switch                           = remove   # ignore/add/remove/force
+
+# Add or remove blank line before 'synchronized'
+nl_before_synchronized                    = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'synchronized' statement
+nl_after_synchronized                     = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'do'
+nl_before_do                              = add   # ignore/add/remove/force
+
+# Add or remove blank line after 'do/while' statement
+nl_after_do                               = add   # ignore/add/remove/force
+
+# Whether to double-space commented-entries in struct/enum
+nl_ds_struct_enum_cmt                     = false    # false/true
+
+# Whether to double-space before the close brace of a struct/union/enum
+# (lower priority than 'eat_blanks_before_close_brace')
+nl_ds_struct_enum_close_brace             = false    # false/true
+
+# Add or remove a newline around a class colon.
+# Related to pos_class_colon, nl_class_init_args, and pos_class_comma.
+nl_class_colon                            = remove   # ignore/add/remove/force
+
+# Add or remove a newline around a class constructor colon.
+# Related to pos_constr_colon, nl_constr_init_args, and pos_constr_comma.
+nl_constr_colon                           = add   # ignore/add/remove/force
+
+# Change simple unbraced if statements into a one-liner
+# 'if(b)\n i++;' => 'if(b) i++;'
+nl_create_if_one_liner                    = false    # false/true
+
+# Change simple unbraced for statements into a one-liner
+# 'for (i=0;i<5;i++)\n foo(i);' => 'for (i=0;i<5;i++) foo(i);'
+nl_create_for_one_liner                   = false    # false/true
+
+# Change simple unbraced while statements into a one-liner
+# 'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'
+nl_create_while_one_liner                 = false    # false/true
+
+#
+# Positioning options
+#
+
+# The position of arithmetic operators in wrapped expressions
+pos_arith                                 = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of assignment in wrapped expressions.
+# Do not affect '=' followed by '{'
+pos_assign                                = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of boolean operators in wrapped expressions
+pos_bool                                  = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of comparison operators in wrapped expressions
+pos_compare                               = join   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of conditional (b ? t : f) operators in wrapped expressions
+pos_conditional                           = join   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of the comma in wrapped expressions
+pos_comma                                 = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of the comma in the class base list
+pos_class_comma                           = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of the comma in the constructor initialization list
+pos_constr_comma                          = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of colons between class and base class list
+pos_class_colon                           = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of colons between constructor and member initialization
+pos_constr_colon                          = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+#
+# Line Splitting options
+#
+
+# Try to limit code width to N number of columns
+code_width                                = 100        # number
+
+# Whether to fully split long 'for' statements at semi-colons
+ls_for_split_full                         = true    # false/true
+
+# Whether to fully split long function protos/calls at commas
+ls_func_split_full                        = true   # false/true
+
+# Whether to split lines as close to code_width as possible and ignore some groupings
+ls_code_width                             = true    # false/true
+
+#
+# Blank line options
+#
+
+# The maximum consecutive newlines
+nl_max                                    = 2        # number
+
+# The number of newlines after a function prototype, if followed by another function prototype
+nl_after_func_proto                       = 1        # number
+
+# The number of newlines after a function prototype, if not followed by another function prototype
+nl_after_func_proto_group                 = 1        # number
+
+# The number of newlines after '}' of a multi-line function body
+nl_after_func_body                        = 2        # number
+
+# The number of newlines after '}' of a multi-line function body in a class declaration
+nl_after_func_body_class                  = 2        # number
+
+# The number of newlines after '}' of a single line function body
+nl_after_func_body_one_liner              = 2        # number
+
+# The minimum number of newlines before a multi-line comment.
+# Doesn't apply if after a brace open or another multi-line comment.
+nl_before_block_comment                   = 2        # number
+
+# The minimum number of newlines before a single-line C comment.
+# Doesn't apply if after a brace open or other single-line C comments.
+nl_before_c_comment                       = 2        # number
+
+# The minimum number of newlines before a CPP comment.
+# Doesn't apply if after a brace open or other CPP comments.
+nl_before_cpp_comment                     = 2        # number
+
+# Whether to force a newline after a multi-line comment.
+nl_after_multiline_comment                = false    # false/true
+
+# Whether to force a newline after a label's colon.
+nl_after_label_colon                      = false    # false/true
+
+# The number of newlines after '}' or ';' of a struct/enum/union definition
+nl_after_struct                           = 1        # number
+
+# The number of newlines after '}' or ';' of a class definition
+nl_after_class                            = 1        # number
+
+# The number of newlines before a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
+# Will not change the newline count if after a brace open.
+# 0 = No change.
+nl_before_access_spec                     = 2        # number
+
+# The number of newlines after a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
+# 0 = No change.
+nl_after_access_spec                      = 1        # number
+
+# The number of newlines between a function def and the function comment.
+# 0 = No change.
+nl_comment_func_def                       = 0        # number
+
+# The number of newlines after a try-catch-finally block that isn't followed by a brace close.
+# 0 = No change.
+nl_after_try_catch_finally                = 1        # number
+
+# The number of newlines before and after a property, indexer or event decl.
+# 0 = No change.
+nl_around_cs_property                     = 1        # number
+
+# The number of newlines between the get/set/add/remove handlers in C#.
+# 0 = No change.
+nl_between_get_set                        = 0        # number
+
+# Add or remove newline between C# property and the '{'
+nl_property_brace                         = ignore   # ignore/add/remove/force
+
+# Whether to remove blank lines after '{'
+eat_blanks_after_open_brace               = true    # false/true
+
+# Whether to remove blank lines before '}'
+eat_blanks_before_close_brace             = true   # false/true
+
+# How aggressively to remove extra newlines not in preproc.
+# 0: No change
+# 1: Remove most newlines not handled by other config
+# 2: Remove all newlines and reformat completely by config
+nl_remove_extra_newlines                  = 0        # number
+
+# Whether to put a blank line before 'return' statements, unless after an open brace.
+nl_before_return                          = false    # false/true
+
+# Whether to put a blank line after 'return' statements, unless followed by a close brace.
+nl_after_return                           = true    # false/true
+
+# Whether to put a newline after a Java annotation statement.
+# Only affects annotations that are after a newline.
+nl_after_annotation                       = ignore   # ignore/add/remove/force
+
+# Controls the newline between two annotations.
+nl_between_annotation                     = ignore   # ignore/add/remove/force
+
+#
+# Code modifying options (non-whitespace)
+#
+
+# Add or remove braces on single-line 'do' statement
+mod_full_brace_do                         = ignore   # ignore/add/remove/force
+
+# Add or remove braces on single-line 'for' statement
+mod_full_brace_for                        = ignore  # ignore/add/remove/force
+
+# Add or remove braces on single-line function definitions. (Pawn)
+mod_full_brace_function                   = ignore   # ignore/add/remove/force
+
+# Add or remove braces on single-line 'if' statement. Will not remove the braces if they contain an 'else'.
+mod_full_brace_if                         = ignore   # ignore/add/remove/force
+
+# Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
+# If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
+mod_full_brace_if_chain                   = true    # false/true
+
+# Don't remove braces around statements that span N newlines
+mod_full_brace_nl                         = 1        # number
+
+# Add or remove braces on single-line 'while' statement
+mod_full_brace_while                      = ignore   # ignore/add/remove/force
+
+# Add or remove braces on single-line 'using ()' statement
+mod_full_brace_using                      = ignore   # ignore/add/remove/force
+
+# Add or remove unnecessary paren on 'return' statement
+mod_paren_on_return                       = remove   # ignore/add/remove/force
+
+# Whether to change optional semicolons to real semicolons
+mod_pawn_semicolon                        = false    # false/true
+
+# Add parens on 'while' and 'if' statement around bools
+mod_full_paren_if_bool                    = true    # false/true
+
+# Whether to remove superfluous semicolons
+mod_remove_extra_semicolon                = false    # false/true
+
+# If a function body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_function_closebrace_comment  = 0        # number
+
+# If a namespace body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_namespace_closebrace_comment = 200        # number
+
+# If a switch body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_switch_closebrace_comment    = 0        # number
+
+# If an #ifdef body exceeds the specified number of newlines and doesn't have a comment after
+# the #endif, a comment will be added.
+mod_add_long_ifdef_endif_comment          = 0        # number
+
+# If an #ifdef or #else body exceeds the specified number of newlines and doesn't have a comment after
+# the #else, a comment will be added.
+mod_add_long_ifdef_else_comment           = 0        # number
+
+# If TRUE, will sort consecutive single-line 'import' statements [Java, D]
+mod_sort_import                           = false    # false/true
+
+# If TRUE, will sort consecutive single-line 'using' statements [C#]
+mod_sort_using                            = false    # false/true
+
+# If TRUE, will sort consecutive single-line '#include' statements [C/C++] and '#import' statements [Obj-C]
+# This is generally a bad idea, as it may break your code.
+mod_sort_include                          = false    # false/true
+
+# If TRUE, it will move a 'break' that appears after a fully braced 'case' before the close brace.
+mod_move_case_break                       = false    # false/true
+
+# Will add or remove the braces around a fully braced case statement.
+# Will only remove the braces if there are no variable declarations in the block.
+mod_case_brace                            = ignore   # ignore/add/remove/force
+
+# If TRUE, it will remove a void 'return;' that appears as the last statement in a function.
+mod_remove_empty_return                   = true    # false/true
+
+#
+# Comment modifications
+#
+
+# Try to wrap comments at cmt_width columns
+cmt_width                                 = 100        # number
+
+# Set the comment reflow mode (default: 0)
+# 0: no reflowing (apart from the line wrapping due to cmt_width)
+# 1: no touching at all
+# 2: full reflow
+cmt_reflow_mode                           = 2        # number
+
+# Whether to convert all tabs to spaces in comments. Default is to leave tabs inside comments alone, unless used for indenting.
+cmt_convert_tab_to_spaces                 = true    # false/true
+
+# If false, disable all multi-line comment changes, including cmt_width. keyword substitution, and leading chars.
+# Default is true.
+cmt_indent_multi                          = true     # false/true
+
+# Whether to group c-comments that look like they are in a block
+cmt_c_group                               = true    # false/true
+
+# Whether to put an empty '/*' on the first line of the combined c-comment
+cmt_c_nl_start                            = true    # false/true
+
+# Whether to put a newline before the closing '*/' of the combined c-comment
+cmt_c_nl_end                              = false    # false/true
+
+# Whether to group cpp-comments that look like they are in a block
+cmt_cpp_group                             = true    # false/true
+
+# Whether to put an empty '/*' on the first line of the combined cpp-comment
+cmt_cpp_nl_start                          = true    # false/true
+
+# Whether to put a newline before the closing '*/' of the combined cpp-comment
+cmt_cpp_nl_end                            = true    # false/true
+
+# Whether to change cpp-comments into c-comments
+cmt_cpp_to_c                              = false    # false/true
+
+# Whether to put a star on subsequent comment lines
+cmt_star_cont                             = false    # false/true
+
+# The number of spaces to insert at the start of subsequent comment lines
+cmt_sp_before_star_cont                   = 0        # number
+
+# The number of spaces to insert after the star on subsequent comment lines
+cmt_sp_after_star_cont                    = 0        # number
+
+# For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
+# the comment are the same length. Default=True
+cmt_multi_check_last                      = true     # false/true
+
+# The filename that contains text to insert at the head of a file if the file doesn't start with a C/C++ comment.
+# Will substitute $(filename) with the current file's name.
+cmt_insert_file_header                    = ""         # string
+
+# The filename that contains text to insert at the end of a file if the file doesn't end with a C/C++ comment.
+# Will substitute $(filename) with the current file's name.
+cmt_insert_file_footer                    = ""         # string
+
+# The filename that contains text to insert before a function implementation if the function isn't preceded with a C/C++ comment.
+# Will substitute $(function) with the function name and $(javaparam) with the javadoc @param and @return stuff.
+# Will also substitute $(fclass) with the class name: void CFoo::Bar() { ... }
+# cmt_insert_func_header                    = "func_comment.tpl"         # string
+
+# The filename that contains text to insert before a class if the class isn't preceded with a C/C++ comment.
+# Will substitute $(class) with the class name.
+cmt_insert_class_header                   = ""         # string
+
+# The filename that contains text to insert before a Obj-C message specification if the method isn't preceded with a C/C++ comment.
+# Will substitute $(message) with the function name and $(javaparam) with the javadoc @param and @return stuff.
+cmt_insert_oc_msg_header                  = ""         # string
+
+# If a preprocessor is encountered when stepping backwards from a function name, then
+# this option decides whether the comment should be inserted.
+# Affects cmt_insert_oc_msg_header, cmt_insert_func_header and cmt_insert_class_header.
+cmt_insert_before_preproc                 = false    # false/true
+
+#
+# Preprocessor options
+#
+
+# Control indent of preprocessors inside #if blocks at brace level 0 (file-level)
+pp_indent                                 = ignore   # ignore/add/remove/force
+
+# Whether to indent #if/#else/#endif at the brace level (true) or from column 1 (false)
+pp_indent_at_level                        = false    # false/true
+
+# Specifies the number of columns to indent preprocessors per level at brace level 0 (file-level).
+# If pp_indent_at_level=false, specifies the number of columns to indent preprocessors per level at brace level > 0 (function-level).
+# Default=1.
+pp_indent_count                           = 1        # number
+
+# Add or remove space after # based on pp_level of #if blocks
+pp_space                                  = ignore   # ignore/add/remove/force
+
+# Sets the number of spaces added with pp_space
+pp_space_count                            = 0        # number
+
+# The indent for #region and #endregion in C# and '#pragma region' in C/C++
+pp_indent_region                          = 0        # number
+
+# Whether to indent the code between #region and #endregion
+pp_region_indent_code                     = false    # false/true
+
+# If pp_indent_at_level=true, sets the indent for #if, #else, and #endif when not at file-level.
+# 0:  indent preprocessors using output_tab_size.
+# >0: column at which all preprocessors will be indented.
+pp_indent_if                              = 0        # number
+
+# Control whether to indent the code between #if, #else and #endif.
+pp_if_indent_code                         = false    # false/true
+
+# Whether to indent '#define' at the brace level (true) or from column 1 (false)
+pp_define_at_level                        = false    # false/true
+
+# You can force a token to be a type with the 'type' option.
+# Example:
+# type myfoo1 myfoo2
+#
+# You can create custom macro-based indentation using macro-open,
+# macro-else and macro-close.
+# Example:
+# macro-open  BEGIN_TEMPLATE_MESSAGE_MAP
+# macro-open  BEGIN_MESSAGE_MAP
+# macro-close END_MESSAGE_MAP
+#
+# You can assign any keyword to any type with the set option.
+# set func_call_user _ N_
+#
+# The full syntax description of all custom definition config entries
+# is shown below:
+#
+# define custom tokens as:
+# - embed whitespace in token using '' escape character, or
+#   put token in quotes
+# - these: ' " and ` are recognized as quote delimiters
+#
+# type token1 token2 token3 ...
+#             ^ optionally specify multiple tokens on a single line
+# define def_token output_token
+#                  ^ output_token is optional, then NULL is assumed
+# macro-open token
+# macro-close token
+# macro-else token
+# set id token1 token2 ...
+#               ^ optionally specify multiple tokens on a single line
+#     ^ id is one of the names in token_enum.h sans the CT_ prefix,
+#       e.g. PP_PRAGMA
+#
+# all tokens are separated by any mix of ',' commas, '=' equal signs
+# and whitespace (space, tab)
+#
+# You can add support for other file extensions using the 'file_ext' command.
+# The first arg is the language name used with the '-l' option.
+# The remaining args are file extensions, matched with 'endswith'.
+#   file_ext CPP .ch .cxx .cpp.in
+#

--- a/uncrustify.sh
+++ b/uncrustify.sh
@@ -1,0 +1,43 @@
+#!/bin/sh 
+
+if [ ! -n "$1" ]; then
+echo "Syntax is: uncrustify.sh dirname filesuffix"
+echo "Syntax is: uncrustify.sh filename"
+echo "Example: uncrustify.sh temp cpp"
+exit 1
+fi
+
+if [ -d "$1" ]; then
+#echo "Dir ${1} exists"
+if [ -n "$2" ]; then
+filesuffix=$2
+else
+filesuffix="*"
+fi
+
+#echo "Filtering files using suffix ${filesuffix}"
+
+file_list=`find ${1} -name "*.${filesuffix}" -type f`
+for file2indent in $file_list
+do 
+echo "Indenting file $file2indent"
+#!/bin/bash
+uncrustify -f "$file2indent" -c uncrustify.cfg -o indentoutput.tmp
+mv indentoutput.tmp "$file2indent"
+
+done
+else
+if [ -f "$1" ]; then
+echo "Indenting one file $1"
+#!/bin/bash
+uncrustify -f "$1" -c uncrustify.cfg -o indentoutput.tmp
+mv indentoutput.tmp "$1"
+
+else
+echo "ERROR: As parameter given directory or file does not exist!"
+echo "Syntax is: uncrustify.sh dirname filesuffix"
+echo "Syntax is: uncrustify.sh filename"
+echo "Example: uncrustify.sh temp cpp"
+exit 1
+fi
+fi


### PR DESCRIPTION
Here is an example of changes that uncrustify can do on the code in src/storage. Looks pretty nice, IMHO. Uncrustify only reformat code so there should be no issue with any missing parts of code.  

There is a comprehensive code style for C++: https://google.github.io/styleguide/cppguide.html
with cpplint that does check https://github.com/google/styleguide/tree/gh-pages/cpplint 
Still this uncrustify does not solve all problems pointed out by cpplint but the code looks
cleaner.
Perhaps the solution would be to use cpplint as a git hook, unfortunately it can be only locally so
it is rather a case agreement. At least it will prevent from committing 
the files without a proper code style.

cc: @stuehn @govarguz @junghans 
issue #39 
