### PR TITLE
Update DumpXTC for latest GROMACS version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
     - j="$(grep -c processor /proc/cpuinfo 2>/dev/null)" || j=0; ((j++))
     - mkdir -p build
     - pushd build
-    - cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DEXTERNAL_BOOST=$EXTERNAL -DEXTERNAL_MPI4PY=$EXTERNAL -DWITH_XTC=ON -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    - cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DEXTERNAL_BOOST=$EXTERNAL -DEXTERNAL_MPI4PY=$EXTERNAL -DWITH_XTC=OFF -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     - make -O -k -j${j} -l${j} VERBOSE=1
     - make test CTEST_OUTPUT_ON_FAILURE=1
     - make install DESTDIR=${PWD}/install && rm -rf ${PWD}/install/usr && rmdir ${PWD}/install

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
     - j="$(grep -c processor /proc/cpuinfo 2>/dev/null)" || j=0; ((j++))
     - mkdir -p build
     - pushd build
-    - cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DEXTERNAL_BOOST=$EXTERNAL -DEXTERNAL_MPI4PY=$EXTERNAL -DWITH_XTC=OFF -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    - cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DEXTERNAL_BOOST=$EXTERNAL -DEXTERNAL_MPI4PY=$EXTERNAL -DWITH_XTC=ON -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     - make -O -k -j${j} -l${j} VERBOSE=1
     - make test CTEST_OUTPUT_ON_FAILURE=1
     - make install DESTDIR=${PWD}/install && rm -rf ${PWD}/install/usr && rmdir ${PWD}/install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ stages:
 
 env:
     - DISTRO=ubuntu BUILD_UG=ON XTC=ON
-    - DISTRO=ubuntu_rolling XTC=OFF
+    - DISTRO=ubuntu_rolling XTC=ON
     - DISTRO=ubuntu_mpich XTC=ON
     - DISTRO=fedora XTC=ON
     - DISTRO=fedora_mpich XTC=ON

--- a/src/io/DumpXTC.hpp
+++ b/src/io/DumpXTC.hpp
@@ -1,4 +1,6 @@
 /*
+  Copyright (C) 2020
+      Jakub Krajniak (jkrajniak at gmail.com)
   Copyright (C) 2017
       Gregor Deichmann (TU Darmstadt, deichmann(at)cpc.tu-darmstadt.de) 
  
@@ -37,7 +39,8 @@
 #include <string>
 #include <iostream>
 
-#include "gromacs/fileio/xtcio.h"
+#include <gromacs/trajectory/trajectoryframe.h>
+#include <gromacs/fileio/trxio.h>
 
 namespace espressopp {
   namespace io{
@@ -85,7 +88,7 @@ namespace espressopp {
     
     private:
       
-      t_fileio *fio;
+      t_trxstatus *fio;
       static const int dim=3;
       real xtcprec;
 

--- a/src/io/DumpXTC.py
+++ b/src/io/DumpXTC.py
@@ -57,7 +57,7 @@ writing down trajectory using ExtAnalyze extension
 >>> integrator.addExtension(ext_analyze)
 >>> integrator.run(2000)
 
-Both exapmles will give the same result: 200 configurations in trajectory .xtc file.
+Both examples will give the same result: 200 configurations in trajectory .xtc file.
 
 setting up length scale
 

--- a/src/io/DumpXTCAdress.hpp
+++ b/src/io/DumpXTCAdress.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2017
+  Copyright (C) 2017,2020
       Jakub Krajniak (jkrajniak at gmail.com)
 
   This file is part of ESPResSo++.
@@ -28,7 +28,6 @@
 #include <iostream>
 #include "mpi.hpp"
 
-#include "gromacs/fileio/xtcio.h"
 #include "types.hpp"
 #include "System.hpp"
 #include "io/FileBackup.hpp"
@@ -39,6 +38,9 @@
 #include "FixedTupleListAdress.hpp"
 
 #include "esutil/Error.hpp"
+
+#include <gromacs/trajectory/trajectoryframe.h>
+#include <gromacs/fileio/trxio.h>
 
 
 namespace espressopp {
@@ -83,7 +85,7 @@ class DumpXTCAdress : public ParticleAccess {
   static void registerPython();
 
  private:
-  t_fileio *fio;
+  t_trxstatus *fio;
   static const int dim = 3;
   real xtcprec;
 


### PR DESCRIPTION
Package libgromacs-devel does not provide `gromacs/fileio/xtcio.h` on ubuntu; This is more general problem as GROMACS 2020 changed the available header files. I have update DumpXTC and DumpXTCAddress to use `gromacs/fileio/trxio.h` and appropriate methods.

cc: @jnvance 