### PR TITLE
Fixes segfault when exclusion list is added after VerletList init

### DIFF
--- a/src/VerletList.cpp
+++ b/src/VerletList.cpp
@@ -152,7 +152,12 @@ namespace espressopp {
         c_pos.resize(c_resize);
       }
       c_type.resize(c_resize);
-      if(USE_EXCLUSION_LIST){
+    }
+
+    // exclusion list may have been added later so check size of c_id separately
+    if(USE_EXCLUSION_LIST){
+      if(c_reserve > c_id.size()) {
+        size_t c_resize = 2*c_reserve;
         c_id.resize(c_resize);
       }
     }


### PR DESCRIPTION
This solves a segfault that happens when an exclusion list is provided after the VerletList constructor, e.g.
```py
verletlist = espressopp.VerletList(system, rc)
verletlist.exclude(exclusions)
```
instead of 
```py
verletlist = espressopp.VerletList(system, rc, exclusions)
```