### PR TITLE
Removed harmless but duplicate header in VSphereSelfInteractionTemplate.hpp

### DIFF
--- a/src/interaction/VSphereSelfInteractionTemplate.hpp
+++ b/src/interaction/VSphereSelfInteractionTemplate.hpp
@@ -34,7 +34,6 @@
 #include "bc/BC.hpp"
 #include "SystemAccess.hpp"
 #include "storage/Storage.hpp"
-#include "Interaction.hpp"
 #include "types.hpp"
 
 namespace espressopp {


### PR DESCRIPTION
Removed simple harmless duplicate.

One could use:

`sort <file> | uniq -c | grep -v '^ *1 ' | grep "include"`
and running it through all the files in src/ (put in a sort of for loop that goes recursively) to report eventual similar situations or use some tool but I haven't tried...