### PR TITLE
more changes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ is free, open-source software published under the GNU General Public License
 QUICKSTART:
 ===========
 
-To get a copy of the developer version (most recent version) of ESPResSo++, you can use git or docker.
+To get a copy of the developer version (most recent version) of ESPResSo++, you can use git or docker. Using docker will give you a binary release (nothing to compile, but performance may not be optimal). If you use git clone or download a tarball, you will have to compile ESPResSo+ yourself, which might lead to better performance.
 
 Using [docker](https://www.docker.com):
 ```
@@ -34,7 +34,7 @@ QUICKINSTALL:
 ```
 # cd espressopp
 # cmake -DEXTERNAL_BOOST=OFF -DEXTERNAL_MPI4PY=OFF .
-# make [for multicore CPUs make -j#(cores+1)]
+# make -j2
 # source ESPRC
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,20 @@ is free, open-source software published under the GNU General Public License
 QUICKSTART:
 ===========
 
+To get a copy of the developer version (most recent version) of ESPResSo++, you can use git or docker.
+
 Using [docker](https://www.docker.com):
 ```
 # docker pull espressopp/espressopp
 # docker run -it espressopp/espressopp /bin/bash
 ```
 
+Using git:
+```
+# git clone https://github.com/espressopp/espressopp.git
+```
+
+Alternatively, you can download a tarball or zip file of [previous release versions](https://github.com/espressopp/espressopp/releases) of ESPResSo++.
 
 QUICKINSTALL:
 =============
@@ -31,6 +39,21 @@ QUICKINSTALL:
 ```
 
 After building go to the `examples` directory and have a look at the python scripts.
+
+DOCUMENTATION:
+==============
+
+Documentation for the developer version of ESPResSo++ is at:
+
+http://espressopp.github.io
+
+Documentation for release versions from v1.9.4.1 onward is at:
+
+http://espressopp.github.io/vXXX
+
+where XXX is the version number, e.g.: 
+
+http://espressopp.github.io/v1.9.4.1
 
 ISSUES:
 =======


### PR DESCRIPTION
The most recent version of the README makes it look like the only way to get a working version of espressopp is via docker. Let's add info about git clone and the tarballs too. (I know those options are obvious to someone who's already using github, but it's not obvious to the potential user who googled his way to the espressopp github homepage.)