### PR TITLE
Removed trivial warning with clang [-Wcomment]

### DIFF
--- a/src/interaction/LennardJones.hpp
+++ b/src/interaction/LennardJones.hpp
@@ -3,21 +3,21 @@
       Max Planck Institute for Polymer Research
   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
-  
+
   This file is part of ESPResSo++.
-  
+
   ESPResSo++ is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-  
+
   ESPResSo++ is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 // ESPP_CLASS
@@ -55,21 +55,21 @@ namespace espressopp {
         preset();
       }
 
-      LennardJones(real _epsilon, real _sigma, 
-		   real _cutoff, real _shift) 
+      LennardJones(real _epsilon, real _sigma,
+		   real _cutoff, real _shift)
 	: epsilon(_epsilon), sigma(_sigma) {
         setShift(_shift);
         setCutoff(_cutoff);
         preset();
       }
 
-      LennardJones(real _epsilon, real _sigma, 
+      LennardJones(real _epsilon, real _sigma,
 		   real _cutoff)
-	: epsilon(_epsilon), sigma(_sigma) {	
+	: epsilon(_epsilon), sigma(_sigma) {
         autoShift = false;
         setCutoff(_cutoff);
         preset();
-        setAutoShift(); 
+        setAutoShift();
       }
 
       virtual ~LennardJones() {};
@@ -90,11 +90,11 @@ namespace espressopp {
         updateAutoShift();
         preset();
       }
-      
+
       real getEpsilon() const { return epsilon; }
 
-      void setSigma(real _sigma) { 
-        sigma = _sigma; 
+      void setSigma(real _sigma) {
+        sigma = _sigma;
         LOG4ESPP_INFO(theLogger, "sigma=" << sigma);
         updateAutoShift();
         preset();
@@ -106,9 +106,9 @@ namespace espressopp {
         real frac6 = frac2 * frac2 * frac2;
         real energy = 4.0 * epsilon * (frac6 * frac6 - frac6);
         return energy;
-        
+
         // FORCE CAPPING HACK (was temporarily used for some ideal gas test simulations)
-          /*real caprad = 0.1;          
+          /*real caprad = 0.1;
           real capradSqr = caprad * caprad;
 
           if (distSqr > capradSqr) {
@@ -124,9 +124,9 @@ namespace espressopp {
               real forcepart = 48.0 * epsilon * frac6 * (frac6-0.5) / (caprad);
               real out = energy + forcepart*(caprad-sqrt(distSqr));
               return out;
-              
+
           }*/
-        
+
       }
 
       bool _computeForceRaw(Real3D& force,
@@ -138,7 +138,7 @@ namespace espressopp {
         real ffactor = frac6 * (ff1 * frac6 - ff2) * frac2;
         force = dist * ffactor;
         return true;
-        
+
         // FORCE CAPPING HACK (was temporarily used for some ideal gas test simulations)
           /*real caprad = 0.1;
           real capradSqr = caprad * caprad;
@@ -151,20 +151,20 @@ namespace espressopp {
               return true;
           }
           else { // capped part
-              
+
              real frac2 = 1.0 / capradSqr;
              real frac6 = frac2 * frac2 * frac2;
              real ffactor = frac6 * (ff1 * frac6 - ff2) * frac2;
              force = dist * ffactor * (caprad/sqrt(distSqr));
              //std::cout << "LennardJones, capped Force: " << sqrt(distSqr) * ffactor * (caprad/sqrt(distSqr)) << "\n"; 0.1 LEADS TO 3.15815e+08
              return true;
-              
-             /*real frac2 = (sigma/caprad)*(sigma/caprad);
+
+             real frac2 = (sigma/caprad)*(sigma/caprad);
              real frac6 = frac2 * frac2 * frac2;
              real ffactor = 48.0 * epsilon * frac6 * (frac6-0.5) / (caprad*sqrt(distSqr));
              force = dist * ffactor;
-             return true;       
-          
+             return true;
+
           }*/
       }
       static LOG4ESPP_DECL_LOGGER(theLogger);


### PR DESCRIPTION
Removed trivial warning in clang:

"warning: '/*' within block comment [-Wcomment]"