### PR TITLE
Corrected typo of the potential form in VSpherePair.py

### DIFF
--- a/src/interaction/VSpherePair.cpp
+++ b/src/interaction/VSpherePair.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2012,2013
+  Copyright (C) 2012,2013,2017
       Max Planck Institute for Polymer Research
   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI

--- a/src/interaction/VSpherePair.hpp
+++ b/src/interaction/VSpherePair.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2012,2013
+  Copyright (C) 2012,2013,2017
       Max Planck Institute for Polymer Research
   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
@@ -37,7 +37,7 @@ namespace espressopp {
 
     \f[
 
-         V(r_{ij}, \sigma_{ij}) = \frac{\varepsilon}{\beta}
+         V(r_{ij}, \sigma_{ij}) = \varepsilon
 	                      \left( \frac{2 \pi}{3} \sigma_{ij} \right)^{- \frac{3}{2}}
 			      e^{- \frac{3}{2} \frac{r_{ij}^2}{\sigma_{ij}}} ,
                               r_{ij} = \left| \vec{r_i} - \vec{r_j} \right| ,

--- a/src/interaction/VSpherePair.hpp
+++ b/src/interaction/VSpherePair.hpp
@@ -37,10 +37,11 @@ namespace espressopp {
 
     \f[
 
-         V(r_ij, \sigma_ij) = \frac{\varepsilon}{\beta} \left( \frac{2 \pi}{3} \right)
-                              \sigma_ij^{- \frac{3}{2}} e^{- \frac{3}{2} \frac{r_ij}{\sigma_ij}} ,
-                              r_ij = \left| \vec{r_i} - \vec{r_j} \right| ,
-                              \sigma_ij = \sigma_i^2 + \sigma_j^2
+         V(r_{ij}, \sigma_{ij}) = \frac{\varepsilon}{\beta}
+	                      \left( \frac{2 \pi}{3} \sigma_{ij} \right)^{- \frac{3}{2}}
+			      e^{- \frac{3}{2} \frac{r_{ij}^2}{\sigma_{ij}}} ,
+                              r_{ij} = \left| \vec{r_i} - \vec{r_j} \right| ,
+                              \sigma_{ij} = \sigma_i^2 + \sigma_j^2
 
     \f]
 
@@ -80,8 +81,8 @@ namespace espressopp {
       virtual ~VSpherePair() {};
 
       void preset() {
-      	mfh = -(3.0/2.0);
-    	mth = -(5.0/2.0);
+      	mth = -(3.0/2.0);
+    	mfh = -(5.0/2.0);
         ef1 = epsilon*pow(1.0L*(2*M_PIl/3.0), 1.0L*mth);
         ff1 = 3 * ef1;
       }
@@ -96,8 +97,7 @@ namespace espressopp {
       real getEpsilon() const { return epsilon; }
 
       real _computeEnergySqrRaw(real distSqr, real sigmaij) const {
-    	real rij = sqrt(distSqr);
-        real energy = ef1*pow(1.0L*sigmaij, 1.0L*mth)*exp(mth*rij/sigmaij);
+        real energy = ef1*pow(1.0L*sigmaij, 1.0L*mth)*exp(mth*distSqr/sigmaij);
         return energy;
       }
 
@@ -106,13 +106,11 @@ namespace espressopp {
                             real distSqr, real sigmai, real sigmaj) const {
 
     	real sigmaij = sigmai*sigmai + sigmaj*sigmaj;
-    	real rij     = sqrt(distSqr);
-    	real invrij  = 1/rij;
-    	real eh      = exp(mth*rij/sigmaij);
-    	real fs      = ff1*pow(1.0L*sigmaij, 1.0L*mfh) * eh * (1 + rij);
-    	force        = ff1*pow(1.0L*sigmaij, 1.0L*mth) * eh * dist * invrij;
-    	fsi          = fs * sigmai;
-    	fsj          = fs * sigmaj;
+    	real eh      = exp(mth*distSqr/sigmaij);
+    	//real fs      = ff1*pow(1.0L*sigmaij, 1.0L*mfh) * eh * (1 - 0.5*distSqr/sigmaij);
+    	force        = ff1*pow(1.0L*sigmaij, 1.0L*mfh) * eh * dist;
+    	//fsi          = fs * sigmai;
+    	//fsj          = fs * sigmaj;
     	return true;
       }
     };

--- a/src/interaction/VSpherePair.py
+++ b/src/interaction/VSpherePair.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2012,2013
+#  Copyright (C) 2012,2013,2017
 #      Max Planck Institute for Polymer Research
 #  Copyright (C) 2008,2009,2010,2011
 #      Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
@@ -29,7 +29,7 @@ the VSpherePair potential.
 
 .. math::
 
-         V(r_{ij}, \sigma_{ij}) = \frac{\varepsilon}{\beta}
+         V(r_{ij}, \sigma_{ij}) = \varepsilon
                               \left( \frac{2 \pi}{3} \sigma_{ij}\right)^{- \frac{3}{2}}
                               e^{- \frac{3}{2} \frac{r_{ij}^2}{\sigma_{ij}}} ,
                               r_{ij} = \left| \vec{r_i} - \vec{r_j} \right| ,

--- a/src/interaction/VSpherePair.py
+++ b/src/interaction/VSpherePair.py
@@ -29,16 +29,13 @@ the VSpherePair potential.
 
 .. math::
 
-         V(r_{ij}, \sigma_{ij}) = \frac{\varepsilon}{\beta} \left( \frac{2 \pi}{3} \right)
-                              \sigma_{ij}^{- \frac{3}{2}} e^{- \frac{3}{2} \frac{r_{ij}^2}{\sigma_{ij}}} ,
+         V(r_{ij}, \sigma_{ij}) = \frac{\varepsilon}{\beta}
+                              \left( \frac{2 \pi}{3} \sigma_{ij}\right)^{- \frac{3}{2}}
+                              e^{- \frac{3}{2} \frac{r_{ij}^2}{\sigma_{ij}}} ,
                               r_{ij} = \left| \vec{r_i} - \vec{r_j} \right| ,
                               \sigma_{ij} = \sigma_i^2 + \sigma_j^2
 
-
-
-
-
-
+Reference: Flactuating soft-sphere approach to coars-graining of polymer melts, Soft matter, 2010, 6, 2282
 
 .. function:: espressopp.interaction.VSpherePair(epsilon, cutoff, shift)
 

--- a/src/interaction/VerletListVSphereInteractionTemplate.hpp
+++ b/src/interaction/VerletListVSphereInteractionTemplate.hpp
@@ -127,9 +127,7 @@ namespace espressopp {
         if(potential._computeForce(force, fsi, fsj, p1, p2)) {
           p1.force() += force;
           p2.force() -= force;
-          p1.fradius() = fsi;
-          p2.fradius() = fsj;
-          std::cout << "(" << p1.id() << ", " << p2.id() << ") force=" << force << " fradius: (" << p1.fradius() << ", " << p2.fradius() << ")" << std::endl;
+
           LOG4ESPP_TRACE(theLogger, "id1=" << p1.id() << " id2=" << p2.id() << " force=" << force);
         }
       }


### PR DESCRIPTION
According with "Flactuating soft-sphere approach to coars-graining of polymer melts, Soft matter, 2010, 6, 2282", I corrected potential and force form in VSpherePair.hpp and deleted verbose messages in VerletListVSphereInteractionTemplate.hpp.

Additionally, I corrected typo of the potential form in VSpherePair.py.