### PR TITLE
Generalize configuration/s in analysis

### DIFF
--- a/src/analysis/Configuration.cpp
+++ b/src/analysis/Configuration.cpp
@@ -140,6 +140,23 @@ namespace espressopp {
       return 0;
     }
 
+    boost::python::list Configuration::getIds()
+    {
+      boost::python::list ids;
+
+      size_t sizePos    = coordinates.size();
+      size_t sizeVel    = velocities.size();
+      size_t sizeForce  = forces.size();
+      size_t sizeRadius = radii.size();
+
+      if      (sizePos    > 0) for(auto m: coordinates) ids.append(m.first);
+      else if (sizeVel    > 0) for(auto m: velocities)  ids.append(m.first);
+      else if (sizeForce  > 0) for(auto m: forces)      ids.append(m.first);
+      else if (sizeRadius > 0) for(auto m: radii)       ids.append(m.first);
+
+      return ids;
+    }
+
 /*
     ConfigurationIterator Configuration::getIterator()
     {
@@ -191,6 +208,11 @@ namespace espressopp {
         ("analysis_Configuration", no_init)
       .add_property("size", &Configuration::getSize)
       .def("__getitem__", &Configuration::getCoordinates)
+      .def("getCoordinates", &Configuration::getCoordinates)
+      .def("getVelocities", &Configuration::getVelocities)
+      .def("getForces", &Configuration::getCoordinates)
+      .def("getRadius", &Configuration::getCoordinates)
+      .def("getIds", &Configuration::getIds)
       // .def("__iter__", &Configuration::getIterator)
       ;
     }

--- a/src/analysis/Configuration.cpp
+++ b/src/analysis/Configuration.cpp
@@ -210,8 +210,8 @@ namespace espressopp {
       .def("__getitem__", &Configuration::getCoordinates)
       .def("getCoordinates", &Configuration::getCoordinates)
       .def("getVelocities", &Configuration::getVelocities)
-      .def("getForces", &Configuration::getCoordinates)
-      .def("getRadius", &Configuration::getCoordinates)
+      .def("getForces", &Configuration::getForces)
+      .def("getRadius", &Configuration::getRadius)
       .def("getIds", &Configuration::getIds)
       // .def("__iter__", &Configuration::getIterator)
       ;

--- a/src/analysis/Configuration.hpp
+++ b/src/analysis/Configuration.hpp
@@ -59,6 +59,7 @@ namespace espressopp {
       Real3D getVelocities(size_t id);
       Real3D getForces(size_t id);
       real getRadius(size_t id);
+      boost::python::list getIds();
       size_t getSize();
       void set(size_t id, real x, real y, real z);
       void setCoordinates(size_t id, Real3D _pos);

--- a/src/analysis/Configurations.cpp
+++ b/src/analysis/Configurations.cpp
@@ -173,7 +173,7 @@ namespace espressopp {
 
       if (system.comm->rank() == 0) {
 
-         ConfigurationPtr config = make_shared<Configuration> (); //totalN
+         ConfigurationPtr config = make_shared<Configuration> (gatherPos, gatherVel, gatherForce, gatherRadius); //totalN
 
          // root process collects data from all processors and sets it
 
@@ -309,6 +309,7 @@ namespace espressopp {
 
       class_<Configurations>
         ("analysis_Configurations", init< shared_ptr< System > >())
+      .def(init<shared_ptr< System >,bool,bool,bool,bool,bool>())
       .add_property("size", &Configurations::getSize)
       .add_property("capacity", &Configurations::getCapacity, 
                                 &Configurations::setCapacity)

--- a/src/analysis/Configurations.hpp
+++ b/src/analysis/Configurations.hpp
@@ -45,11 +45,12 @@ namespace espressopp {
 
       /** Constructor, allow for unlimited snapshots. */
       Configurations(shared_ptr<System> system) : SystemAccess (system) {
-    	  gatherPos = true;
-    	  gatherVel = false;
-    	  gatherForce = false;
-    	  gatherRadius = false;
-    	  maxConfigs = 0;
+        gatherPos = true;
+        gatherVel = false;
+        gatherForce = false;
+        gatherRadius = false;
+        folded = true;
+        maxConfigs = 0;
       }
       Configurations(shared_ptr<System> system, bool _pos, bool _vel, bool _force, bool _radius, bool _folded)
                     : SystemAccess (system), gatherPos(_pos), gatherVel(_vel), gatherForce(_force), gatherRadius(_radius), folded(_folded)

--- a/src/analysis/Configurations.py
+++ b/src/analysis/Configurations.py
@@ -94,9 +94,9 @@ from _espressopp import analysis_Configurations
 
 class ConfigurationsLocal(ObservableLocal, analysis_Configurations):
 
-    def __init__(self, system):
-	if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-          cxxinit(self, analysis_Configurations, system)
+    def __init__(self, system, pos=True, vel=False, force=False, radius=False, folded=True):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            cxxinit(self, analysis_Configurations, system, pos, vel, force, radius, folded)
     def gather(self):
         return self.cxxclass.gather(self)
     def clear(self):


### PR DESCRIPTION
This allows gathering and retrieving other particle information (coordinates, velocities, forces, radii, ids) directly from Configurations. Back-compatibility to dependent modules is maintained since:
 - coordinates are still accessed by default
 - default boolean arguments in python match original constructor in C++

Also, I've set position folding to true by default (previously undefined).