### PR TITLE
default constructor now returns 0 energy and force

### DIFF
--- a/src/interaction/CoulombTruncated.hpp
+++ b/src/interaction/CoulombTruncated.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2012,2013,2015
+  Copyright (C) 2012,2013,2015,2016
       Max Planck Institute for Polymer Research
   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
@@ -41,7 +41,7 @@ namespace espressopp {
     public:
       static void registerPython();
 
-      CoulombTruncated(): prefactor(1.0) {
+      CoulombTruncated(): prefactor(0.0) {
         setShift(0.0);
         setCutoff(infinity);
         autoShift = false;

--- a/src/interaction/ReactionFieldGeneralized.hpp
+++ b/src/interaction/ReactionFieldGeneralized.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2012,2013
+  Copyright (C) 2012,2013,2016
       Max Planck Institute for Polymer Research
   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
@@ -69,7 +69,7 @@ namespace espressopp {
                 static void registerPython();
 
                 ReactionFieldGeneralized()
-                : prefactor(1), kappa(0.0),
+                : prefactor(0.0), kappa(0.0),
                  epsilon1(1.0), epsilon2(80.0),
                  rc(1.0){
                     setShift(0.0);


### PR DESCRIPTION
in ReactionFieldGeneralized and CoulombTruncated.
This is necessary because potentials' default
constructors are used to fill in empty entries
in the 2D potential types arrays.