### PR TITLE
increase size of timeForceComp array

### DIFF
--- a/src/integrator/VelocityVerlet.hpp
+++ b/src/integrator/VelocityVerlet.hpp
@@ -152,7 +152,7 @@ namespace espressopp {
         real timeRun;
         real timeLost;
         real timeForce;
-        real timeForceComp[100];
+        real timeForceComp[10000];
         real timeComm1;
         real timeComm2;
         real timeInt1;


### PR DESCRIPTION
The size of the array timeForceComp is hard-coded in the VelocityVerlet class. If a system has more interactions than the size of timeForceComp, random segmentation faults will occur. 
Temporary hack: increase size of array. 
Long-term solution should be to re-write the whole timer setup in VelocityVerlet class.  
See issue #154