### PR TITLE
Fixed wrong message reported when Sphinx not found.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,5 +250,5 @@ if ( SPHINX_EXECUTABLE )
 
    message ( STATUS "Generate LaTeX manual via ${SPHINX_EXECUTABLE}: make ug-pdf")
 else ( SPHINX_EXECUTABLE )
-    message ( WARNING "Not building user documentation because Doxygen not found.")
+    message ( WARNING "Not building user documentation because Sphinx not found.")
 endif ( SPHINX_EXECUTABLE )


### PR DESCRIPTION
Fixed message when Sphinx not found.

In the Sphinx branch in the main CMakeLists.txt, the message was reporting still Doxygen not found, probably due to a copy-paste.