### PR TITLE
ensure consistent code formatting for the c++ code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,7 @@
 BasedOnStyle: Google
 ColumnLimit: 100
+AccessModifierOffset: '-4'
+BinPackParameters: 'false'
+BreakBeforeBraces: Allman
+IndentWidth: '4'
+SortIncludes: false

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -1,0 +1,31 @@
+name: format-command
+on:
+  repository_dispatch:
+    types: [format-command]
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BOT_PAT }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+
+      - name: Format
+        run: ./format.sh
+
+      - name: Commit to the PR branch
+        run: |
+          git config --global user.name 'espressopp-bot'
+          git config --global user.email 'espressopp-bot@no-reply.com'
+          git commit -am "[BOT] clang-format"
+          git push
+
+      - name: Add reaction
+        uses: peter-evans/create-or-update-comment@38214a08ee61b78dc42bd8f45294668c5bfc1be0
+        with:
+          token: ${{ secrets.BOT_PAT }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reaction-type: hooray

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -1,0 +1,14 @@
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@8e02cf5c38baa3ddce3b993cef6fa49aa33e22ac
+        with:
+          token: ${{ secrets.BOT_PAT }}
+          commands: format
+          repository: espressopp/espressopp

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -153,3 +153,14 @@ jobs:
 
       - name: Upload Report to codecov.io
         uses: codecov/codecov-action@v1
+
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: run formatter
+        run: ./format.sh
+
+      - name: check formatting
+        run: git diff --exit-code

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+git ls-files -- src*.cpp src*.hpp testsuite*.cpp testsuite*.hpp | xargs clang-format -i -style=file

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,13 +84,3 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ DESTINATION ${PYTHON_INSTDIR}/esp
         FILES_MATCHING PATTERN "*.py"
         PATTERN "CMakeFiles" EXCLUDE)
 
-find_program(CLANG_FORMAT "clang-format")
-if (CLANG_FORMAT)
-    add_custom_target(
-            format
-            COMMAND ${CLANG_FORMAT}
-            -style=file
-            -i
-            ${ESPRESSO_SOURCES}
-    )
-endif()


### PR DESCRIPTION
Using `clang-format` to ensure consistent formatting. Run `format.sh` in the root folder to format the whole code base.

closes #202 
closes #201 