### PR TITLE
replaced icpc build with oneapi release build

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,9 +15,9 @@ jobs:
         CXX: ['g++', 'clang++']
         EXTERNAL_MPI4PY: ['On']
         include:
-          - BUILD_TYPE: 'Debug'
-            DISTRO: 'fedora_intel'
-            CXX: 'icpc'
+          - BUILD_TYPE: 'Release'
+            DISTRO: 'fedora_intel-oneapi'
+            CXX: 'icpx'
             EXTERNAL_MPI4PY: 'On'
           - BUILD_TYPE: 'Debug'
             DISTRO: 'fedora_intel-oneapi'
@@ -34,13 +34,7 @@ jobs:
           restore-keys: ${{ matrix.DISTRO }}-${{ matrix.CXX }}-${{ matrix.BUILD_TYPE }}
 
       - uses: actions/checkout@v2
-
-      - name: Get trail license
-        if: ${{ matrix.CXX == 'icpc' }}
-        run: |
-          mkdir ~/Licenses
-          curl https://dynamicinstaller.intel.com/api/v2/license > ~/Licenses/intel.lic
-
+      
       - name: Configure
         run: cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$HOME/espressopp -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_CXX_COMPILER=${{ matrix.CXX }} -DEXTERNAL_MPI4PY=${{ matrix.EXTERNAL_MPI4PY }} -DUSE_CCACHE=ON
 

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -13,9 +13,9 @@ jobs:
         CXX: ['g++', 'clang++']
         EXTERNAL_MPI4PY: ['On','Off']
         include:
-          - BUILD_TYPE: 'Debug'
-            DISTRO: 'fedora_intel'
-            CXX: 'icpc'
+          - BUILD_TYPE: 'Release'
+            DISTRO: 'fedora_intel-oneapi'
+            CXX: 'icpx'
             EXTERNAL_MPI4PY: 'On'
           - BUILD_TYPE: 'Debug'
             DISTRO: 'fedora_intel-oneapi'
@@ -32,12 +32,6 @@ jobs:
           restore-keys: ${{ matrix.DISTRO }}-${{ matrix.CXX }}-${{ matrix.BUILD_TYPE }}
 
       - uses: actions/checkout@v2
-
-      - name: Get trail license
-        if: ${{ matrix.CXX == 'icpc' }}
-        run: |
-          mkdir ~/Licenses
-          curl https://dynamicinstaller.intel.com/api/v2/license > ~/Licenses/intel.lic
       
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_CXX_COMPILER=${{ matrix.CXX }} -DEXTERNAL_MPI4PY=${{ matrix.EXTERNAL_MPI4PY }}
@@ -45,8 +39,8 @@ jobs:
       - name: Build
         run: cmake --build build --verbose --target all -j 2
 
-      #    - name: Install
-      #      run: cmake --install build
+      - name: Install
+        run: cmake --install build
 
       - name: Test
         working-directory: build


### PR DESCRIPTION
For the time being removed fedora icpc builds. Since we still have Intel builds I think this is ok.