### PR TITLE
fix warnings

### DIFF
--- a/src/analysis/OrderParameter.hpp
+++ b/src/analysis/OrderParameter.hpp
@@ -380,7 +380,7 @@ namespace espressopp {
           sendGhostInfo.push_back( opp_map.find( *it )->second );
         }
 
-        maxSize, vecSize  = sendGhostInfo.size();
+        vecSize  = sendGhostInfo.size();
         mpi::all_reduce( *cmm, vecSize, maxSize, mpi::maximum<int>() );
         while(sendGhostInfo.size()<maxSize) sendGhostInfo.push_back( OrderParticleProps() );
 
@@ -429,7 +429,7 @@ namespace espressopp {
           }
         }
 
-        maxSize, vecSize  = sendGhostInfo.size();
+        vecSize  = sendGhostInfo.size();
         mpi::all_reduce( *cmm, vecSize, maxSize, mpi::maximum<int>() );
         while(sendGhostInfo.size()<maxSize) sendGhostInfo.push_back( OrderParticleProps() );
         totID.clear();

--- a/src/analysis/RDFatomistic.cpp
+++ b/src/analysis/RDFatomistic.cpp
@@ -131,7 +131,7 @@ namespace espressopp {
               if (molP1 != molP2) {
 
                 if( ( (typeP1 == target1) && (typeP2 == target2) ) || ( (typeP1 == target2) && (typeP2 == target1) ) ) {
-                  Real3D distVector = (0.0, 0.0, 0.0);
+                  Real3D distVector(0.0, 0.0, 0.0);
                   system.bc->getMinimumImageVector(distVector, coordP1, coordP2);
 
                   int bin = (int)( distVector.abs() / dr );

--- a/src/analysis/StaticStructF.cpp
+++ b/src/analysis/StaticStructF.cpp
@@ -122,7 +122,7 @@ namespace espressopp {
             Real3D q;
 
             //calculations for binning
-            real bin_size = bin_factor * min(dqs[0], (dqs[1], dqs[2]));
+            real bin_size = bin_factor * std::min(dqs[0], std::min(dqs[1], dqs[2]));
             real q_sqr_max = nqx * nqx * dqs[0] * dqs[0]
                     + nqy * nqy * dqs[1] * dqs[1]
                     + nqz * nqz * dqs[2] * dqs[2];
@@ -265,7 +265,7 @@ namespace espressopp {
             Real3D q;
 
             //calculations for binning
-            real bin_size = bin_factor * min(dqs[0], (dqs[1], dqs[2]));
+            real bin_size = bin_factor * std::min(dqs[0], std::min(dqs[1], dqs[2]));
             real q_sqr_max = nqx * nqx * dqs[0] * dqs[0]
                     + nqy * nqy * dqs[1] * dqs[1]
                     + nqz * nqz * dqs[2] * dqs[2];

--- a/src/include/ut.hpp
+++ b/src/include/ut.hpp
@@ -25,10 +25,6 @@
 
 #include <acconfig.hpp>
 
-#ifdef PARALLEL_TEST_MODULE
-#define BOOST_TEST_MODULE PARALLEL_TEST_MODULE
-#endif
-
 #include <boost/test/unit_test.hpp>
 
 #ifdef PARALLEL_TEST_MODULE

--- a/src/integrator/FreeEnergyCompensation.cpp
+++ b/src/integrator/FreeEnergyCompensation.cpp
@@ -39,11 +39,9 @@ namespace espressopp {
     LOG4ESPP_LOGGER(FreeEnergyCompensation::theLogger, "FreeEnergyCompensation");
 
     FreeEnergyCompensation::FreeEnergyCompensation(shared_ptr<System> system, bool _sphereAdr, int _ntrotter, bool _slow)
-    :Extension(system), sphereAdr(_sphereAdr), ntrotter(_ntrotter), slow(_slow) {
+    :Extension(system), sphereAdr(_sphereAdr), ntrotter(_ntrotter), slow(_slow), center(0.0,0.0,0.0) {
 
         type = Extension::FreeEnergyCompensation;
-
-        center = (0.0,0.0,0.0);
 
         LOG4ESPP_INFO(theLogger, "FreeEnergyCompensation constructed");
     }

--- a/src/integrator/OnTheFlyFEC.cpp
+++ b/src/integrator/OnTheFlyFEC.cpp
@@ -39,14 +39,13 @@ namespace espressopp {
     LOG4ESPP_LOGGER(OnTheFlyFEC::theLogger, "OnTheFlyFEC");
 
     OnTheFlyFEC::OnTheFlyFEC(shared_ptr<System> system)
-    :Extension(system) {
+    :Extension(system), center(0.0,0.0,0.0) {
 
         type = Extension::FreeEnergyCompensation;
         
         bins = 0;
         gap = 0;
         steps = 0;
-        center = (0.0,0.0,0.0);
         
         counter = 0;
         gapcounter = 0;

--- a/src/integrator/TDforce.cpp
+++ b/src/integrator/TDforce.cpp
@@ -54,7 +54,7 @@ namespace espressopp {
         }
         else
         {
-          center = (0.0,0.0,0.0);
+          center = Real3D(0.0,0.0,0.0);
         }
 
         LOG4ESPP_INFO(theLogger, "TDforce constructed");

--- a/src/interaction/LennardJones.hpp
+++ b/src/interaction/LennardJones.hpp
@@ -159,7 +159,7 @@ namespace espressopp {
              //std::cout << "LennardJones, capped Force: " << sqrt(distSqr) * ffactor * (caprad/sqrt(distSqr)) << "\n"; 0.1 LEADS TO 3.15815e+08
              return true;
               
-             /*real frac2 = (sigma/caprad)*(sigma/caprad);
+             real frac2 = (sigma/caprad)*(sigma/caprad);
              real frac6 = frac2 * frac2 * frac2;
              real ffactor = 48.0 * epsilon * frac6 * (frac6-0.5) / (caprad*sqrt(distSqr));
              force = dist * ffactor;

--- a/testsuite/bc/TestOrthorhombicBC.cpp
+++ b/testsuite/bc/TestOrthorhombicBC.cpp
@@ -21,6 +21,7 @@
 */
 
 #define PARALLEL_TEST_MODULE BoundaryConditions
+#define BOOST_TEST_MODULE BoundaryConditions
 
 #include "ut.hpp"
 #include <memory>

--- a/testsuite/esutil/PTestError.cpp
+++ b/testsuite/esutil/PTestError.cpp
@@ -21,6 +21,7 @@
 */
 
 #define PARALLEL_TEST_MODULE ERROR
+#define BOOST_TEST_MODULE ERROR
 
 #include "include/ut.hpp"
 

--- a/testsuite/esutil/PTestRNG.cpp
+++ b/testsuite/esutil/PTestRNG.cpp
@@ -21,6 +21,7 @@
 */
 
 #define PARALLEL_TEST_MODULE RNG
+#define BOOST_TEST_MODULE RNG
 
 #include "include/ut.hpp"
 

--- a/testsuite/integrator/PTestVelocityVerlet.cpp
+++ b/testsuite/integrator/PTestVelocityVerlet.cpp
@@ -21,6 +21,7 @@
 */
 
 #define PARALLEL_TEST_MODULE VelocityVerlet
+#define BOOST_TEST_MODULE VelocityVerlet
 #include "ut.hpp"
 
 #include "types.hpp"

--- a/testsuite/storage/PTestDomainDecomposition.cpp
+++ b/testsuite/storage/PTestDomainDecomposition.cpp
@@ -21,6 +21,7 @@
 */
 
 #define PARALLEL_TEST_MODULE DomainDecomposition
+#define BOOST_TEST_MODULE DomainDecomposition
 
 #include "ut.hpp"
 


### PR DESCRIPTION
```
/__w/espressopp/espressopp/src/analysis/OrderParameter.hpp:432:9: warning: expression result unused [-Wunused-value]
        maxSize, vecSize  = sendGhostInfo.size();
        ^~~~~~~
            
/__w/espressopp/espressopp/src/analysis/RDFatomistic.cpp:134:40: warning: expression result unused [-Wunused-value]
                  Real3D distVector = (0.0, 0.0, 0.0);
                                       ^~~
                                       
/__w/espressopp/espressopp/src/analysis/StaticStructF.cpp:125:60: warning: expression result unused [-Wunused-value]
            real bin_size = bin_factor * min(dqs[0], (dqs[1], dqs[2]));
                                                      ~~~ ~^
```
We should target warning free builds. These are not only warnings but more or less bugs...