### PR TITLE
Added missing ghost particle properties (radius, extVar) in the copyShifted method

### DIFF
--- a/src/Particle.hpp
+++ b/src/Particle.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2012,2013
+  Copyright (C) 2012,2013,2017
       Max Planck Institute for Polymer Research
   Copyright (C) 2008,2009,2010,2011
       Max-Planck-Institute for Polymer Research & Fraunhofer SCAI
@@ -79,6 +79,8 @@ namespace espressopp {
 
     void copyShifted(ParticlePosition& dst, const Real3D& shift) const {
       dst.p = p + shift;
+      dst.radius = radius;
+      dst.extVar = extVar;
     }
   private:
     friend class boost::serialization::access;


### PR DESCRIPTION
This PR fixs a bug in Particle.hpp.
In present version, Ghost particles miss to receive ParticlePosition.radius and ParticlePosition.extVar.
Hence, Ghosts particles have wrong ParticePosition.radius and extVar.

By this PR, GhostParticle can receive ParticlePosition.radius and ParticlePosition.extVar at the function "copyShifted".