### PR TITLE
use long long step instead of int

### DIFF
--- a/src/esutil/RNG.cpp
+++ b/src/esutil/RNG.cpp
@@ -83,7 +83,7 @@ namespace espressopp {
       return boostRNG;
     }
 
-    void RNG::saveState(int step) {
+    void RNG::saveState(long long step) {
       std::ostringstream oss;
       oss << *boostRNG;
       if ( mpiWorld->rank()==0 ) {

--- a/src/esutil/RNG.hpp
+++ b/src/esutil/RNG.hpp
@@ -73,7 +73,7 @@ namespace espressopp {
 
       shared_ptr< RNGType > getBoostRNG();
 
-      void saveState(int);
+      void saveState(long long);
 
       void loadState(const char*);
 


### PR DESCRIPTION
I have changed the argument type from int to long long of the saveState function in the RNG class. As the type of step in the integrator is long long, it makes more sense use long long here too.