### PR TITLE
codecov: don't check contrib/testsuite

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,3 +2,6 @@ coverage:
   precision: 1
   round: down
   range: "70...100"
+ignore:
+  - contrib/
+  - testsuite/ 


### PR DESCRIPTION
The testsuite and `contrib/` should not go into the coverage percentage, as there is no point in testing the tests.