### PR TITLE
cmake: fix gromacs include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ include_directories(${FFTW3_INCLUDES})
 
 if(WITH_XTC)
   find_package(GROMACS REQUIRED)
-  include_directories(${GROMACS_INCLUDE_DIRS})
+  include_directories(${GROMACS_INCLUDES})
   add_definitions( -DHAS_GROMACS )
 endif()
 


### PR DESCRIPTION
Fix #233 