### PR TITLE
Fix warning extra semicolon logger: warning: extra ';' inside a class [-Wextra-semi]

### DIFF
--- a/src/include/log4espp.hpp
+++ b/src/include/log4espp.hpp
@@ -421,9 +421,9 @@ class LogClass {
   *   LOG4ESPP_LOGGER(logger,name)                       *
   *******************************************************/
 
-#define LOG4ESPP_ROOTLOGGER(aLogger) LogClass aLogger;
-#define LOG4ESPP_LOGGER(aLogger,name) LogClass aLogger;
-#define LOG4ESPP_DECL_LOGGER(aLogger) LogClass aLogger;
+#define LOG4ESPP_ROOTLOGGER(aLogger) LogClass aLogger
+#define LOG4ESPP_LOGGER(aLogger,name) LogClass aLogger
+#define LOG4ESPP_DECL_LOGGER(aLogger) LogClass aLogger
 
 #define LOG4ESPP_TRACE_ON(logger) (0)
 #define LOG4ESPP_DEBUG_ON(logger) (0)

--- a/src/include/log4espp.hpp
+++ b/src/include/log4espp.hpp
@@ -1,23 +1,25 @@
 /*
+  Copyright (C) 2016
+      Max Planck Institute for Polymer Research & JGU Mainz
   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
+
   This file is part of ESPResSo++.
-  
+
   ESPResSo++ is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-  
+
   ESPResSo++ is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 /****************************************************************************
@@ -184,7 +186,7 @@
 
 #define LOG4ESPP_ROOTLOGGER(aLogger) log4cpp::Category& aLogger = log4cpp::Category::getRoot()
 
-#define LOG4ESPP_DECL_LOGGER(aLogger) log4cpp::Category& aLogger;
+#define LOG4ESPP_DECL_LOGGER(aLogger) log4cpp::Category& aLogger
 #define LOG4ESPP_LOGGER(aLogger,name) log4cpp::Category& aLogger = log4cpp::Category::getInstance(std::string(name))
 
   /*******************************************************
@@ -205,7 +207,7 @@
 #ifdef LOG4ESPP_TRACE_ENABLED
 #define LOG4ESPP_TRACE(logger,msg) { if (logger.isPriorityEnabled(log4cpp::Priority::DEBUG)) \
                  { std::ostringstream omsg; omsg << msg; logger.debug(omsg.str()); }}
-#else 
+#else
 #define LOG4ESPP_TRACE(logger,msg)
 #endif
 
@@ -216,7 +218,7 @@
 #ifdef LOG4ESPP_DEBUG_ENABLED
 #define LOG4ESPP_DEBUG(logger,msg) { if (logger.isPriorityEnabled(log4cpp::Priority::DEBUG)) \
                  { std::ostringstream omsg; omsg << msg; logger.debug(omsg.str()); }}
-#else 
+#else
 #define LOG4ESPP_DEBUG(logger,msg)
 #endif
 
@@ -227,7 +229,7 @@
 #ifdef LOG4ESPP_INFO_ENABLED
 #define LOG4ESPP_INFO(logger,msg) { if (logger.isPriorityEnabled(log4cpp::Priority::INFO)) \
                  { std::ostringstream omsg; omsg << msg; logger.info(omsg.str()); }}
-#else 
+#else
 #define LOG4ESPP_INFO(logger,msg)
 #endif
 
@@ -238,7 +240,7 @@
 #ifdef LOG4ESPP_WARN_ENABLED
 #define LOG4ESPP_WARN(logger,msg) { if (logger.isPriorityEnabled(log4cpp::Priority::WARN)) \
                  { std::ostringstream omsg; omsg << msg; logger.warn(omsg.str()); }}
-#else 
+#else
 #define LOG4ESPP_WARN(logger,msg)
 #endif
 
@@ -249,7 +251,7 @@
 #ifdef LOG4ESPP_ERROR_ENABLED
 #define LOG4ESPP_ERROR(logger,msg) { if (logger.isPriorityEnabled(log4cpp::Priority::ERROR)) \
                  { std::ostringstream omsg; omsg << msg; logger.error(omsg.str()); }}
-#else 
+#else
 #define LOG4ESPP_ERROR(logger,msg)
 #endif
 
@@ -260,7 +262,7 @@
 #ifdef LOG4ESPP_FATAL_ENABLED
 #define LOG4ESPP_FATAL(logger,msg) { if (logger.isPriorityEnabled(log4cpp::Priority::FATAL)) \
                  { std::ostringstream omsg; omsg << msg; logger.fatal(omsg.str()); }}
-#else 
+#else
 #define LOG4ESPP_FATAL(logger,msg)
 #endif
 
@@ -456,7 +458,7 @@ class LogClass {
 
 #define LOG4ESPP_ROOTLOGGER(aLogger) log4espp::Logger& aLogger = log4espp::Logger::getRoot()
 
-#define LOG4ESPP_DECL_LOGGER(aLogger) log4espp::Logger& aLogger;
+#define LOG4ESPP_DECL_LOGGER(aLogger) log4espp::Logger& aLogger
 #define LOG4ESPP_LOGGER(aLogger,name) log4espp::Logger& aLogger = log4espp::Logger::getInstance(std::string(name))
 
   /*******************************************************
@@ -477,7 +479,7 @@ class LogClass {
 #ifdef LOG4ESPP_TRACE_ENABLED
 #define LOG4ESPP_TRACE(logger,msg) { if (logger.isTraceEnabled()) \
         { std::ostringstream omsg; omsg << msg; logger.trace(LOG4ESPP_LOCATION, omsg.str()); } }
-#else 
+#else
 #define LOG4ESPP_TRACE(logger,msg)
 #endif
 
@@ -488,7 +490,7 @@ class LogClass {
 #ifdef LOG4ESPP_DEBUG_ENABLED
 #define LOG4ESPP_DEBUG(logger,msg) { if (logger.isDebugEnabled()) \
         { std::ostringstream omsg; omsg << msg; logger.debug(LOG4ESPP_LOCATION, omsg.str()); } }
-#else 
+#else
 #define LOG4ESPP_DEBUG(logger,msg)
 #endif
 
@@ -499,7 +501,7 @@ class LogClass {
 #ifdef LOG4ESPP_INFO_ENABLED
 #define LOG4ESPP_INFO(logger,msg) { if (logger.isInfoEnabled()) \
         { std::ostringstream omsg; omsg << msg; logger.info(LOG4ESPP_LOCATION, omsg.str()); } }
-#else 
+#else
 #define LOG4ESPP_INFO(logger,msg)
 #endif
 
@@ -510,7 +512,7 @@ class LogClass {
 #ifdef LOG4ESPP_WARN_ENABLED
 #define LOG4ESPP_WARN(logger,msg) { if (logger.isWarnEnabled()) \
         { std::ostringstream omsg; omsg << msg; logger.warn(LOG4ESPP_LOCATION, omsg.str()); } }
-#else 
+#else
 #define LOG4ESPP_WARN(logger,msg)
 #endif
 
@@ -521,7 +523,7 @@ class LogClass {
 #ifdef LOG4ESPP_ERROR_ENABLED
 #define LOG4ESPP_ERROR(logger,msg) { if (logger.isErrorEnabled()) \
         { std::ostringstream omsg; omsg << msg; logger.error(LOG4ESPP_LOCATION, omsg.str()); } }
-#else 
+#else
 #define LOG4ESPP_ERROR(logger,msg)
 #endif
 
@@ -532,7 +534,7 @@ class LogClass {
 #ifdef LOG4ESPP_FATAL_ENABLED
 #define LOG4ESPP_FATAL(logger,msg) { if (logger.isFatalEnabled()) \
         { std::ostringstream omsg; omsg << msg; logger.fatal(LOG4ESPP_LOCATION, omsg.str()); } }
-#else 
+#else
 #define LOG4ESPP_FATAL(logger,msg)
 #endif
 

--- a/src/integrator/StochasticVelocityRescaling.hpp
+++ b/src/integrator/StochasticVelocityRescaling.hpp
@@ -1,23 +1,25 @@
 /*
+  Copyright (C) 2016
+      Max Planck Institute for Polymer Research & JGU Mainz
   Copyright (C) 2012,2013
       Max Planck Institute for Polymer Research
   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
+
   This file is part of ESPResSo++.
-  
+
   ESPResSo++ is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-  
+
   ESPResSo++ is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 // ESPP_CLASS
@@ -110,11 +112,11 @@ public:
 
 private:
     boost::signals2::connection _runInit, _aftIntV;
-    
+
 	real temperature; //!< desired user temperature
 	real coupling; // how strong is the coupling, i.e., tau_t coupling time
   real pref; // factor in the rescaling part
-  
+
   int NPart, NPart_local, DegreesOfFreedom;
   real EKin_ref;
 
@@ -128,10 +130,9 @@ private:
 
     void connect();
     void disconnect();
-    
+
 	/** Logger */
-	static LOG4ESPP_DECL_LOGGER(theLogger)
-	;
+	static LOG4ESPP_DECL_LOGGER(theLogger);
 };
 
 }


### PR DESCRIPTION
Running with -Wall -Wextra -pedantic on OSX 10.11.4 revealed (besides others...but just one at a time ;) ) a warning:

warning: extra ';' inside a class [-Wextra-semi]
      static LOG4ESPP_DECL_LOGGER(logger);

I fixed it. I have the logs from running make (~12 MB each) which I can share and the simple python script I used to count the total number of warnings generated, which I can also share.

Here the results:

Sum of warnings: 19198 for file output_pedantic_Wall_Werr_pedantic_no_fixed.txt
Sum of warnings: 17957 for file output_pedantic_Wall_fixed_doublesemicolons_warnings_forlogger_all_should_reducewarnings.txt

So the amount of warnings suppressed with this change is: 19198 - 17957 = 1241; 
at least with my version of OSX 10.11.4 and clang. I can also share the output from when cmake . is run.

I didn't expect to be so high, since 
static LOG4ESPP_DECL_LOGGER(logger);

doesn't appear like everywhere...but these are the numbers I get. Someone else should run it too maybe. Or enable a run to check that on Travis.

Tests pass on my machine.
Copyright has been updated on touched files.
Wait for tests on Travis.