### PR TITLE
replace boost::shared_ptr with std::shared_ptr

### DIFF
--- a/src/BufferDynamic.hpp
+++ b/src/BufferDynamic.hpp
@@ -28,7 +28,6 @@
 #include "mpi.hpp"
 #include "Particle.hpp"
 #include <vector>
-#include <boost/shared_ptr.hpp>
 #include <stdexcept>
 
 /** Initial buffer size for incoming and outgoing messages 

--- a/src/FixedListComm.cpp
+++ b/src/FixedListComm.cpp
@@ -31,7 +31,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(FixedListComm::theLogger, "FixedListComm");
 
-    FixedListComm::FixedListComm(shared_ptr <storage::Storage> _storage)
+    FixedListComm::FixedListComm(std::shared_ptr <storage::Storage> _storage)
         : storage(_storage), globalLists(){
 
         //std::cout << "fixedlist" << std::endl;

--- a/src/FixedListComm.hpp
+++ b/src/FixedListComm.hpp
@@ -36,7 +36,7 @@ namespace espressopp {
     class FixedListComm: public PairList, public TripleList, public QuadrupleList {
         protected:
         boost::signals2::connection con1, con2, con3;
-        shared_ptr<storage::Storage> storage;
+        std::shared_ptr<storage::Storage> storage;
         typedef std::vector<longint> pvec;
         typedef boost::unordered_multimap<longint, pvec> GlobalList;
         GlobalList globalLists;
@@ -47,7 +47,7 @@ namespace espressopp {
         //virtual void add(std::vector<Particle*> tmp)=0;
 
         public:
-        FixedListComm(shared_ptr<storage::Storage> _storage);
+        FixedListComm(std::shared_ptr<storage::Storage> _storage);
         ~FixedListComm();
         bool add(pvec pids);
         void beforeSendParticles(ParticleList& pl, class OutBuffer& buf);

--- a/src/FixedLocalTupleList.cpp
+++ b/src/FixedLocalTupleList.cpp
@@ -33,7 +33,7 @@ namespace espressopp {
     
     LOG4ESPP_LOGGER(FixedLocalTupleList::theLogger, "FixedLocalTupleList");
     
-    FixedLocalTupleList::FixedLocalTupleList(shared_ptr< storage::Storage > _storage)
+    FixedLocalTupleList::FixedLocalTupleList(std::shared_ptr< storage::Storage > _storage)
 	: storage(_storage), globalTuples()
     {
 	LOG4ESPP_INFO(theLogger, "construct FixedLocalTupleList");
@@ -232,8 +232,8 @@ namespace espressopp {
 	
 	using namespace espressopp::python;
 	
-	class_< FixedLocalTupleList, shared_ptr< FixedLocalTupleList > >
-	    ("FixedLocalTupleList", init< shared_ptr< storage::Storage > >())
+	class_< FixedLocalTupleList, std::shared_ptr< FixedLocalTupleList > >
+	    ("FixedLocalTupleList", init< std::shared_ptr< storage::Storage > >())
 	    .def("addTuple", &FixedLocalTupleList::addTuple)
 	    .def("getTuples", &FixedLocalTupleList::getTuples)
 	    .def("size", &FixedLocalTupleList::size)

--- a/src/FixedLocalTupleList.hpp
+++ b/src/FixedLocalTupleList.hpp
@@ -34,14 +34,14 @@ namespace espressopp {
     class FixedLocalTupleList : public TupleList {
     protected:
 	boost::signals2::connection con1, con2, con3;
-	shared_ptr<storage::Storage> storage;
+	std::shared_ptr<storage::Storage> storage;
 	typedef std::vector<longint> tuple;
 	typedef std::multimap <longint,tuple > GlobalTuples;
 	GlobalTuples globalTuples;
 	using TupleList::add;
 	
     public:
-	FixedLocalTupleList(shared_ptr<storage::Storage> _storage);
+	FixedLocalTupleList(std::shared_ptr<storage::Storage> _storage);
 	virtual ~FixedLocalTupleList();
 	virtual bool addTuple(boost::python::list& tuple);
 	virtual void beforeSendParticles(ParticleList& pl, class OutBuffer &buf);

--- a/src/FixedPairDistList.cpp
+++ b/src/FixedPairDistList.cpp
@@ -33,7 +33,7 @@ namespace espressopp {
   LOG4ESPP_LOGGER(FixedPairDistList::theLogger, "FixedPairDistList");
 
 
-  FixedPairDistList::FixedPairDistList(shared_ptr< storage::Storage > _storage) 
+  FixedPairDistList::FixedPairDistList(std::shared_ptr< storage::Storage > _storage)
     : storage(_storage), pairsDist()
   {
     LOG4ESPP_INFO(theLogger, "construct FixedPairDistList");
@@ -268,8 +268,8 @@ namespace espressopp {
       = &FixedPairDistList::add;
     //bool (FixedPairDistList::*pyAdd)(pvec pids) = &FixedPairDistList::add;
 
-    class_<FixedPairDistList, shared_ptr<FixedPairDistList> >
-      ("FixedPairDistList", init <shared_ptr<storage::Storage> >())
+    class_<FixedPairDistList, std::shared_ptr<FixedPairDistList> >
+      ("FixedPairDistList", init <std::shared_ptr<storage::Storage> >())
       .def("add", pyAdd)
       .def("size", &FixedPairDistList::size)
       .def("getPairs",  &FixedPairDistList::getPairs)

--- a/src/FixedPairDistList.hpp
+++ b/src/FixedPairDistList.hpp
@@ -40,12 +40,12 @@ namespace espressopp {
 	  protected:
 	    typedef std::multimap<longint, std::pair<longint, real> > PairsDist;
 		boost::signals2::connection con1, con2, con3;
-		shared_ptr <storage::Storage> storage;
+		std::shared_ptr <storage::Storage> storage;
 		PairsDist pairsDist;
 		using PairList::add;
 
 	  public:
-		FixedPairDistList(shared_ptr< storage::Storage > _storage);
+		FixedPairDistList(std::shared_ptr< storage::Storage > _storage);
 		virtual ~FixedPairDistList();
 
 		/** Add the given particle pair to the list on this processor if the

--- a/src/FixedPairList.cpp
+++ b/src/FixedPairList.cpp
@@ -39,7 +39,7 @@ using namespace std;
 namespace espressopp {
 
   /*
-  FixedPairList::FixedPairList(shared_ptr< storage::Storage > _storage)
+  FixedPairList::FixedPairList(std::shared_ptr< storage::Storage > _storage)
   : FixedListComm (_storage){}
 
   FixedPairList::~FixedPairList() {
@@ -51,7 +51,7 @@ namespace espressopp {
   LOG4ESPP_LOGGER(FixedPairList::theLogger, "FixedPairList");
 
 
-  FixedPairList::FixedPairList(shared_ptr< storage::Storage > _storage)
+  FixedPairList::FixedPairList(std::shared_ptr< storage::Storage > _storage)
     : storage(_storage), globalPairs()
   {
     LOG4ESPP_INFO(theLogger, "construct FixedPairList");
@@ -325,8 +325,8 @@ namespace espressopp {
       = &FixedPairList::add;
     //bool (FixedPairList::*pyAdd)(pvec pids) = &FixedPairList::add;
 
-    class_<FixedPairList, shared_ptr<FixedPairList> >
-      ("FixedPairList", init <shared_ptr<storage::Storage> >())
+    class_<FixedPairList, std::shared_ptr<FixedPairList> >
+      ("FixedPairList", init <std::shared_ptr<storage::Storage> >())
       .def("add", pyAdd)
       .def("size", &FixedPairList::size)
       .def("totalSize", &FixedPairList::totalSize)

--- a/src/FixedPairList.hpp
+++ b/src/FixedPairList.hpp
@@ -43,13 +43,13 @@ namespace espressopp {
 
 	  protected:
 		boost::signals2::connection sigBeforeSend, sigOnParticlesChanged, sigAfterRecv;
-		shared_ptr <storage::Storage> storage;
+		std::shared_ptr <storage::Storage> storage;
 		GlobalPairs globalPairs;
 		using PairList::add;
 		real longtimeMaxBondSqr;
 
 	  public:
-		FixedPairList(shared_ptr <storage::Storage> _storage);
+		FixedPairList(std::shared_ptr <storage::Storage> _storage);
 		virtual ~FixedPairList();
 
 		real getLongtimeMaxBondSqr();

--- a/src/FixedPairListAdress.cpp
+++ b/src/FixedPairListAdress.cpp
@@ -34,8 +34,8 @@ namespace espressopp {
 
 
   FixedPairListAdress::
-  FixedPairListAdress(shared_ptr< storage::Storage > _storage,
-          shared_ptr<FixedTupleListAdress> _fixedtupleList)
+  FixedPairListAdress(std::shared_ptr< storage::Storage > _storage,
+          std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
           : FixedPairList(_storage), fixedtupleList(_fixedtupleList) {
     LOG4ESPP_INFO(theLogger, "construct FixedPairListAdress");
     
@@ -245,10 +245,10 @@ namespace espressopp {
     bool (FixedPairListAdress::*pyAdd)(longint pid1, longint pid2)
       = &FixedPairListAdress::add;
 
-    class_<FixedPairListAdress, shared_ptr<FixedPairListAdress> >
+    class_<FixedPairListAdress, std::shared_ptr<FixedPairListAdress> >
       ("FixedPairListAdress",
-              init <shared_ptr<storage::Storage>,
-                     shared_ptr<FixedTupleListAdress> >())
+              init <std::shared_ptr<storage::Storage>,
+                     std::shared_ptr<FixedTupleListAdress> >())
       .def("add", pyAdd)
       .def("remove",  &FixedPairListAdress::remove)
       .def("getBonds",  &FixedPairListAdress::getBonds)

--- a/src/FixedPairListAdress.hpp
+++ b/src/FixedPairListAdress.hpp
@@ -43,8 +43,8 @@ namespace espressopp {
      */
 	class FixedPairListAdress : public FixedPairList {
 	  public:
-		FixedPairListAdress(shared_ptr<storage::Storage> _storage,
-		        shared_ptr<FixedTupleListAdress> _fixedtupleList);
+		FixedPairListAdress(std::shared_ptr<storage::Storage> _storage,
+		        std::shared_ptr<FixedTupleListAdress> _fixedtupleList);
 		virtual ~FixedPairListAdress();
 
 		/** Add the given particle pair to the list on this processor if the
@@ -66,7 +66,7 @@ namespace espressopp {
 		boost::signals2::connection sigBeforeSendAT, sigAfterRecvAT;
 
 	  private:
-		shared_ptr<FixedTupleListAdress> fixedtupleList;
+		std::shared_ptr<FixedTupleListAdress> fixedtupleList;
 		using PairList::add;
 		static LOG4ESPP_DECL_LOGGER(theLogger);
 	};

--- a/src/FixedQuadrupleAngleList.cpp
+++ b/src/FixedQuadrupleAngleList.cpp
@@ -44,7 +44,7 @@ namespace espressopp {
 
   LOG4ESPP_LOGGER(FixedQuadrupleAngleList::theLogger, "FixedQuadrupleAngleList");
 
-  FixedQuadrupleAngleList::FixedQuadrupleAngleList(shared_ptr< storage::Storage > _storage) 
+  FixedQuadrupleAngleList::FixedQuadrupleAngleList(std::shared_ptr< storage::Storage > _storage)
     : storage(_storage), quadruplesAngles()
   {
     LOG4ESPP_INFO(theLogger, "construct FixedQuadrupleAngleList");
@@ -338,8 +338,8 @@ namespace espressopp {
     bool (FixedQuadrupleAngleList::*pyAdd)(longint pid1, longint pid2,
            longint pid3, longint pid4) = &FixedQuadrupleAngleList::add;
 
-    class_< FixedQuadrupleAngleList, shared_ptr< FixedQuadrupleAngleList > >
-      ("FixedQuadrupleAngleList", init< shared_ptr< storage::Storage > >())
+    class_< FixedQuadrupleAngleList, std::shared_ptr< FixedQuadrupleAngleList > >
+      ("FixedQuadrupleAngleList", init< std::shared_ptr< storage::Storage > >())
       .def("add", pyAdd)
       .def("size", &FixedQuadrupleAngleList::size)
       .def("getQuadruples",  &FixedQuadrupleAngleList::getQuadruples)

--- a/src/FixedQuadrupleAngleList.hpp
+++ b/src/FixedQuadrupleAngleList.hpp
@@ -40,12 +40,12 @@ namespace espressopp {
     boost::signals2::connection con1, con2, con3;
     typedef std::multimap< longint,
             std::pair<Triple < longint, longint, longint >, real> > QuadruplesAngles;
-    shared_ptr <storage::Storage> storage;
+    std::shared_ptr <storage::Storage> storage;
     QuadruplesAngles quadruplesAngles;
     using QuadrupleList::add;
 
   public:
-    FixedQuadrupleAngleList(shared_ptr <storage::Storage> _storage);
+    FixedQuadrupleAngleList(std::shared_ptr <storage::Storage> _storage);
     ~FixedQuadrupleAngleList();
 
     /** Add the given particle quadruple to the list on this processor if the

--- a/src/FixedQuadrupleList.cpp
+++ b/src/FixedQuadrupleList.cpp
@@ -37,14 +37,14 @@
 namespace espressopp {
 
   /*
-  FixedQuadrupleList::FixedQuadrupleList(shared_ptr< storage::Storage > _storage)
+  FixedQuadrupleList::FixedQuadrupleList(std::shared_ptr< storage::Storage > _storage)
   : FixedListComm (_storage){}
   */
 
 
   LOG4ESPP_LOGGER(FixedQuadrupleList::theLogger, "FixedQuadrupleList");
 
-  FixedQuadrupleList::FixedQuadrupleList(shared_ptr< storage::Storage > _storage) 
+  FixedQuadrupleList::FixedQuadrupleList(std::shared_ptr< storage::Storage > _storage)
     : storage(_storage), globalQuadruples()
   {
     LOG4ESPP_INFO(theLogger, "construct FixedQuadrupleList");
@@ -306,8 +306,8 @@ namespace espressopp {
     //bool (FixedQuadrupleList::*pyAdd)(pvec pids)
     //          = &FixedQuadrupleList::add;
 
-    class_< FixedQuadrupleList, shared_ptr< FixedQuadrupleList > >
-      ("FixedQuadrupleList", init< shared_ptr< storage::Storage > >())
+    class_< FixedQuadrupleList, std::shared_ptr< FixedQuadrupleList > >
+      ("FixedQuadrupleList", init< std::shared_ptr< storage::Storage > >())
       .def("add", pyAdd)
       .def("size", &FixedQuadrupleList::size)
       .def("remove",  &FixedQuadrupleList::remove)

--- a/src/FixedQuadrupleList.hpp
+++ b/src/FixedQuadrupleList.hpp
@@ -39,14 +39,14 @@ namespace espressopp {
   class FixedQuadrupleList : public QuadrupleList {
   protected:
     boost::signals2::connection sigBeforeSend, sigAfterRecv, sigOnParticlesChanged;
-    shared_ptr< storage::Storage > storage;
+    std::shared_ptr< storage::Storage > storage;
     typedef boost::unordered_multimap< longint,
             Triple < longint, longint, longint > > GlobalQuadruples;
     GlobalQuadruples globalQuadruples;
     using QuadrupleList::add;
 
   public:
-    FixedQuadrupleList(shared_ptr< storage::Storage > _storage);
+    FixedQuadrupleList(std::shared_ptr< storage::Storage > _storage);
     ~FixedQuadrupleList();
 
     /** Add the given particle quadruple to the list on this processor if the

--- a/src/FixedQuadrupleListAdress.cpp
+++ b/src/FixedQuadrupleListAdress.cpp
@@ -37,7 +37,7 @@ namespace espressopp {
 LOG4ESPP_LOGGER(FixedQuadrupleListAdress::theLogger, "FixedQuadrupleListAdress");
 
 FixedQuadrupleListAdress::FixedQuadrupleListAdress(
-    shared_ptr< storage::Storage > _storage, shared_ptr<FixedTupleListAdress> _fixedtupleList)
+    std::shared_ptr< storage::Storage > _storage, std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
     : FixedQuadrupleList(_storage), fixedtupleList(_fixedtupleList) {
   LOG4ESPP_INFO(theLogger, "construct FixedQuadrupleListAdress");
 
@@ -219,9 +219,9 @@ void FixedQuadrupleListAdress::registerPython() {
   bool (FixedQuadrupleListAdress::*pyAdd)(longint pid1, longint pid2,
          longint pid3, longint pid4) = &FixedQuadrupleListAdress::add;
 
-  class_< FixedQuadrupleListAdress, shared_ptr< FixedQuadrupleListAdress > >
+  class_< FixedQuadrupleListAdress, std::shared_ptr< FixedQuadrupleListAdress > >
     ("FixedQuadrupleListAdress",
-        init<shared_ptr< storage::Storage>, shared_ptr<FixedTupleListAdress> >())
+        init<std::shared_ptr< storage::Storage>, std::shared_ptr<FixedTupleListAdress> >())
     .def("add", pyAdd)
     .def("size", &FixedQuadrupleListAdress::size)
     .def("getQuadruples",  &FixedQuadrupleListAdress::getQuadruples)

--- a/src/FixedQuadrupleListAdress.hpp
+++ b/src/FixedQuadrupleListAdress.hpp
@@ -39,8 +39,8 @@
 namespace espressopp {
 class FixedQuadrupleListAdress : public FixedQuadrupleList {
  public:
-  FixedQuadrupleListAdress(shared_ptr< storage::Storage > _storage,
-                           shared_ptr<FixedTupleListAdress> _fixedtupleList);
+  FixedQuadrupleListAdress(std::shared_ptr< storage::Storage > _storage,
+                           std::shared_ptr<FixedTupleListAdress> _fixedtupleList);
   ~FixedQuadrupleListAdress();
 
   /** Add the given particle quadruple to the list on this processor if the
@@ -62,7 +62,7 @@ class FixedQuadrupleListAdress : public FixedQuadrupleList {
   boost::signals2::connection sigBeforeSendAT, sigAfterRecvAT;
 
  private:
-  shared_ptr<FixedTupleListAdress> fixedtupleList;
+  std::shared_ptr<FixedTupleListAdress> fixedtupleList;
   using QuadrupleList::add;
   static LOG4ESPP_DECL_LOGGER(theLogger);
 };

--- a/src/FixedSingleList.cpp
+++ b/src/FixedSingleList.cpp
@@ -36,7 +36,7 @@ namespace espressopp {
   LOG4ESPP_LOGGER(FixedSingleList::theLogger, "FixedSingleList");
 
 
-  FixedSingleList::FixedSingleList(shared_ptr< storage::Storage > _storage)
+  FixedSingleList::FixedSingleList(std::shared_ptr< storage::Storage > _storage)
     : storage(_storage), globalSingles()
   {
     LOG4ESPP_INFO(theLogger, "construct FixedSingleList");
@@ -153,8 +153,8 @@ namespace espressopp {
 
     bool (FixedSingleList::*pyAdd)(longint pid1) = &FixedSingleList::add;
 
-    class_<FixedSingleList, shared_ptr<FixedSingleList> >
-      ("FixedSingleList", init <shared_ptr<storage::Storage> >())
+    class_<FixedSingleList, std::shared_ptr<FixedSingleList> >
+      ("FixedSingleList", init <std::shared_ptr<storage::Storage> >())
       .def("add", pyAdd)
       .def("size", &FixedSingleList::size)
       .def("getSingles",  &FixedSingleList::getSingles)

--- a/src/FixedSingleList.hpp
+++ b/src/FixedSingleList.hpp
@@ -40,12 +40,12 @@ namespace espressopp {
 
 	  protected:
 		boost::signals2::connection con1, con2, con3;
-		shared_ptr <storage::Storage> storage;
+		std::shared_ptr <storage::Storage> storage;
 		GlobalSingles globalSingles;
 		using SingleList::add;
 
 	  public:
-		FixedSingleList(shared_ptr <storage::Storage> _storage);
+		FixedSingleList(std::shared_ptr <storage::Storage> _storage);
 		virtual ~FixedSingleList();
 
 		/** Add the given particle to the list on this processor if the

--- a/src/FixedTripleAngleList.cpp
+++ b/src/FixedTripleAngleList.cpp
@@ -35,7 +35,7 @@ namespace espressopp {
 
   LOG4ESPP_LOGGER(FixedTripleAngleList::theLogger, "FixedTripleAngleList");
 
-  FixedTripleAngleList::FixedTripleAngleList(shared_ptr< storage::Storage > _storage)
+  FixedTripleAngleList::FixedTripleAngleList(std::shared_ptr< storage::Storage > _storage)
   : storage(_storage), triplesAngles()
   {
     LOG4ESPP_INFO(theLogger, "construct FixedTripleAngleList");
@@ -288,8 +288,8 @@ namespace espressopp {
     //bool (FixedTripleAngleList::*pyAdd)(pvec pids)
     //      = &FixedTripleAngleList::add;
 
-    class_< FixedTripleAngleList, shared_ptr< FixedTripleAngleList > >
-      ("FixedTripleAngleList", init< shared_ptr< storage::Storage > >())
+    class_< FixedTripleAngleList, std::shared_ptr< FixedTripleAngleList > >
+      ("FixedTripleAngleList", init< std::shared_ptr< storage::Storage > >())
       .def("add", pyAdd)
       .def("size", &FixedTripleAngleList::size)
       .def("getTriples",  &FixedTripleAngleList::getTriples)

--- a/src/FixedTripleAngleList.hpp
+++ b/src/FixedTripleAngleList.hpp
@@ -48,12 +48,12 @@ namespace espressopp {
       protected:
 		boost::signals2::connection con1, con2, con3;
 		typedef multimap <longint,pair<pair<longint, longint>, real> > TriplesAngles;
-		shared_ptr <storage::Storage> storage;
+		std::shared_ptr <storage::Storage> storage;
 		TriplesAngles triplesAngles;
 		using TripleList::add;
 
 	  public:
-		FixedTripleAngleList( shared_ptr<storage::Storage> _storage );
+		FixedTripleAngleList( std::shared_ptr<storage::Storage> _storage );
 		virtual ~FixedTripleAngleList();
 		/** Add the given particle triple to the list on this processor if the
 		particle with the lower id belongs to this processor.  Note that

--- a/src/FixedTripleList.cpp
+++ b/src/FixedTripleList.cpp
@@ -36,14 +36,14 @@
 namespace espressopp {
 
   /*
-  FixedTripleList::FixedTripleList(shared_ptr< storage::Storage > _storage)
+  FixedTripleList::FixedTripleList(std::shared_ptr< storage::Storage > _storage)
   : FixedListComm (_storage){}
   */
 
 
   LOG4ESPP_LOGGER(FixedTripleList::theLogger, "FixedTripleList");
 
-  FixedTripleList::FixedTripleList(shared_ptr< storage::Storage > _storage)
+  FixedTripleList::FixedTripleList(std::shared_ptr< storage::Storage > _storage)
     : storage(_storage), globalTriples()
   {
     LOG4ESPP_INFO(theLogger, "construct FixedTripleList");
@@ -311,8 +311,8 @@ namespace espressopp {
     //bool (FixedTripleList::*pyAdd)(pvec pids)
     //      = &FixedTripleList::add;
 
-    class_< FixedTripleList, shared_ptr< FixedTripleList > >
-      ("FixedTripleList", init< shared_ptr< storage::Storage > >())
+    class_< FixedTripleList, std::shared_ptr< FixedTripleList > >
+      ("FixedTripleList", init< std::shared_ptr< storage::Storage > >())
       .def("add", pyAdd)
       .def("size", &FixedTripleList::size)
       .def("remove",  &FixedTripleList::remove)

--- a/src/FixedTripleList.hpp
+++ b/src/FixedTripleList.hpp
@@ -39,7 +39,7 @@ namespace espressopp {
   class FixedTripleList : public TripleList {
       protected:
 		boost::signals2::connection sigAfterRecv, sigOnParticleChanged, sigBeforeSend;
-		shared_ptr<storage::Storage> storage;
+		std::shared_ptr<storage::Storage> storage;
 		typedef boost::unordered_multimap <longint,std::pair <longint, longint> > GlobalTriples;
 		GlobalTriples globalTriples;
 		using TripleList::add;
@@ -47,7 +47,7 @@ namespace espressopp {
       //FixedListComm<FixedTripleList, 3> _comm;
 
 	  public:
-		FixedTripleList(shared_ptr<storage::Storage> _storage);
+		FixedTripleList(std::shared_ptr<storage::Storage> _storage);
 		virtual ~FixedTripleList();
 		//bool add(pvec pids) { _comm.add(pids); }
 		/** Add the given particle triple to the list on this processor if the

--- a/src/FixedTripleListAdress.cpp
+++ b/src/FixedTripleListAdress.cpp
@@ -39,8 +39,8 @@ namespace espressopp {
 
   LOG4ESPP_LOGGER(FixedTripleListAdress::theLogger, "FixedTripleListAdress");
 
-FixedTripleListAdress::FixedTripleListAdress(shared_ptr< storage::Storage > _storage,
-    shared_ptr<FixedTupleListAdress> _fixedtupleList)
+FixedTripleListAdress::FixedTripleListAdress(std::shared_ptr< storage::Storage > _storage,
+    std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
     : FixedTripleList(_storage), fixedtupleList(_fixedtupleList) {
   LOG4ESPP_INFO(theLogger, "construct FixedTripleListAdress");
 
@@ -249,10 +249,10 @@ FixedTripleListAdress::~FixedTripleListAdress() {
     bool (FixedTripleListAdress::*pyAdd)(longint pid1, longint pid2, longint pid3)
       = &FixedTripleListAdress::add;
 
-    class_<FixedTripleListAdress, shared_ptr<FixedTripleListAdress> >
+    class_<FixedTripleListAdress, std::shared_ptr<FixedTripleListAdress> >
       ("FixedTripleListAdress",
-              init <shared_ptr<storage::Storage>,
-                     shared_ptr<FixedTupleListAdress> >())
+              init <std::shared_ptr<storage::Storage>,
+                     std::shared_ptr<FixedTupleListAdress> >())
       .def("add", pyAdd)
       .def("remove",  &FixedTripleList::remove)
       ;

--- a/src/FixedTripleListAdress.hpp
+++ b/src/FixedTripleListAdress.hpp
@@ -44,8 +44,8 @@ namespace espressopp {
      */
 	class FixedTripleListAdress : public FixedTripleList {
 	  public:
-		FixedTripleListAdress(shared_ptr<storage::Storage> _storage,
-		        shared_ptr<FixedTupleListAdress> _fixedtupleList);
+		FixedTripleListAdress(std::shared_ptr<storage::Storage> _storage,
+		        std::shared_ptr<FixedTupleListAdress> _fixedtupleList);
 		~FixedTripleListAdress();
 
 		/** Add the given particle triple to the list on this processor if the
@@ -66,7 +66,7 @@ namespace espressopp {
 		boost::signals2::connection sigBeforeSendAT, sigAfterRecvAT;
 
 	  private:
-		shared_ptr<FixedTupleListAdress> fixedtupleList;
+		std::shared_ptr<FixedTupleListAdress> fixedtupleList;
 		using TripleList::add;
 		static LOG4ESPP_DECL_LOGGER(theLogger);
 	};

--- a/src/FixedTupleList.cpp
+++ b/src/FixedTupleList.cpp
@@ -38,7 +38,7 @@ namespace espressopp {
 
   LOG4ESPP_LOGGER(FixedTupleList::theLogger, "FixedTupleList");
 
-  FixedTupleList::FixedTupleList(shared_ptr< storage::Storage > _storage)
+  FixedTupleList::FixedTupleList(std::shared_ptr< storage::Storage > _storage)
     : storage(_storage), globalTuples()
   {
     LOG4ESPP_INFO(theLogger, "construct FixedTupleList");
@@ -237,8 +237,8 @@ namespace espressopp {
     //bool (FixedTupleList::*pyAdd)(pvec pids)
     //      = &FixedTupleList::add;
 
-    class_< FixedTupleList, shared_ptr< FixedTupleList > >
-      ("FixedTupleList", init< shared_ptr< storage::Storage > >())
+    class_< FixedTupleList, std::shared_ptr< FixedTupleList > >
+      ("FixedTupleList", init< std::shared_ptr< storage::Storage > >())
       .def("addTuple", &FixedTupleList::addTuple)
      .def("getTuples", &FixedTupleList::getTuples)
       .def("size", &FixedTupleList::size)

--- a/src/FixedTupleList.hpp
+++ b/src/FixedTupleList.hpp
@@ -36,7 +36,7 @@ namespace espressopp {
   class FixedTupleList : public TupleList {
       protected:
 		boost::signals2::connection con1, con2, con3;
-		shared_ptr<storage::Storage> storage;
+		std::shared_ptr<storage::Storage> storage;
                 typedef std::vector<longint> tuple;
 		typedef std::multimap <longint,tuple > GlobalTuples;
 		GlobalTuples globalTuples;
@@ -45,7 +45,7 @@ namespace espressopp {
       //FixedListComm<FixedTupleList, 3> _comm;
 
 	  public:
-		FixedTupleList(shared_ptr<storage::Storage> _storage);
+		FixedTupleList(std::shared_ptr<storage::Storage> _storage);
 		virtual ~FixedTupleList();
 		virtual bool addTuple(boost::python::list& tuple);
 		virtual void beforeSendParticles(ParticleList& pl, class OutBuffer &buf);

--- a/src/FixedTupleListAdress.cpp
+++ b/src/FixedTupleListAdress.cpp
@@ -41,7 +41,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(FixedTupleListAdress::theLogger, "FixedTupleListAdress");
 
-    FixedTupleListAdress::FixedTupleListAdress(shared_ptr<storage::Storage> _storage)
+    FixedTupleListAdress::FixedTupleListAdress(std::shared_ptr<storage::Storage> _storage)
         : storage(_storage), globalTuples(){
 
         LOG4ESPP_INFO(theLogger, "construct FixedTupleListAdress");
@@ -368,8 +368,8 @@ namespace espressopp {
 
       void (FixedTupleListAdress::*pyAdd)(longint pid) = &FixedTupleListAdress::add;
 
-      class_<FixedTupleListAdress, shared_ptr<FixedTupleListAdress>, boost::noncopyable >
-        ("FixedTupleListAdress", init<shared_ptr<storage::Storage> >())
+      class_<FixedTupleListAdress, std::shared_ptr<FixedTupleListAdress>, boost::noncopyable >
+        ("FixedTupleListAdress", init<std::shared_ptr<storage::Storage> >())
         .def("add", pyAdd)
         .def("addTs", &FixedTupleListAdress::addTs)
         ;

--- a/src/FixedTupleListAdress.hpp
+++ b/src/FixedTupleListAdress.hpp
@@ -39,14 +39,14 @@ namespace espressopp {
     class FixedTupleListAdress: public TupleList  {
         protected:
             boost::signals2::connection sigOnTupleChanged, sigAfterRecv, sigBeforeSend;
-            shared_ptr<storage::Storage> storage;
+            std::shared_ptr<storage::Storage> storage;
             typedef std::vector<longint> tuple;
             typedef boost::unordered_map<longint, tuple> GlobalTuples;
             GlobalTuples globalTuples;
             using TupleList::add;
 
         public:
-            FixedTupleListAdress(shared_ptr<storage::Storage> _storage);
+            FixedTupleListAdress(std::shared_ptr<storage::Storage> _storage);
             ~FixedTupleListAdress();
 
             void add(longint pid) { tmppids.push_back(pid); } // add particle id (called from python)

--- a/src/MultiSystemAccess.hpp
+++ b/src/MultiSystemAccess.hpp
@@ -41,12 +41,12 @@ namespace espressopp {
 
     /** Constructor */
 
-	MultiSystemAccess(shared_ptr<System> system1, shared_ptr<System> system2);
+	MultiSystemAccess(std::shared_ptr<System> system1, std::shared_ptr<System> system2);
 
     /** Get shared pointers to the systems */
 
-    shared_ptr<System> getSystem1() const;
-    shared_ptr<System> getSystem2() const;
+    std::shared_ptr<System> getSystem1() const;
+    std::shared_ptr<System> getSystem2() const;
 
     /** Get system references */
 
@@ -66,7 +66,7 @@ namespace espressopp {
   *  Implementation                                                         *
   **************************************************************************/
 
-  inline MultiSystemAccess::MultiSystemAccess(shared_ptr<System> system1, shared_ptr<System> system2) {
+  inline MultiSystemAccess::MultiSystemAccess(std::shared_ptr<System> system1, std::shared_ptr<System> system2) {
 	if (!system1) {
 	  throw std::runtime_error("NULL system1");
 	}
@@ -86,7 +86,7 @@ namespace espressopp {
     mySystem = system->getShared();
   }
 
-  inline shared_ptr<System> MultiSystemAccess::getSystem1() const {
+  inline std::shared_ptr<System> MultiSystemAccess::getSystem1() const {
 
     if (mySystem1.expired()) {
        throw std::runtime_error("expired system1");
@@ -95,7 +95,7 @@ namespace espressopp {
     return mySystem1.lock();
   }
 
-  inline shared_ptr<System> MultiSystemAccess::getSystem2() const {
+  inline std::shared_ptr<System> MultiSystemAccess::getSystem2() const {
  
     if (mySystem2.expired()) {
        throw std::runtime_error("expired system2");

--- a/src/ParticleAccess.hpp
+++ b/src/ParticleAccess.hpp
@@ -28,7 +28,7 @@
 namespace espressopp {
   class ParticleAccess : public SystemAccess {
   public:
-    ParticleAccess(shared_ptr< System > system) : SystemAccess(system) {}
+    ParticleAccess(std::shared_ptr< System > system) : SystemAccess(system) {}
     virtual ~ParticleAccess() {}
 
     virtual void perform_action() = 0;

--- a/src/ParticleGroup.cpp
+++ b/src/ParticleGroup.cpp
@@ -27,7 +27,7 @@
 
 namespace espressopp {
 
-    ParticleGroup::ParticleGroup(shared_ptr <storage::Storage> _storage)
+    ParticleGroup::ParticleGroup(std::shared_ptr <storage::Storage> _storage)
     : storage(_storage) {
         con_send = storage->beforeSendParticles.connect
                 (boost::bind(&ParticleGroup::beforeSendParticles, this, _1, _2));
@@ -127,8 +127,8 @@ namespace espressopp {
 
         using namespace espressopp::python;
 
-        class_< ParticleGroup, shared_ptr <ParticleGroup> >
-                ("ParticleGroup", init <shared_ptr <storage::Storage> >())
+        class_< ParticleGroup, std::shared_ptr <ParticleGroup> >
+                ("ParticleGroup", init <std::shared_ptr <storage::Storage> >())
                 .def("add", &ParticleGroup::add)
                 .def("show", &ParticleGroup::print)
                 .def("has", &ParticleGroup::has)

--- a/src/ParticleGroup.hpp
+++ b/src/ParticleGroup.hpp
@@ -46,7 +46,7 @@ namespace espressopp {
      */
     class ParticleGroup {
         public:
-            ParticleGroup(shared_ptr <storage::Storage> _storage);
+            ParticleGroup(std::shared_ptr <storage::Storage> _storage);
             ~ParticleGroup();
 
             /**
@@ -114,7 +114,7 @@ namespace espressopp {
             std::set<longint> particles;
 
             // pointer to storage object
-            shared_ptr<storage::Storage> storage;
+            std::shared_ptr<storage::Storage> storage;
 
             // some signalling stuff to keep track of the particles in cell
             boost::signals2::connection con_send, con_recv, con_changed;

--- a/src/RealND.hpp
+++ b/src/RealND.hpp
@@ -112,13 +112,13 @@ namespace espressopp {
   };
 
   class RealNDs {
-    std::vector<shared_ptr <RealND>> data;
+    std::vector<std::shared_ptr <RealND>> data;
   private:
     int dimension;
   public:
     void setDimension(int _dim) {
       for (int i = dimension; i<_dim; ++i) {
-        data.push_back(boost::make_shared<RealND>());
+        data.push_back(std::make_shared<RealND>());
       }
       dimension = _dim;
     }

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -59,7 +59,7 @@ namespace espressopp {
     //};
     
     // Following is some extreme typecasting which we need to convert the
-    // pmi python object pmi._MPIcomm into a shared_ptr< boost::mpi::communicator >
+    // pmi python object pmi._MPIcomm into a std::shared_ptr< boost::mpi::communicator >
     // I have not yet figured out how to do it in a more elegant way
     PyObject *pyobj = _pyobj.ptr();
     // in mpi4py.1.2.1 this has to be:
@@ -67,7 +67,7 @@ namespace espressopp {
     // in version >= mpi4py.1.2.2 this has to be:
     PyMPICommObject* pyMPIComm = (PyMPICommObject*) pyobj;
     MPI_Comm * comm_p = &pyMPIComm->ob_mpi;
-    shared_ptr< mpi::communicator > newcomm = make_shared< mpi::communicator >(*comm_p, mpi::comm_attach);
+    std::shared_ptr< mpi::communicator > newcomm = std::make_shared< mpi::communicator >(*comm_p, mpi::comm_attach);
 
     comm = newcomm;
     maxCutoff = 0.0;
@@ -92,7 +92,7 @@ namespace espressopp {
     return skin;
   }
 
-  void System::addInteraction(shared_ptr< interaction::Interaction > ia){
+  void System::addInteraction(std::shared_ptr< interaction::Interaction > ia){
     shortRangeInteractions.push_back(ia);
     
     // check if the cutoff of this interaction is bigger then maxCutoff
@@ -129,7 +129,7 @@ namespace espressopp {
     }
   }
 
-  shared_ptr< interaction::Interaction > System::getInteraction(int i)
+  std::shared_ptr< interaction::Interaction > System::getInteraction(int i)
   {
     return shortRangeInteractions[i];
   }

--- a/src/System.hpp
+++ b/src/System.hpp
@@ -46,11 +46,11 @@ namespace espressopp {
     System();
     System(python::object _pyobj);
 
-    shared_ptr< mpi::communicator > comm;
+    std::shared_ptr< mpi::communicator > comm;
 
-    shared_ptr< storage::Storage > storage;
-    shared_ptr< bc::BC > bc;
-    shared_ptr< esutil::RNG > rng;
+    std::shared_ptr< storage::Storage > storage;
+    std::shared_ptr< bc::BC > bc;
+    std::shared_ptr< esutil::RNG > rng;
 
     interaction::InteractionList shortRangeInteractions;
 
@@ -58,7 +58,7 @@ namespace espressopp {
 
     bool CommunicatorIsInitialized;
 
-    shared_ptr< System > getShared() { 
+    std::shared_ptr< System > getShared() {
       return shared_from_this();
     }
     
@@ -69,9 +69,9 @@ namespace espressopp {
     void scaleVolume(Real3D s, bool particleCoordinates);
     void scaleVolume3D(Real3D s);
     void setTrace(bool flag);
-    void addInteraction(shared_ptr< interaction::Interaction > ia);
+    void addInteraction(std::shared_ptr< interaction::Interaction > ia);
     void removeInteraction(int i);
-    shared_ptr< interaction::Interaction > getInteraction(int i);
+    std::shared_ptr< interaction::Interaction > getInteraction(int i);
     int getNumberOfInteractions();
     static void registerPython();
 

--- a/src/SystemAccess.hpp
+++ b/src/SystemAccess.hpp
@@ -37,13 +37,13 @@ namespace espressopp {
   class SystemAccess {
   public:
     /** Constructor */
-    SystemAccess(shared_ptr<System> system);
-    SystemAccess(shared_ptr<System> system1, shared_ptr<System> system2);
+    SystemAccess(std::shared_ptr<System> system);
+    SystemAccess(std::shared_ptr<System> system1, std::shared_ptr<System> system2);
 
     /** Get shared pointer to the system */
-    shared_ptr<System> getSystem() const;
-    shared_ptr<System> getSystem1() const;
-    shared_ptr<System> getSystem2() const;
+    std::shared_ptr<System> getSystem() const;
+    std::shared_ptr<System> getSystem1() const;
+    std::shared_ptr<System> getSystem2() const;
 
     /** Get a system reference */
     System& getSystemRef() const { return *(getSystem().get()); }
@@ -60,7 +60,7 @@ namespace espressopp {
   *  Implementation                                                         *
   **************************************************************************/
 
-  inline SystemAccess::SystemAccess(shared_ptr<System> system) {
+  inline SystemAccess::SystemAccess(std::shared_ptr<System> system) {
     if (!system) {
        throw std::runtime_error("NULL system");
     } 
@@ -72,7 +72,7 @@ namespace espressopp {
     mySystem = system->getShared();
   }
 
-  inline SystemAccess::SystemAccess(shared_ptr<System> system1, shared_ptr<System> system2) {
+  inline SystemAccess::SystemAccess(std::shared_ptr<System> system1, std::shared_ptr<System> system2) {
 	if (!system1) {
 	  throw std::runtime_error("NULL system1");
 	}
@@ -93,7 +93,7 @@ namespace espressopp {
   }
 
 
-  inline shared_ptr<System> SystemAccess::getSystem() const {
+  inline std::shared_ptr<System> SystemAccess::getSystem() const {
  
     if (mySystem.expired()) {
        throw std::runtime_error("expired system");
@@ -102,7 +102,7 @@ namespace espressopp {
     return mySystem.lock();
   }
 
-  inline shared_ptr<System> SystemAccess::getSystem1() const {
+  inline std::shared_ptr<System> SystemAccess::getSystem1() const {
 
     if (mySystem1.expired()) {
        throw std::runtime_error("expired system1");
@@ -111,7 +111,7 @@ namespace espressopp {
     return mySystem1.lock();
   }
 
-  inline shared_ptr<System> SystemAccess::getSystem2() const {
+  inline std::shared_ptr<System> SystemAccess::getSystem2() const {
 
     if (mySystem2.expired()) {
        throw std::runtime_error("expired system2");

--- a/src/VerletList.cpp
+++ b/src/VerletList.cpp
@@ -41,7 +41,7 @@ namespace espressopp {
 /*-------------------------------------------------------------*/
 
   // cut is a cutoff (without skin)
-  VerletList::VerletList(shared_ptr<System> system, real _cut, bool rebuildVL, bool useBuffers, bool useSOA)
+  VerletList::VerletList(std::shared_ptr<System> system, real _cut, bool rebuildVL, bool useBuffers, bool useSOA)
     : SystemAccess(system), useBuffers(useBuffers), useSOA(useSOA)
   {
     LOG4ESPP_INFO(theLogger, "construct VerletList, cut = " << _cut);
@@ -348,8 +348,8 @@ namespace espressopp {
           = &VerletList::exclude;
 
 
-    class_<VerletList, shared_ptr<VerletList> >
-      ("VerletList", init< shared_ptr<System>, real, bool, bool, bool >())
+    class_<VerletList, std::shared_ptr<VerletList> >
+      ("VerletList", init< std::shared_ptr<System>, real, bool, bool, bool >())
       .add_property("system", &SystemAccess::getSystem)
       .add_property("builds", &VerletList::getBuilds, &VerletList::setBuilds)
       .def("totalSize", &VerletList::totalSize)

--- a/src/VerletList.hpp
+++ b/src/VerletList.hpp
@@ -56,7 +56,7 @@ namespace espressopp {
 
     */
 
-    VerletList(shared_ptr< System >, real cut, bool rebuildVL, bool useBuffers=true, bool useSOA=false);
+    VerletList(std::shared_ptr< System >, real cut, bool rebuildVL, bool useBuffers=true, bool useSOA=false);
 
     ~VerletList();
 

--- a/src/VerletListAdress.cpp
+++ b/src/VerletListAdress.cpp
@@ -39,7 +39,7 @@ namespace espressopp {
 
   /*-------------------------------------------------------------*/
 
-    VerletListAdress::VerletListAdress(shared_ptr<System> system, real cut, real adrCut,
+    VerletListAdress::VerletListAdress(std::shared_ptr<System> system, real cut, real adrCut,
                                        bool rebuildVL, real _dEx, real _dHy)
     :SystemAccess(system) {
       LOG4ESPP_INFO(theLogger, "construct VerletList, cut = " << cut);
@@ -244,8 +244,8 @@ namespace espressopp {
       void (VerletListAdress::*pySetAdrRegionType)(bool _sphereAdr)
             = &VerletListAdress::setAdrRegionType;
 
-      class_<VerletListAdress, shared_ptr<VerletList> >
-        ("VerletListAdress", init< shared_ptr<System>, real, real, bool, real, real>())
+      class_<VerletListAdress, std::shared_ptr<VerletList> >
+        ("VerletListAdress", init< std::shared_ptr<System>, real, real, bool, real, real>())
         .add_property("system", &SystemAccess::getSystem)
         .add_property("builds", &VerletListAdress::getBuilds, &VerletListAdress::setBuilds)
         .def("totalSize", &VerletListAdress::totalSize)

--- a/src/VerletListAdress.hpp
+++ b/src/VerletListAdress.hpp
@@ -52,7 +52,7 @@ namespace espressopp {
 
     */
 
-    VerletListAdress(shared_ptr< System >, real cut, real adrcut, bool rebuildVL, real _dEx, real _dHy);
+    VerletListAdress(std::shared_ptr< System >, real cut, real adrcut, bool rebuildVL, real _dEx, real _dHy);
 
     ~VerletListAdress();
 

--- a/src/VerletListTriple.cpp
+++ b/src/VerletListTriple.cpp
@@ -37,7 +37,7 @@ namespace espressopp {
 /*-------------------------------------------------------------*/
 
   // cut is a cutoff (without skin)
-  VerletListTriple::VerletListTriple(shared_ptr<System> system, real _cut, bool rebuildVL):SystemAccess(system){
+  VerletListTriple::VerletListTriple(std::shared_ptr<System> system, real _cut, bool rebuildVL):SystemAccess(system){
     LOG4ESPP_INFO(theLogger, "construct VerletListTriple, cut = " << _cut);
   
     if (!system->storage) {
@@ -176,8 +176,8 @@ namespace espressopp {
 
     bool (VerletListTriple::*pyExclude)(longint pid) = &VerletListTriple::exclude;
 
-    class_<VerletListTriple, shared_ptr<VerletListTriple> >
-      ("VerletListTriple", init< shared_ptr<System>, real, bool >())
+    class_<VerletListTriple, std::shared_ptr<VerletListTriple> >
+      ("VerletListTriple", init< std::shared_ptr<System>, real, bool >())
       .add_property("system", &SystemAccess::getSystem)
       .add_property("builds", &VerletListTriple::getBuilds, &VerletListTriple::setBuilds)
       .def("totalSize", &VerletListTriple::totalSize)

--- a/src/VerletListTriple.hpp
+++ b/src/VerletListTriple.hpp
@@ -50,7 +50,7 @@ namespace espressopp {
 
     */
 
-    VerletListTriple(shared_ptr< System >, real cut, bool rebuildVL);
+    VerletListTriple(std::shared_ptr< System >, real cut, bool rebuildVL);
 
     ~VerletListTriple();
 

--- a/src/analysis/AdressDensity.cpp
+++ b/src/analysis/AdressDensity.cpp
@@ -60,7 +60,7 @@ namespace espressopp {
       int id = 0;
       int bin = 0;
       if(system.storage->getFixedTuples()){
-            shared_ptr<FixedTupleListAdress> fixedtupleList=system.storage->getFixedTuples();
+            std::shared_ptr<FixedTupleListAdress> fixedtupleList=system.storage->getFixedTuples();
             CellList realCells = system.storage->getRealCells();
 
             for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {  // Iterate over all (CG) particles.
@@ -231,7 +231,7 @@ namespace espressopp {
     void AdressDensity::registerPython() {
       using namespace espressopp::python;
       class_<AdressDensity, bases< Observable > >
-        ("analysis_AdressDensity", init< shared_ptr< System >, shared_ptr<VerletListAdress> >())
+        ("analysis_AdressDensity", init< std::shared_ptr< System >, std::shared_ptr<VerletListAdress> >())
         .def("addExclpid", &AdressDensity::addExclpid)
         .def("compute", &AdressDensity::computeArray)
       ;

--- a/src/analysis/AdressDensity.hpp
+++ b/src/analysis/AdressDensity.hpp
@@ -32,9 +32,9 @@ namespace espressopp {
     // Class to compute the density profile along slabs in the x-direction of the system.
     class AdressDensity : public Observable {
     public:
-      AdressDensity(shared_ptr< System > system, shared_ptr<VerletListAdress> _verletList) : Observable(system), verletList(_verletList) {}
+      AdressDensity(std::shared_ptr< System > system, std::shared_ptr<VerletListAdress> _verletList) : Observable(system), verletList(_verletList) {}
       ~AdressDensity() {}
-      shared_ptr<VerletListAdress> verletList;
+      std::shared_ptr<VerletListAdress> verletList;
       virtual real compute() const;
       virtual python::list computeArray(int) const;
 

--- a/src/analysis/AdressDensity.py
+++ b/src/analysis/AdressDensity.py
@@ -38,9 +38,9 @@ Examples:
 .. function:: espressopp.analysis.AdressDensity(system, verletlist)
 
         :param system: system object
-        :type system: shared_ptr<System>
+        :type system: std::shared_ptr<System>
         :param verletlist: verletlist object
-        :type verletlist: shared_ptr<VerletListAdress>
+        :type verletlist: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.analysis.AdressDensity.compute(bins)
 

--- a/src/analysis/AllParticlePos.hpp
+++ b/src/analysis/AllParticlePos.hpp
@@ -47,7 +47,7 @@ namespace espressopp {
 
     class AllParticlePos : public SystemAccess {
     public:
-      AllParticlePos(shared_ptr<System> system) : SystemAccess (system) {};
+      AllParticlePos(std::shared_ptr<System> system) : SystemAccess (system) {};
       ~AllParticlePos() {};
       /** gather and broadcast all particle positions to all cpus */
       void gatherAllPositions();

--- a/src/analysis/AnalysisBase.hpp
+++ b/src/analysis/AnalysisBase.hpp
@@ -43,7 +43,7 @@ namespace espressopp {
     * */
       class AnalysisBase : public ParticleAccess{ //SystemAccess {
       public:
-        AnalysisBase(shared_ptr< System > system) : ParticleAccess(system) {}
+        AnalysisBase(std::shared_ptr< System > system) : ParticleAccess(system) {}
         virtual ~AnalysisBase() {}
       virtual void performMeasurement() = 0;
       virtual void reset() = 0;
@@ -62,7 +62,7 @@ namespace espressopp {
     template < class ResultType >
     class AnalysisBaseTemplate : public AnalysisBase {
     public:
-      AnalysisBaseTemplate(shared_ptr< System > system) : AnalysisBase(system) {
+      AnalysisBaseTemplate(std::shared_ptr< System > system) : AnalysisBase(system) {
     	  //this->reset();
       };
       virtual ~AnalysisBaseTemplate() {};

--- a/src/analysis/Autocorrelation.cpp
+++ b/src/analysis/Autocorrelation.cpp
@@ -169,7 +169,7 @@ namespace espressopp {
 
       class_<Autocorrelation>(
         "analysis_Autocorrelation",
-        init< shared_ptr< System > >()
+        init< std::shared_ptr< System > >()
       )
       .def_readonly("size", &Autocorrelation::getListSize)
       

--- a/src/analysis/Autocorrelation.hpp
+++ b/src/analysis/Autocorrelation.hpp
@@ -48,7 +48,7 @@ namespace espressopp {
 
     public:
       // Constructor, allow for unlimited snapshots.
-      Autocorrelation(shared_ptr<System> system): SystemAccess (system){
+      Autocorrelation(std::shared_ptr<System> system): SystemAccess (system){
       }
       ~Autocorrelation(){
         valueList.clear();

--- a/src/analysis/CMVelocity.cpp
+++ b/src/analysis/CMVelocity.cpp
@@ -96,7 +96,7 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<CMVelocity, bases<AnalysisBase> >
-        ("analysis_CMVelocity", init<shared_ptr<System> >())
+        ("analysis_CMVelocity", init<std::shared_ptr<System> >())
       .add_property("v", &CMVelocity::getV)
       ;
     }

--- a/src/analysis/CMVelocity.hpp
+++ b/src/analysis/CMVelocity.hpp
@@ -40,7 +40,7 @@ namespace espressopp {
 
     public:
 
-      CMVelocity(shared_ptr<System> system) : AnalysisBaseTemplate <Real3D> (system) {}
+      CMVelocity(std::shared_ptr<System> system) : AnalysisBaseTemplate <Real3D> (system) {}
 
       ~CMVelocity() {}
 

--- a/src/analysis/CenterOfMass.cpp
+++ b/src/analysis/CenterOfMass.cpp
@@ -74,7 +74,7 @@ namespace espressopp {
     void CenterOfMass::registerPython() {
       using namespace espressopp::python;
       class_<CenterOfMass, bases< Observable > >
-        ("analysis_CenterOfMass", init< shared_ptr< System > >())
+        ("analysis_CenterOfMass", init< std::shared_ptr< System > >())
         .def("compute", &CenterOfMass::computeVector)
       ;
     }

--- a/src/analysis/CenterOfMass.hpp
+++ b/src/analysis/CenterOfMass.hpp
@@ -33,7 +33,7 @@ namespace espressopp {
     /** Class to compute the center-of-mass of the system. */
     class CenterOfMass : public Observable {
     public:
-      CenterOfMass(shared_ptr< System > system) : Observable(system) {}
+      CenterOfMass(std::shared_ptr< System > system) : Observable(system) {}
       ~CenterOfMass() {}
       virtual real compute() const;
       virtual Real3D computeVector() const;

--- a/src/analysis/ConfigsParticleDecomp.cpp
+++ b/src/analysis/ConfigsParticleDecomp.cpp
@@ -58,7 +58,7 @@ namespace espressopp {
         stringstream msg;
         msg << "Error. Velocities::get <out-of-range>" << endl;
         err.setException( msg.str() );
-        return shared_ptr<Configuration>();
+        return std::shared_ptr<Configuration>();
       }
     }
 
@@ -89,7 +89,7 @@ namespace espressopp {
         }
       }
 
-      ConfigurationPtr config = make_shared<Configuration> ();
+      ConfigurationPtr config = std::make_shared<Configuration> ();
       for (int rank_i=0; rank_i<nprocs; rank_i++) {
         map< size_t, Real3D > conf;
         if (rank_i == myrank) {
@@ -139,7 +139,7 @@ namespace espressopp {
 
       int localN = system.storage->getNRealParticles();
 
-      ConfigurationPtr config = make_shared<Configuration> ();
+      ConfigurationPtr config = std::make_shared<Configuration> ();
       map< size_t, Real3D > conf;
 
       if (myrank==0) {
@@ -193,7 +193,7 @@ namespace espressopp {
 
       class_<ConfigsParticleDecomp, boost::noncopyable >(
         "analysis_ConfigsParticleDecomp", no_init
-        //init< shared_ptr< System > >()
+        //init< std::shared_ptr< System > >()
       )
       .def_readonly("size", &ConfigsParticleDecomp::getListSize)
       

--- a/src/analysis/ConfigsParticleDecomp.hpp
+++ b/src/analysis/ConfigsParticleDecomp.hpp
@@ -65,7 +65,7 @@ namespace espressopp {
        * Constructor, allow for unlimited snapshots. It defines how many particles
        * correspond to different cpu.
        */
-      ConfigsParticleDecomp(shared_ptr<System> system): SystemAccess (system){
+      ConfigsParticleDecomp(std::shared_ptr<System> system): SystemAccess (system){
         // by default key = "position", it will store the particle positions
         // (option: "velocity" or "unfolded")
         esutil::Error err(system->comm);
@@ -147,7 +147,7 @@ namespace espressopp {
         * !! works for particles numbered like 0+start_pid, 1+start_pid, 2+start_pid,... !!
         * !! with each chain consisting of particles with subsequent ids     !!
        */
-      ConfigsParticleDecomp(shared_ptr<System> system, int _chainlength, int _start_pid): SystemAccess (system){
+      ConfigsParticleDecomp(std::shared_ptr<System> system, int _chainlength, int _start_pid): SystemAccess (system){
         // by default key = "position", it will store the particle positions
         // (option: "velocity" or "unfolded")
         esutil::Error err(system->comm);

--- a/src/analysis/Configuration.hpp
+++ b/src/analysis/Configuration.hpp
@@ -31,7 +31,7 @@
 namespace espressopp {
   namespace analysis {
 
-    typedef shared_ptr<class Configuration> ConfigurationPtr;
+    typedef std::shared_ptr<class Configuration> ConfigurationPtr;
 
     /** Iterator class for configuration to be used in Python
     class ConfigurationIterator {

--- a/src/analysis/ConfigurationExt.hpp
+++ b/src/analysis/ConfigurationExt.hpp
@@ -33,7 +33,7 @@
 namespace espressopp {
   namespace analysis {
 
-    typedef shared_ptr<class ConfigurationExt> ConfigurationExtPtr;
+    typedef std::shared_ptr<class ConfigurationExt> ConfigurationExtPtr;
 
     /** Iterator class for configuration to be used in Python */
 

--- a/src/analysis/Configurations.cpp
+++ b/src/analysis/Configurations.cpp
@@ -91,7 +91,7 @@ namespace espressopp {
         return configurations[nconfigs - 1 - stackpos];
       } else {
         LOG4ESPP_ERROR(logger, "Configurations::get <out-of-range>");
-        return shared_ptr<Configuration>();
+        return std::shared_ptr<Configuration>();
       }
     }
 
@@ -173,7 +173,7 @@ namespace espressopp {
 
       if (system.comm->rank() == 0) {
 
-         ConfigurationPtr config = make_shared<Configuration> (gatherPos, gatherVel, gatherForce, gatherRadius); //totalN
+         ConfigurationPtr config = std::make_shared<Configuration> (gatherPos, gatherVel, gatherForce, gatherRadius); //totalN
 
          // root process collects data from all processors and sets it
 
@@ -308,8 +308,8 @@ namespace espressopp {
       ;
 
       class_<Configurations>
-        ("analysis_Configurations", init< shared_ptr< System > >())
-      .def(init<shared_ptr< System >,bool,bool,bool,bool,bool>())
+        ("analysis_Configurations", init< std::shared_ptr< System > >())
+      .def(init<std::shared_ptr< System >,bool,bool,bool,bool,bool>())
       .add_property("size", &Configurations::getSize)
       .add_property("capacity", &Configurations::getCapacity, 
                                 &Configurations::setCapacity)

--- a/src/analysis/Configurations.hpp
+++ b/src/analysis/Configurations.hpp
@@ -44,7 +44,7 @@ namespace espressopp {
     public:
 
       /** Constructor, allow for unlimited snapshots. */
-      Configurations(shared_ptr<System> system) : SystemAccess (system) {
+      Configurations(std::shared_ptr<System> system) : SystemAccess (system) {
         gatherPos = true;
         gatherVel = false;
         gatherForce = false;
@@ -52,7 +52,7 @@ namespace espressopp {
         folded = true;
         maxConfigs = 0;
       }
-      Configurations(shared_ptr<System> system, bool _pos, bool _vel, bool _force, bool _radius, bool _folded)
+      Configurations(std::shared_ptr<System> system, bool _pos, bool _vel, bool _force, bool _radius, bool _folded)
                     : SystemAccess (system), gatherPos(_pos), gatherVel(_vel), gatherForce(_force), gatherRadius(_radius), folded(_folded)
       { maxConfigs = 0; }
 

--- a/src/analysis/ConfigurationsExt.cpp
+++ b/src/analysis/ConfigurationsExt.cpp
@@ -94,7 +94,7 @@ namespace espressopp {
         return configurationsExt[nconfigs - 1 - stackpos];
       } else {
         LOG4ESPP_ERROR(logger, "ConfigurationsExt::get <out-of-range>");
-        return shared_ptr<ConfigurationExt>();
+        return std::shared_ptr<ConfigurationExt>();
       }
     }
 
@@ -194,7 +194,7 @@ namespace espressopp {
 
       if (system.comm->rank() == 0) {
 
-         ConfigurationExtPtr config = make_shared<ConfigurationExt> (); //totalN
+         ConfigurationExtPtr config = std::make_shared<ConfigurationExt> (); //totalN
 
          // root process collects data from all processors and sets it
 
@@ -320,7 +320,7 @@ namespace espressopp {
       ;
 
       class_<ConfigurationsExt>
-        ("analysis_ConfigurationsExt", init< shared_ptr< System > >())
+        ("analysis_ConfigurationsExt", init< std::shared_ptr< System > >())
       .add_property("size", &ConfigurationsExt::getSize)
       .add_property("capacity", &ConfigurationsExt::getCapacity,
                                 &ConfigurationsExt::setCapacity)

--- a/src/analysis/ConfigurationsExt.hpp
+++ b/src/analysis/ConfigurationsExt.hpp
@@ -47,7 +47,7 @@ namespace espressopp {
 
       /** Constructor, allow for unlimited snapshots. */
 
-      ConfigurationsExt(shared_ptr<System> system) : SystemAccess (system)
+      ConfigurationsExt(std::shared_ptr<System> system) : SystemAccess (system)
       { maxConfigs = 0; }
 
       /** set number of maximal snapshots. */

--- a/src/analysis/ConfigurationsExtAdress.cpp
+++ b/src/analysis/ConfigurationsExtAdress.cpp
@@ -92,7 +92,7 @@ namespace espressopp {
         return configurationsExtAdress[nconfigs - 1 - stackpos];
       } else {
         LOG4ESPP_ERROR(logger, "ConfigurationsExtAdress::get <out-of-range>");
-        return shared_ptr<ConfigurationExt>();
+        return std::shared_ptr<ConfigurationExt>();
       }
     }
 
@@ -214,7 +214,7 @@ namespace espressopp {
 
       if (system.comm->rank() == 0) {
 
-         ConfigurationExtPtr config = make_shared<ConfigurationExt> (); //totalN
+         ConfigurationExtPtr config = std::make_shared<ConfigurationExt> (); //totalN
 
          // root process collects data from all processors and sets it
 
@@ -337,7 +337,7 @@ namespace espressopp {
 //      ;
 
       class_<ConfigurationsExtAdress>
-        ("analysis_ConfigurationsExtAdress", init< shared_ptr< System >, shared_ptr<FixedTupleListAdress> >())
+        ("analysis_ConfigurationsExtAdress", init< std::shared_ptr< System >, std::shared_ptr<FixedTupleListAdress> >())
       .add_property("size", &ConfigurationsExtAdress::getSize)
       .add_property("capacity", &ConfigurationsExtAdress::getCapacity, 
                                 &ConfigurationsExtAdress::setCapacity)

--- a/src/analysis/ConfigurationsExtAdress.hpp
+++ b/src/analysis/ConfigurationsExtAdress.hpp
@@ -46,7 +46,7 @@ namespace espressopp {
 
       /** Constructor, allow for unlimited snapshots. */
 
-      ConfigurationsExtAdress(shared_ptr<System> system,shared_ptr<FixedTupleListAdress> _fixedTupleList) : SystemAccess (system),fixedTupleList(_fixedTupleList)
+      ConfigurationsExtAdress(std::shared_ptr<System> system,std::shared_ptr<FixedTupleListAdress> _fixedTupleList) : SystemAccess (system),fixedTupleList(_fixedTupleList)
       { maxConfigs = 0; }
 
       /** set number of maximal snapshots. */
@@ -79,7 +79,7 @@ namespace espressopp {
       void clear() { configurationsExtAdress.clear(); }
 
       void
-      setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+      setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedTupleList = _fixedtupleList;
       }
 
@@ -88,7 +88,7 @@ namespace espressopp {
     protected:
 
       static LOG4ESPP_DECL_LOGGER(logger);
-      shared_ptr<FixedTupleListAdress> fixedTupleList;
+      std::shared_ptr<FixedTupleListAdress> fixedTupleList;
 
     private:
 

--- a/src/analysis/IntraChainDistSq.cpp
+++ b/src/analysis/IntraChainDistSq.cpp
@@ -60,7 +60,7 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<IntraChainDistSq, bases< AllParticlePos > >
-        ("analysis_IntraChainDistSq", init< shared_ptr< System >, shared_ptr< FixedPairList > >())
+        ("analysis_IntraChainDistSq", init< std::shared_ptr< System >, std::shared_ptr< FixedPairList > >())
         .def("compute", &IntraChainDistSq::compute)
         ;
 

--- a/src/analysis/IntraChainDistSq.hpp
+++ b/src/analysis/IntraChainDistSq.hpp
@@ -38,8 +38,8 @@ namespace espressopp {
 
     class IntraChainDistSq : public AllParticlePos {
     public:
-      shared_ptr<FixedPairList> fpl;
-      IntraChainDistSq(shared_ptr<System> system, shared_ptr<FixedPairList> _fpl) : AllParticlePos(system), fpl(_fpl) {};
+      std::shared_ptr<FixedPairList> fpl;
+      IntraChainDistSq(std::shared_ptr<System> system, std::shared_ptr<FixedPairList> _fpl) : AllParticlePos(system), fpl(_fpl) {};
       ~IntraChainDistSq() {};
       python::list compute();
       static void registerPython();

--- a/src/analysis/KineticEnergy.cpp
+++ b/src/analysis/KineticEnergy.cpp
@@ -38,8 +38,8 @@ void KineticEnergy::registerPython() {
   using namespace espressopp::python;  //NOLINT
   class_<KineticEnergy, bases<Observable> >
     ("analysis_KineticEnergy",
-        init< shared_ptr<System>, shared_ptr<Temperature> >())
-    .def(init<shared_ptr<System> >())
+        init< std::shared_ptr<System>, std::shared_ptr<Temperature> >())
+    .def(init<std::shared_ptr<System> >())
     .add_property("value", &KineticEnergy::compute_real);
 }
 }  // end namespace analysis

--- a/src/analysis/KineticEnergy.hpp
+++ b/src/analysis/KineticEnergy.hpp
@@ -31,24 +31,24 @@ namespace analysis {
 
 class KineticEnergy : public Observable {
  public:
-  KineticEnergy(shared_ptr<System> system, shared_ptr<Temperature> temperature):
+  KineticEnergy(std::shared_ptr<System> system, std::shared_ptr<Temperature> temperature):
       Observable(system), temperature_(temperature) {
     result_type = real_scalar;
     observable_type = KINETIC_ENERGY;
     precomputed_ = true;
   }
-  KineticEnergy(shared_ptr<System> system): Observable(system) {
+  KineticEnergy(std::shared_ptr<System> system): Observable(system) {
     result_type = real_scalar;
     observable_type = KINETIC_ENERGY;
     precomputed_ = false;
-    temperature_ = make_shared<Temperature>(system);
+    temperature_ = std::make_shared<Temperature>(system);
   }
   ~KineticEnergy() {}
   real compute_real() const;
 
   static void registerPython();
  private:
-  shared_ptr<Temperature> temperature_;
+  std::shared_ptr<Temperature> temperature_;
   bool precomputed_;
 };
 }  // end namespace analysis

--- a/src/analysis/LBOutput.hpp
+++ b/src/analysis/LBOutput.hpp
@@ -33,8 +33,8 @@ namespace espressopp {
       class LBOutput : public AnalysisBaseTemplate< real > {
       public:
          /* Constructor for the class */
-         LBOutput(shared_ptr< System > _system,
-                  shared_ptr< integrator::LatticeBoltzmann > _latticeboltzmann)
+         LBOutput(std::shared_ptr< System > _system,
+                  std::shared_ptr< integrator::LatticeBoltzmann > _latticeboltzmann)
          : AnalysisBaseTemplate< real >(_system) {
             latticeboltzmann = _latticeboltzmann;
          }
@@ -68,7 +68,7 @@ namespace espressopp {
 
          static void registerPython();
       protected:
-         shared_ptr<integrator::LatticeBoltzmann> latticeboltzmann;
+         std::shared_ptr<integrator::LatticeBoltzmann> latticeboltzmann;
       };
    }
 }

--- a/src/analysis/LBOutputScreen.cpp
+++ b/src/analysis/LBOutputScreen.cpp
@@ -26,8 +26,8 @@
 namespace espressopp {
    namespace analysis {
       //  LOG4ESPP_LOGGER(LBOutputScreen::theLogger, "LBOutputScreen");
-      LBOutputScreen::LBOutputScreen(shared_ptr<System> system,
-                                     shared_ptr< integrator::LatticeBoltzmann >latticeboltzmann)
+      LBOutputScreen::LBOutputScreen(std::shared_ptr<System> system,
+                                     std::shared_ptr< integrator::LatticeBoltzmann >latticeboltzmann)
       : LBOutput(system, latticeboltzmann) {}
 
       void LBOutputScreen::writeOutput() {
@@ -175,8 +175,8 @@ namespace espressopp {
          using namespace espressopp::python;
 
          class_<LBOutputScreen, bases< LBOutput > >
-         ("analysis_LBOutput_Screen", init< shared_ptr< System >,
-          shared_ptr< integrator::LatticeBoltzmann > >())
+         ("analysis_LBOutput_Screen", init< std::shared_ptr< System >,
+          std::shared_ptr< integrator::LatticeBoltzmann > >())
 
          .def("writeOutput", &LBOutputScreen::writeOutput)
          .def("getLBMom", &LBOutputScreen::getLBMom)

--- a/src/analysis/LBOutputScreen.hpp
+++ b/src/analysis/LBOutputScreen.hpp
@@ -30,8 +30,8 @@ namespace espressopp {
    namespace analysis {
       class LBOutputScreen : public LBOutput {
       public:
-         LBOutputScreen(shared_ptr<System> _system,
-                        shared_ptr< integrator::LatticeBoltzmann > _latticeboltzmann);
+         LBOutputScreen(std::shared_ptr<System> _system,
+                        std::shared_ptr< integrator::LatticeBoltzmann > _latticeboltzmann);
 
          void writeOutput();
          void findLBMom(int _mode);

--- a/src/analysis/LBOutputScreen.py
+++ b/src/analysis/LBOutputScreen.py
@@ -27,7 +27,7 @@ fluxes should be :math:`0`, i.e. :math:`j_{LB} + j_{MD} = 0`.
 
 .. py:class:: espressopp.analysis.LBOutputScreen(system,lb)
 
-        :param shared_ptr system: system object defined earlier in the python-script
+        :param std::shared_ptr system: system object defined earlier in the python-script
         :param lb_object lb: lattice boltzmann object defined earlier in the python-script
 
 Example:

--- a/src/analysis/LBOutputVzInTime.cpp
+++ b/src/analysis/LBOutputVzInTime.cpp
@@ -25,8 +25,8 @@
 namespace espressopp {
    namespace analysis {
       //    LOG4ESPP_LOGGER(LBOutputVzInTime::theLogger, "LBOutputVzInTime");
-      LBOutputVzInTime::LBOutputVzInTime(shared_ptr<System> system,
-                                         shared_ptr< integrator::LatticeBoltzmann > latticeboltzmann)
+      LBOutputVzInTime::LBOutputVzInTime(std::shared_ptr<System> system,
+                                         std::shared_ptr< integrator::LatticeBoltzmann > latticeboltzmann)
       : LBOutput(system, latticeboltzmann) {}
 
       void LBOutputVzInTime::writeOutput()
@@ -66,8 +66,8 @@ namespace espressopp {
          using namespace espressopp::python;
 
          class_<LBOutputVzInTime, bases< LBOutput > >
-         ("analysis_LBOutput_VzInTime", init< shared_ptr< System >,
-          shared_ptr< integrator::LatticeBoltzmann > >())
+         ("analysis_LBOutput_VzInTime", init< std::shared_ptr< System >,
+          std::shared_ptr< integrator::LatticeBoltzmann > >())
 
          .def("writeOutput", &LBOutputVzInTime::writeOutput)
          ;

--- a/src/analysis/LBOutputVzInTime.hpp
+++ b/src/analysis/LBOutputVzInTime.hpp
@@ -29,8 +29,8 @@ namespace espressopp {
    namespace analysis {
       class LBOutputVzInTime : public LBOutput {
       public:
-         LBOutputVzInTime(shared_ptr<System> _system,
-                          shared_ptr< integrator::LatticeBoltzmann > _latticeboltzmann);
+         LBOutputVzInTime(std::shared_ptr<System> _system,
+                          std::shared_ptr< integrator::LatticeBoltzmann > _latticeboltzmann);
 
          void writeOutput();
 

--- a/src/analysis/LBOutputVzInTime.py
+++ b/src/analysis/LBOutputVzInTime.py
@@ -26,7 +26,7 @@ an index :math:`(0.25*N_i, 0, 0)`.
 
 .. py:class:: espressopp.analysis.LBOutputVzInTime(system,lb)
 
-        :param shared_ptr system: system object defined earlier in the python-script
+        :param std::shared_ptr system: system object defined earlier in the python-script
         :param lb_object lb: lattice boltzmann object defined earlier in the python-script
 
 Example:

--- a/src/analysis/LBOutputVzOfX.cpp
+++ b/src/analysis/LBOutputVzOfX.cpp
@@ -24,8 +24,8 @@
 
 namespace espressopp {
    namespace analysis {
-      LBOutputVzOfX::LBOutputVzOfX(shared_ptr<System> system,
-                                   shared_ptr< integrator::LatticeBoltzmann > latticeboltzmann)
+      LBOutputVzOfX::LBOutputVzOfX(std::shared_ptr<System> system,
+                                   std::shared_ptr< integrator::LatticeBoltzmann > latticeboltzmann)
       : LBOutput(system, latticeboltzmann) {}
 
       void LBOutputVzOfX::writeOutput()
@@ -62,8 +62,8 @@ namespace espressopp {
          using namespace espressopp::python;
 
          class_<LBOutputVzOfX, bases< LBOutput > >
-         ("analysis_LBOutput_VzOfX", init< shared_ptr< System >,
-          shared_ptr< integrator::LatticeBoltzmann > >())
+         ("analysis_LBOutput_VzOfX", init< std::shared_ptr< System >,
+          std::shared_ptr< integrator::LatticeBoltzmann > >())
 
          .def("writeOutput", &LBOutputVzOfX::writeOutput)
          ;

--- a/src/analysis/LBOutputVzOfX.hpp
+++ b/src/analysis/LBOutputVzOfX.hpp
@@ -29,8 +29,8 @@ namespace espressopp {
   namespace analysis {
     class LBOutputVzOfX : public LBOutput {
       public:
-        LBOutputVzOfX(shared_ptr<System> _system,
-                          shared_ptr< integrator::LatticeBoltzmann > _latticeboltzmann);
+        LBOutputVzOfX(std::shared_ptr<System> _system,
+                          std::shared_ptr< integrator::LatticeBoltzmann > _latticeboltzmann);
 
         void writeOutput();
 

--- a/src/analysis/LBOutputVzOfX.py
+++ b/src/analysis/LBOutputVzOfX.py
@@ -26,7 +26,7 @@ conservation when using MD to LB coupling.
 
 .. py:class:: espressopp.analysis.LBOutputVzOfX(system,lb)
 
-    :param shared_ptr system: system object defined earlier in the python-script
+    :param std::shared_ptr system: system object defined earlier in the python-script
     :param lb_object lb: lattice boltzmann object defined earlier in the python-script
 
 Example:

--- a/src/analysis/MaxPID.cpp
+++ b/src/analysis/MaxPID.cpp
@@ -54,7 +54,7 @@ namespace espressopp {
     void MaxPID::registerPython() {
       using namespace espressopp::python;
       class_<MaxPID, bases< Observable > >
-        ("analysis_MaxPID", init< shared_ptr< System > >())
+        ("analysis_MaxPID", init< std::shared_ptr< System > >())
       ;
     }
   }

--- a/src/analysis/MaxPID.hpp
+++ b/src/analysis/MaxPID.hpp
@@ -32,7 +32,7 @@ namespace espressopp {
     /** Class to get the number of particles in the system. */
     class MaxPID : public Observable {
     public:
-      MaxPID(shared_ptr< System > system) : Observable(system) {}
+      MaxPID(std::shared_ptr< System > system) : Observable(system) {}
       virtual ~MaxPID() {}
       virtual real compute() const;
 

--- a/src/analysis/MeanSquareDispl.cpp
+++ b/src/analysis/MeanSquareDispl.cpp
@@ -437,8 +437,8 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<MeanSquareDispl, bases<ConfigsParticleDecomp> >
-      ("analysis_MeanSquareDispl", init< shared_ptr< System > >() )
-      .def(init< shared_ptr< System >, int, int >() )
+      ("analysis_MeanSquareDispl", init< std::shared_ptr< System > >() )
+      .def(init< std::shared_ptr< System >, int, int >() )
       .def("computeG2", &MeanSquareDispl::computeG2)
       .def("computeG3", &MeanSquareDispl::computeG3)
       .add_property("print_progress", &MeanSquareDispl::getPrint_progress, &MeanSquareDispl::setPrint_progress)

--- a/src/analysis/MeanSquareDispl.hpp
+++ b/src/analysis/MeanSquareDispl.hpp
@@ -40,13 +40,13 @@ namespace espressopp {
         class MeanSquareDispl : public ConfigsParticleDecomp {
         public:
 
-            MeanSquareDispl(shared_ptr<System> system) : ConfigsParticleDecomp(system) {
+            MeanSquareDispl(std::shared_ptr<System> system) : ConfigsParticleDecomp(system) {
                 // by default 
                 setPrint_progress(true);
                 key = "unfolded";
             }
 
-            MeanSquareDispl(shared_ptr<System> system, int chainlength, int start_pid) :
+            MeanSquareDispl(std::shared_ptr<System> system, int chainlength, int start_pid) :
                                 ConfigsParticleDecomp(system, chainlength, start_pid) {
                 // by default 
                 setPrint_progress(true);

--- a/src/analysis/MeanSquareInternalDist.cpp
+++ b/src/analysis/MeanSquareInternalDist.cpp
@@ -106,7 +106,7 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<MeanSquareInternalDist, bases<ConfigsParticleDecomp> >
-      ("analysis_MeanSquareInternalDist", init< shared_ptr< System >, int, int >())
+      ("analysis_MeanSquareInternalDist", init< std::shared_ptr< System >, int, int >())
       .add_property("print_progress", &MeanSquareInternalDist::getPrint_progress, &MeanSquareInternalDist::setPrint_progress)
       ;
     }

--- a/src/analysis/MeanSquareInternalDist.hpp
+++ b/src/analysis/MeanSquareInternalDist.hpp
@@ -40,7 +40,7 @@ namespace espressopp {
         class MeanSquareInternalDist : public ConfigsParticleDecomp {
         public:
 
-            MeanSquareInternalDist(shared_ptr<System> system, int chainlength, int start_pid) :
+            MeanSquareInternalDist(std::shared_ptr<System> system, int chainlength, int start_pid) :
                                 ConfigsParticleDecomp(system,chainlength,start_pid) {
                 // by default 
                 setPrint_progress(true);

--- a/src/analysis/NPart.cpp
+++ b/src/analysis/NPart.cpp
@@ -42,7 +42,7 @@ namespace espressopp {
     void NPart::registerPython() {
       using namespace espressopp::python;
       class_<NPart, bases< Observable > >
-        ("analysis_NPart", init< shared_ptr< System > >())
+        ("analysis_NPart", init< std::shared_ptr< System > >())
       ;
     }
   }

--- a/src/analysis/NPart.hpp
+++ b/src/analysis/NPart.hpp
@@ -32,7 +32,7 @@ namespace espressopp {
     /** Class to get the number of particles in the system. */
     class NPart : public Observable {
     public:
-      NPart(shared_ptr< System > system) : Observable(system) {result_type=real_scalar;}
+      NPart(std::shared_ptr< System > system) : Observable(system) {result_type=real_scalar;}
       virtual ~NPart() {}
       virtual real compute_real() const;
 

--- a/src/analysis/NPartSubregion.cpp
+++ b/src/analysis/NPartSubregion.cpp
@@ -73,7 +73,7 @@ namespace espressopp {
       using namespace espressopp::python;
       void (NPartSubregion::*pySetCenter)(real x, real y, real z) = &NPartSubregion::setCenter;
       class_<NPartSubregion, bases< Observable > >
-      ("analysis_NPartSubregion", init< shared_ptr< System >, int, real, int >())
+      ("analysis_NPartSubregion", init< std::shared_ptr< System >, int, real, int >())
       .def("setCenter", pySetCenter)
       ;
     }

--- a/src/analysis/NPartSubregion.hpp
+++ b/src/analysis/NPartSubregion.hpp
@@ -31,7 +31,7 @@ namespace espressopp {
     /** Class to get the number of particles in the system. */
     class NPartSubregion : public Observable {
       public:
-        NPartSubregion(shared_ptr< System > system, int parttype, real span, int geometry) : Observable(system), parttype(parttype), span(span), geometry(geometry) {
+        NPartSubregion(std::shared_ptr< System > system, int parttype, real span, int geometry) : Observable(system), parttype(parttype), span(span), geometry(geometry) {
           result_type=int_scalar;
         }
         virtual ~NPartSubregion() {}

--- a/src/analysis/NPartSubregion.py
+++ b/src/analysis/NPartSubregion.py
@@ -41,7 +41,7 @@ Examples:
                 :param span: radius of the subregion to be considered
                 :param geometry: geometry of the subregion. Can only be in ['spherical', 'bounded-x', 'bounded-y', 'bounded-z']
                 :param center: center of the subregion
-                :type system: shared_ptr<System>
+                :type system: std::shared_ptr<System>
                 :type parttype: int
                 :type span: real
                 :type geometry: str in ['spherical', 'bounded-x', 'bounded-y', 'bounded-z']

--- a/src/analysis/NeighborFluctuation.cpp
+++ b/src/analysis/NeighborFluctuation.cpp
@@ -122,7 +122,7 @@ namespace espressopp {
     void NeighborFluctuation::registerPython() {
       using namespace espressopp::python;
       class_<NeighborFluctuation, bases< Observable > >
-        ("analysis_NeighborFluctuation", init< shared_ptr< System > , real >())
+        ("analysis_NeighborFluctuation", init< std::shared_ptr< System > , real >())
         .def("compute", &NeighborFluctuation::computeValues) 
       ;
     }

--- a/src/analysis/NeighborFluctuation.hpp
+++ b/src/analysis/NeighborFluctuation.hpp
@@ -39,7 +39,7 @@ namespace espressopp {
     /** Class to get the number of particles in the system. */
     class NeighborFluctuation : public Observable {
     public:
-      NeighborFluctuation(shared_ptr< System > system, real _radius) : Observable(system), radius(_radius){
+      NeighborFluctuation(std::shared_ptr< System > system, real _radius) : Observable(system), radius(_radius){
         esutil::Error err(system->comm);
         
         Real3D Li = system->bc->getBoxL();

--- a/src/analysis/Observable.hpp
+++ b/src/analysis/Observable.hpp
@@ -42,7 +42,7 @@ namespace espressopp {
         KINETIC_ENERGY,
         OTHER
       };
-      Observable(shared_ptr< System > system) : SystemAccess(system) {
+      Observable(std::shared_ptr< System > system) : SystemAccess(system) {
         result_type=old_format;
         observable_type = OTHER;
       };

--- a/src/analysis/OrderParameter.cpp
+++ b/src/analysis/OrderParameter.cpp
@@ -66,7 +66,7 @@ namespace espressopp {
     void OrderParameter::registerPython() {
       using namespace espressopp::python;
       class_<OrderParameter, bases< AnalysisBase > >
-        ("analysis_OrderParameter", init< shared_ptr<System>, real, int, bool, bool, real, real>())
+        ("analysis_OrderParameter", init< std::shared_ptr<System>, real, int, bool, bool, real, real>())
         .add_property("l", 
               &OrderParameter::getAngularMomentum,
               &OrderParameter::setAngularMomentum)

--- a/src/analysis/OrderParameter.hpp
+++ b/src/analysis/OrderParameter.hpp
@@ -226,7 +226,7 @@ namespace espressopp {
     public:
       static void registerPython();
 
-      OrderParameter(shared_ptr< System > system,
+      OrderParameter(std::shared_ptr< System > system,
                      real _cutoff,
                      int _angular_momentum,
                      bool _do_cl_an,
@@ -281,8 +281,8 @@ namespace espressopp {
         opp_map.clear();
         pairs.clear();
 
-        shared_ptr< storage::Storage > stor = getSystem()->storage;
-        shared_ptr< mpi::communicator > cmm = getSystem()->comm;
+        std::shared_ptr< storage::Storage > stor = getSystem()->storage;
+        std::shared_ptr< mpi::communicator > cmm = getSystem()->comm;
         int this_node = cmm -> rank();
 
         // ------------------------------------------------------------------------------
@@ -490,7 +490,7 @@ namespace espressopp {
         if(incl_surface){
           // -----------------------------------------------------------------------
           // send ghost info
-          shared_ptr< mpi::communicator > cmm = getSystem()->comm;
+          std::shared_ptr< mpi::communicator > cmm = getSystem()->comm;
           vector <OrderParticleProps> sendGhostInfo;
           for(CellListIterator cit(cells); !cit.isDone(); ++cit) {
             Particle& p = *cit;

--- a/src/analysis/ParticleRadiusDistribution.cpp
+++ b/src/analysis/ParticleRadiusDistribution.cpp
@@ -29,7 +29,7 @@ namespace espressopp {
     void ParticleRadiusDistribution::registerPython() {
       using namespace espressopp::python;
       class_<ParticleRadiusDistribution, bases< AnalysisBase > >
-        ("analysis_ParticleRadiusDistribution", init< shared_ptr< System > >())
+        ("analysis_ParticleRadiusDistribution", init< std::shared_ptr< System > >())
       ;
     }
   }

--- a/src/analysis/ParticleRadiusDistribution.hpp
+++ b/src/analysis/ParticleRadiusDistribution.hpp
@@ -41,7 +41,7 @@ namespace espressopp {
     public:
       static void registerPython();
 
-      ParticleRadiusDistribution(shared_ptr< System > system) : AnalysisBaseTemplate< result >(system) {
+      ParticleRadiusDistribution(std::shared_ptr< System > system) : AnalysisBaseTemplate< result >(system) {
     	  // default binwidth for particle radius histogram
     	  binwidth=0.1;
     	  radave=0.0;

--- a/src/analysis/PotentialEnergy.cpp
+++ b/src/analysis/PotentialEnergy.cpp
@@ -41,8 +41,8 @@ void PotentialEnergy::registerPython() {
   using namespace espressopp::python;  //NOLINT
   class_<PotentialEnergy, bases<Observable> >
     ("analysis_PotentialEnergy",
-        init< shared_ptr<System>, shared_ptr<interaction::Interaction> >())
-    .def(init<shared_ptr<System>, shared_ptr<interaction::Interaction>, bool>())
+        init< std::shared_ptr<System>, std::shared_ptr<interaction::Interaction> >())
+    .def(init<std::shared_ptr<System>, std::shared_ptr<interaction::Interaction>, bool>())
     .add_property("value", &PotentialEnergy::compute_real);
 }
 }  // end namespace analysis

--- a/src/analysis/PotentialEnergy.hpp
+++ b/src/analysis/PotentialEnergy.hpp
@@ -31,13 +31,13 @@ namespace analysis {
 
 class PotentialEnergy : public Observable {
  public:
-  PotentialEnergy(shared_ptr<System> system, shared_ptr<interaction::Interaction> interaction,
+  PotentialEnergy(std::shared_ptr<System> system, std::shared_ptr<interaction::Interaction> interaction,
                   bool compute_at):
       Observable(system), interaction_(interaction), compute_at_(compute_at) {
     result_type = real_scalar;
     compute_global_ = false;
   }
-  PotentialEnergy(shared_ptr<System> system, shared_ptr<interaction::Interaction> interaction)
+  PotentialEnergy(std::shared_ptr<System> system, std::shared_ptr<interaction::Interaction> interaction)
       : Observable(system), interaction_(interaction) {
     result_type = real_scalar;
     compute_global_ = true;
@@ -47,7 +47,7 @@ class PotentialEnergy : public Observable {
 
   static void registerPython();
  private:
-  shared_ptr<interaction::Interaction> interaction_;
+  std::shared_ptr<interaction::Interaction> interaction_;
   bool compute_at_;  // set to true then computeEnergyAA, otherwise computeEnergyCG
   bool compute_global_;
 };

--- a/src/analysis/Pressure.cpp
+++ b/src/analysis/Pressure.cpp
@@ -54,7 +54,7 @@ namespace espressopp {
       
       if (system.storage->getFixedTuples()){ // AdResS - hence, need to distinguish between CG and AT particles.     
           
-          shared_ptr<FixedTupleListAdress> fixedtupleList=system.storage->getFixedTuples();
+          std::shared_ptr<FixedTupleListAdress> fixedtupleList=system.storage->getFixedTuples();
           for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {
                 Particle &vp = *cit;
                 FixedTupleListAdress::iterator it2;
@@ -115,7 +115,7 @@ namespace espressopp {
     void Pressure::registerPython() {
       using namespace espressopp::python;
       class_<Pressure, bases< Observable > >
-        ("analysis_Pressure", init< shared_ptr< System > >())
+        ("analysis_Pressure", init< std::shared_ptr< System > >())
       ;
     }
   }

--- a/src/analysis/Pressure.hpp
+++ b/src/analysis/Pressure.hpp
@@ -32,7 +32,7 @@ namespace espressopp {
     /** Class to compute the pressure. */
     class Pressure : public Observable {
     public:
-      Pressure(shared_ptr< System > system) : Observable(system) {}
+      Pressure(std::shared_ptr< System > system) : Observable(system) {}
       ~Pressure() {}
       virtual real compute() const;
 

--- a/src/analysis/PressureTensor.cpp
+++ b/src/analysis/PressureTensor.cpp
@@ -29,7 +29,7 @@ namespace espressopp {
     void PressureTensor::registerPython() {
       using namespace espressopp::python;
       class_<PressureTensor, bases< AnalysisBase > >
-        ("analysis_PressureTensor", init< shared_ptr< System > >())
+        ("analysis_PressureTensor", init< std::shared_ptr< System > >())
       ;
     }
   }

--- a/src/analysis/PressureTensor.hpp
+++ b/src/analysis/PressureTensor.hpp
@@ -43,7 +43,7 @@ namespace espressopp {
     public:
       static void registerPython();
 
-      PressureTensor(shared_ptr< System > system) : AnalysisBaseTemplate< Tensor >(system) {}
+      PressureTensor(std::shared_ptr< System > system) : AnalysisBaseTemplate< Tensor >(system) {}
       virtual ~PressureTensor() {}
 
       Tensor computeRaw() {

--- a/src/analysis/PressureTensorLayer.cpp
+++ b/src/analysis/PressureTensorLayer.cpp
@@ -29,7 +29,7 @@ namespace espressopp {
     void PressureTensorLayer::registerPython() {
       using namespace espressopp::python;
       class_<PressureTensorLayer, bases< AnalysisBase > >
-        ("analysis_PressureTensorLayer", init< shared_ptr< System >, real, real >())
+        ("analysis_PressureTensorLayer", init< std::shared_ptr< System >, real, real >())
         .add_property("h0",
               &PressureTensorLayer::getH0,
               &PressureTensorLayer::setH0)

--- a/src/analysis/PressureTensorLayer.hpp
+++ b/src/analysis/PressureTensorLayer.hpp
@@ -48,7 +48,7 @@ namespace espressopp {
     public:
       static void registerPython();
 
-      PressureTensorLayer(shared_ptr< System > system, real _z0, real _dz) : AnalysisBaseTemplate< Tensor >(system), z0(_z0), dz(_dz){}
+      PressureTensorLayer(std::shared_ptr< System > system, real _z0, real _dz) : AnalysisBaseTemplate< Tensor >(system), z0(_z0), dz(_dz){}
       virtual ~PressureTensorLayer() {}
       /*
        * calculate a pressure for z0 layer

--- a/src/analysis/PressureTensorMultiLayer.cpp
+++ b/src/analysis/PressureTensorMultiLayer.cpp
@@ -29,7 +29,7 @@ namespace espressopp {
     void PressureTensorMultiLayer::registerPython() {
       using namespace espressopp::python;
       class_<PressureTensorMultiLayer, bases< AnalysisBase > >
-        ("analysis_PressureTensorMultiLayer", init< shared_ptr< System >, int, real >())
+        ("analysis_PressureTensorMultiLayer", init< std::shared_ptr< System >, int, real >())
         .add_property("n",
               &PressureTensorMultiLayer::getN,
               &PressureTensorMultiLayer::setN)

--- a/src/analysis/PressureTensorMultiLayer.hpp
+++ b/src/analysis/PressureTensorMultiLayer.hpp
@@ -49,7 +49,7 @@ namespace espressopp {
     public:
       static void registerPython();
 
-      PressureTensorMultiLayer(shared_ptr< System > system, int _n, real _dz) : AnalysisBaseTemplate< vector<Tensor> >(system), n(_n), dz(_dz){}
+      PressureTensorMultiLayer(std::shared_ptr< System > system, int _n, real _dz) : AnalysisBaseTemplate< vector<Tensor> >(system), n(_n), dz(_dz){}
       virtual ~PressureTensorMultiLayer() {}
       /*
        * calculate the pressure in 'n' layers along Z axis

--- a/src/analysis/RDFatomistic.cpp
+++ b/src/analysis/RDFatomistic.cpp
@@ -64,7 +64,7 @@ namespace espressopp {
       for (int rank_i=0; rank_i<nprocs; rank_i++) {
         map< size_t, data > conf;
         if (rank_i == myrank) {
-          shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+          std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
           CellList realCells = system.storage->getRealCells();
           for(CellListIterator cit(realCells); !cit.isDone(); ++cit) {
 
@@ -221,7 +221,7 @@ namespace espressopp {
       for (int rank_i=0; rank_i<nprocs; rank_i++) {
         map< size_t, dataPathIntegral > conf;
         if (rank_i == myrank) {
-          shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+          std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
           CellList realCells = system.storage->getRealCells();
           for(CellListIterator cit(realCells); !cit.isDone(); ++cit) {
 
@@ -359,7 +359,7 @@ namespace espressopp {
     void RDFatomistic::registerPython() {
       using namespace espressopp::python;
       class_<RDFatomistic, bases< Observable > >
-      ("analysis_RDFatomistic", init< shared_ptr< System >, int, int, real, bool >())
+      ("analysis_RDFatomistic", init< std::shared_ptr< System >, int, int, real, bool >())
       .def("compute", &RDFatomistic::computeArray)
       .def("computePathIntegral", &RDFatomistic::computeArrayPathIntegral)
       ;

--- a/src/analysis/RDFatomistic.hpp
+++ b/src/analysis/RDFatomistic.hpp
@@ -34,7 +34,7 @@ namespace espressopp {
     /** Class to compute the radial distribution function of the system. */
     class RDFatomistic : public Observable {
       public:
-        RDFatomistic(shared_ptr< System > system, int type1, int type2, real _span = 1.0, bool _spanbased = true) : Observable(system), target1(type1), target2(type2), span(_span), spanbased(_spanbased) {}
+        RDFatomistic(std::shared_ptr< System > system, int type1, int type2, real _span = 1.0, bool _spanbased = true) : Observable(system), target1(type1), target2(type2), span(_span), spanbased(_spanbased) {}
         ~RDFatomistic() {}
         virtual real compute() const;
         virtual python::list computeArray(int) const;

--- a/src/analysis/RDFatomistic.py
+++ b/src/analysis/RDFatomistic.py
@@ -73,7 +73,7 @@ Examples:
                 :param type2: type of atom 2
                 :param spanbased: (default: True) If True, calculates RDFs in a cuboid region of radius span from the center (limited in x, periodic in y,z). If False, calculates RDFs with both particles being in the high resolution region (using lambda resolution values and ignoring span parameter).
                 :param span: (default: 1.0) +/- distance from centre of box in x-direction of the cuboid region used for RDF calculation if spanbased == True. If spanbased == False, this parameter is not used.
-                :type system: shared_ptr<System>
+                :type system: std::shared_ptr<System>
                 :type type1: int
                 :type type2: int
                 :type spanbased: bool

--- a/src/analysis/RadGyrXProfilePI.cpp
+++ b/src/analysis/RadGyrXProfilePI.cpp
@@ -55,7 +55,7 @@ namespace espressopp {
       real pos = 0.0;
       int bin = 0;
       if(system.storage->getFixedTuples()) {
-        shared_ptr<FixedTupleListAdress> fixedtupleList=system.storage->getFixedTuples();
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList=system.storage->getFixedTuples();
         CellList realCells = system.storage->getRealCells();
 
         for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {
@@ -150,7 +150,7 @@ namespace espressopp {
     void RadGyrXProfilePI::registerPython() {
       using namespace espressopp::python;
       class_<RadGyrXProfilePI, bases< Observable > >
-      ("analysis_RadGyrXProfilePI", init< shared_ptr< System > >())
+      ("analysis_RadGyrXProfilePI", init< std::shared_ptr< System > >())
       .def("compute", &RadGyrXProfilePI::computeArray)
       ;
     }

--- a/src/analysis/RadGyrXProfilePI.hpp
+++ b/src/analysis/RadGyrXProfilePI.hpp
@@ -32,7 +32,7 @@ namespace espressopp {
     // Class to compute the radius of gyration profile in adaptive path integral-based simulations along slabs in the x-direction of the system.
     class RadGyrXProfilePI : public Observable {
       public:
-        RadGyrXProfilePI(shared_ptr< System > system) : Observable(system) {}
+        RadGyrXProfilePI(std::shared_ptr< System > system) : Observable(system) {}
         ~RadGyrXProfilePI() {}
         virtual real compute() const;
         virtual python::list computeArray(int, int, int) const;

--- a/src/analysis/RadGyrXProfilePI.py
+++ b/src/analysis/RadGyrXProfilePI.py
@@ -37,7 +37,7 @@ Examples:
                 Constructs the RadGyrXProfilePI object.
 
                 :param system: system object
-                :type system: shared_ptr<System>
+                :type system: std::shared_ptr<System>
 
 .. function:: espressopp.analysis.RadGyrXProfilePI.compute(bins, ntrotter, ptype):
 

--- a/src/analysis/RadialDistrF.cpp
+++ b/src/analysis/RadialDistrF.cpp
@@ -60,7 +60,7 @@ namespace espressopp {
                                          // should use for Li_half[XXX] the shortest side length   
       
       int num_part = 0;
-      ConfigurationPtr config = make_shared<Configuration> ();
+      ConfigurationPtr config = std::make_shared<Configuration> ();
       for (int rank_i=0; rank_i<nprocs; rank_i++) {
         map< size_t, Real3D > conf;
         if (rank_i == myrank) {
@@ -155,7 +155,7 @@ namespace espressopp {
     void RadialDistrF::registerPython() {
       using namespace espressopp::python;
       class_<RadialDistrF, bases< Observable > >
-        ("analysis_RadialDistrF", init< shared_ptr< System > >())
+        ("analysis_RadialDistrF", init< std::shared_ptr< System > >())
         .add_property("print_progress", &RadialDistrF::getPrint_progress, &RadialDistrF::setPrint_progress)
         .def("compute", &RadialDistrF::computeArray)
       ;

--- a/src/analysis/RadialDistrF.hpp
+++ b/src/analysis/RadialDistrF.hpp
@@ -34,7 +34,7 @@ namespace espressopp {
     /** Class to compute the radial distribution function of the system. */
     class RadialDistrF : public Observable {
     public:
-      RadialDistrF(shared_ptr< System > system) : Observable(system) {
+      RadialDistrF(std::shared_ptr< System > system) : Observable(system) {
         // by default 
         setPrint_progress(true);
       }

--- a/src/analysis/StaticStructF.cpp
+++ b/src/analysis/StaticStructF.cpp
@@ -76,7 +76,7 @@ namespace espressopp {
             }
 
             int num_part = 0;
-            ConfigurationPtr config = make_shared<Configuration > ();
+            ConfigurationPtr config = std::make_shared<Configuration > ();
             // loop over all CPU-numbers - to give all CPUs all particle coords
             for (int rank_i = 0; rank_i < nprocs; rank_i++) {
                 map< size_t, Real3D > conf;
@@ -225,7 +225,7 @@ namespace espressopp {
             int myrank = system.comm->rank(); // current CPU's number
 
             int num_part = 0;
-            ConfigurationPtr config = make_shared<Configuration > ();
+            ConfigurationPtr config = std::make_shared<Configuration > ();
             // loop over all CPU-numbers - to give all CPUs all particle coords
             for (int rank_i = 0; rank_i < nprocs; rank_i++) {
                 map< size_t, Real3D > conf;
@@ -388,7 +388,7 @@ namespace espressopp {
         void StaticStructF::registerPython() {
             using namespace espressopp::python;
             class_<StaticStructF, bases< Observable > >
-                    ("analysis_StaticStructF", init< shared_ptr< System > >())
+                    ("analysis_StaticStructF", init< std::shared_ptr< System > >())
                     .def("compute", &StaticStructF::computeArray)
                     .def("computeSingleChain", &StaticStructF::computeArraySingleChain)
                     ;

--- a/src/analysis/StaticStructF.hpp
+++ b/src/analysis/StaticStructF.hpp
@@ -35,7 +35,7 @@ namespace espressopp {
         class StaticStructF : public Observable {
         public:
 
-            StaticStructF(shared_ptr< System > system) : Observable(system) {
+            StaticStructF(std::shared_ptr< System > system) : Observable(system) {
             }
 
             ~StaticStructF() {

--- a/src/analysis/SubregionTracking.cpp
+++ b/src/analysis/SubregionTracking.cpp
@@ -75,7 +75,7 @@ namespace espressopp {
       using namespace espressopp::python;
       void (SubregionTracking::*pySetCenter)(real x, real y, real z) = &SubregionTracking::setCenter;
       class_<SubregionTracking, bases< Observable > >
-      ("analysis_SubregionTracking", init< shared_ptr< System >, real, int >())
+      ("analysis_SubregionTracking", init< std::shared_ptr< System >, real, int >())
       .def("setCenter", pySetCenter)
       .def("addPID", &SubregionTracking::addPID)
       ;

--- a/src/analysis/SubregionTracking.hpp
+++ b/src/analysis/SubregionTracking.hpp
@@ -31,7 +31,7 @@ namespace espressopp {
   namespace analysis {
     class SubregionTracking : public Observable {
       public:
-        SubregionTracking(shared_ptr< System > system, real span, int geometry) : Observable(system), span(span), geometry(geometry) {
+        SubregionTracking(std::shared_ptr< System > system, real span, int geometry) : Observable(system), span(span), geometry(geometry) {
           result_type=int_scalar;
         }
         virtual ~SubregionTracking() {}

--- a/src/analysis/SubregionTracking.py
+++ b/src/analysis/SubregionTracking.py
@@ -41,7 +41,7 @@ Examples:
                 :param geometry: geometry of the subregion. Can only be in ['spherical', 'bounded-x', 'bounded-y', 'bounded-z']
                 :param center: center of the subregion
                 :param pidlist: list of particle ids of coarse-grained particles that are counted in the specified subregion
-                :type system: shared_ptr<System>
+                :type system: std::shared_ptr<System>
                 :type span: real
                 :type geometry: str in ['spherical', 'bounded-x', 'bounded-y', 'bounded-z']
                 :type center: list of 3 reals (x,y,z coordinates of center)

--- a/src/analysis/SystemMonitor.cpp
+++ b/src/analysis/SystemMonitor.cpp
@@ -75,7 +75,7 @@ void SystemMonitor::info() {
   }
 }
 
-void SystemMonitor::addObservable(std::string name, shared_ptr<Observable> obs,
+void SystemMonitor::addObservable(std::string name, std::shared_ptr<Observable> obs,
     bool is_visible) {
   observables_.push_back(std::make_pair(name, obs));
   header_->push_back(name);
@@ -89,9 +89,9 @@ void SystemMonitor::registerPython() {
   using namespace espressopp::python;  // NOLINT
   class_<SystemMonitor, bases< ParticleAccess > >
       ("analysis_SystemMonitor", init<
-          shared_ptr<System>,
-          shared_ptr<integrator::MDIntegrator>,
-          shared_ptr<SystemMonitorOutputCSV>
+          std::shared_ptr<System>,
+          std::shared_ptr<integrator::MDIntegrator>,
+          std::shared_ptr<SystemMonitorOutputCSV>
           >())
       .def("add_observable", &SystemMonitor::addObservable)
       .def("info", &SystemMonitor::info)

--- a/src/analysis/SystemMonitor.hpp
+++ b/src/analysis/SystemMonitor.hpp
@@ -49,17 +49,17 @@ class SystemMonitorOutputCSV {
   }
   void write();
 
-  void setSystem(shared_ptr<System> system) {
+  void setSystem(std::shared_ptr<System> system) {
     system_ = system;
   }
 
   static void registerPython();
 
  private:
-  shared_ptr<std::vector<std::string> > keys_;
-  shared_ptr<std::vector<real> > values_;
+  std::shared_ptr<std::vector<std::string> > keys_;
+  std::shared_ptr<std::vector<real> > values_;
   std::string file_name_;
-  shared_ptr<System> system_;
+  std::shared_ptr<System> system_;
   std::string delimiter_;
   bool header_written_;
 };
@@ -67,16 +67,16 @@ class SystemMonitorOutputCSV {
 
 class SystemMonitor : public ParticleAccess {
  public:
-  typedef std::vector<std::pair<std::string, shared_ptr<Observable> > > ObservableList;
-  SystemMonitor(shared_ptr< System > system,
-                shared_ptr<integrator::MDIntegrator> integrator,
-                shared_ptr<SystemMonitorOutputCSV> output):
+  typedef std::vector<std::pair<std::string, std::shared_ptr<Observable> > > ObservableList;
+  SystemMonitor(std::shared_ptr< System > system,
+                std::shared_ptr<integrator::MDIntegrator> integrator,
+                std::shared_ptr<SystemMonitorOutputCSV> output):
         ParticleAccess(system),
         system_(system),
         integrator_(integrator),
         output_(output) {
-    header_ = make_shared<std::vector<std::string> >();
-    values_ = make_shared<std::vector<real> >();
+    header_ = std::make_shared<std::vector<std::string> >();
+    values_ = std::make_shared<std::vector<real> >();
 
     output_->system_ = system;
     output_->keys_ = header_;
@@ -101,18 +101,18 @@ class SystemMonitor : public ParticleAccess {
  private:
   void computeObservables();
 
-  void addObservable(std::string name, shared_ptr<Observable> obs, bool is_visible);
+  void addObservable(std::string name, std::shared_ptr<Observable> obs, bool is_visible);
 
   int current_step_;
   bool header_written_;
   bool header_shown_;
-  shared_ptr<std::vector<real> > values_;
-  shared_ptr<std::vector<std::string> > header_;
+  std::shared_ptr<std::vector<real> > values_;
+  std::shared_ptr<std::vector<std::string> > header_;
   std::vector<int> visible_observables_;
-  shared_ptr<System> system_;
-  shared_ptr<integrator::MDIntegrator> integrator_;
+  std::shared_ptr<System> system_;
+  std::shared_ptr<integrator::MDIntegrator> integrator_;
 
-  shared_ptr<SystemMonitorOutputCSV> output_;
+  std::shared_ptr<SystemMonitorOutputCSV> output_;
   ObservableList observables_;
 };
 

--- a/src/analysis/Temperature.cpp
+++ b/src/analysis/Temperature.cpp
@@ -32,7 +32,7 @@ namespace espressopp {
     void Temperature::registerPython() {
       using namespace espressopp::python;
       class_<Temperature, bases< Observable > >
-        ("analysis_Temperature", init< shared_ptr< System > >())
+        ("analysis_Temperature", init< std::shared_ptr< System > >())
         .def("add_type", &Temperature::addType)
         .def("remove_type", &Temperature::removeType)
       ;

--- a/src/analysis/Temperature.hpp
+++ b/src/analysis/Temperature.hpp
@@ -44,7 +44,7 @@ namespace espressopp {
     public:
       static void registerPython();
 
-      Temperature(shared_ptr< System > system): Observable(system), eKin_(0.0) {
+      Temperature(std::shared_ptr< System > system): Observable(system), eKin_(0.0) {
         has_types = false;
         result_type = real_scalar;
       }
@@ -58,7 +58,7 @@ namespace espressopp {
       int count = 0;
 
       if (system.storage->getFixedTuples()){  // AdResS - hence, need to distinguish between CG and AT particles.
-          shared_ptr<FixedTupleListAdress> fixedtupleList=system.storage->getFixedTuples();
+          std::shared_ptr<FixedTupleListAdress> fixedtupleList=system.storage->getFixedTuples();
           CellList realCells = system.storage->getRealCells();
           for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {  // Iterate over all (CG) particles.
             Particle &vp = *cit;

--- a/src/analysis/Temperature.py
+++ b/src/analysis/Temperature.py
@@ -30,7 +30,7 @@ Calculate the temperature of the system (in :math:`k_B T` units).
 
 .. function:: espressopp.analysis.Temperature(system)
 
-    :param shared_ptr system: system object
+    :param std::shared_ptr system: system object
     :returns: temperature
     :rtype: real
 

--- a/src/analysis/Test.cpp
+++ b/src/analysis/Test.cpp
@@ -29,7 +29,7 @@ namespace espressopp {
     void Test::registerPython() {
       using namespace espressopp::python;
       class_< Test, bases< AnalysisBase > >
-        ("analysis_Test", init< shared_ptr< System > >())
+        ("analysis_Test", init< std::shared_ptr< System > >())
       ;
     }
   }

--- a/src/analysis/Test.hpp
+++ b/src/analysis/Test.hpp
@@ -34,7 +34,7 @@ namespace espressopp {
     public:
       static void registerPython();
 
-      Test(shared_ptr< System > system) : AnalysisBaseTemplate< int >(system) {};
+      Test(std::shared_ptr< System > system) : AnalysisBaseTemplate< int >(system) {};
       virtual ~Test() {};
 
       int computeRaw() {

--- a/src/analysis/Velocities.cpp
+++ b/src/analysis/Velocities.cpp
@@ -90,7 +90,7 @@ namespace espressopp {
         return configurations[nconfigs - 1 - stackpos];
       } else {
         LOG4ESPP_ERROR(logger, "Velocities::get <out-of-range>");
-        return shared_ptr<Configuration>();
+        return std::shared_ptr<Configuration>();
       }
     }
 
@@ -162,7 +162,7 @@ namespace espressopp {
 
       if (system.comm->rank() == 0) {
 
-         ConfigurationPtr config = make_shared<Configuration> (); //totalN
+         ConfigurationPtr config = std::make_shared<Configuration> (); //totalN
 
          // root process collects data from all processors and sets it
 
@@ -260,7 +260,7 @@ namespace espressopp {
       //;
 
       class_<Velocities>
-        ("analysis_Velocities", init< shared_ptr< System > >())
+        ("analysis_Velocities", init< std::shared_ptr< System > >())
       .add_property("size", &Velocities::getSize)
       .add_property("capacity", &Velocities::getCapacity, 
                                 &Velocities::setCapacity)

--- a/src/analysis/Velocities.hpp
+++ b/src/analysis/Velocities.hpp
@@ -44,7 +44,7 @@ namespace espressopp {
     public:
 
       /** Constructor, allow for unlimited snapshots. */
-      Velocities(shared_ptr<System> system) : SystemAccess (system)
+      Velocities(std::shared_ptr<System> system) : SystemAccess (system)
       { maxConfigs = 0; }
 
       /** set number of maximal snapshots. */

--- a/src/analysis/VelocityAutocorrelation.cpp
+++ b/src/analysis/VelocityAutocorrelation.cpp
@@ -105,7 +105,7 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<VelocityAutocorrelation, bases<ConfigsParticleDecomp> >
-      ("analysis_VelocityAutocorrelation",init< shared_ptr< System > >() )
+      ("analysis_VelocityAutocorrelation",init< std::shared_ptr< System > >() )
         .add_property("print_progress", &VelocityAutocorrelation::getPrint_progress, &VelocityAutocorrelation::setPrint_progress)
       ;
     }

--- a/src/analysis/VelocityAutocorrelation.hpp
+++ b/src/analysis/VelocityAutocorrelation.hpp
@@ -36,7 +36,7 @@ namespace espressopp {
 
     public:
       
-      VelocityAutocorrelation(shared_ptr<System> system): ConfigsParticleDecomp (system){
+      VelocityAutocorrelation(std::shared_ptr<System> system): ConfigsParticleDecomp (system){
         // by default calculation progress is printed
         setPrint_progress(true);
         

--- a/src/analysis/Viscosity.cpp
+++ b/src/analysis/Viscosity.cpp
@@ -110,7 +110,7 @@ namespace espressopp {
     void Viscosity::registerPython() {
       using namespace espressopp::python;
 
-      class_<Viscosity>( "analysis_Viscosity", init< shared_ptr< System > >() )
+      class_<Viscosity>( "analysis_Viscosity", init< std::shared_ptr< System > >() )
       .def("gather", &Viscosity::gather)
       .def("compute", &Viscosity::compute)
       ;

--- a/src/analysis/Viscosity.hpp
+++ b/src/analysis/Viscosity.hpp
@@ -48,7 +48,7 @@ namespace espressopp {
 
     public:
       // Constructor, allow for unlimited snapshots.
-      Viscosity(shared_ptr<System> system): Autocorrelation (system){
+      Viscosity(std::shared_ptr<System> system): Autocorrelation (system){
       }
       ~Viscosity(){
       }

--- a/src/analysis/XDensity.cpp
+++ b/src/analysis/XDensity.cpp
@@ -53,12 +53,12 @@ namespace espressopp {
       //for(int i=0;i<splitN;i++) histogram.push_back(0.0);
       real dr = Li / (real)splitN;
       int num_part = 0;
-      //ConfigurationPtr config = make_shared<Configuration> ();
+      //ConfigurationPtr config = std::make_shared<Configuration> ();
       /*for (int rank_i=0; rank_i<nprocs; rank_i++) {
         map< size_t, Real3D > conf;
         if (rank_i == myrank) {
             if(system.storage->getFixedTuples()){
-                shared_ptr<FixedTupleListAdress> fixedtupleList=system.storage->getFixedTuples();
+                std::shared_ptr<FixedTupleListAdress> fixedtupleList=system.storage->getFixedTuples();
                 CellList realCells = system.storage->getRealCells();
                                 
                 for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {  // Iterate over all (CG) particles.              
@@ -119,7 +119,7 @@ namespace espressopp {
       real pos = 0.0;
       int bin = 0;
       if(system.storage->getFixedTuples()){
-            shared_ptr<FixedTupleListAdress> fixedtupleList=system.storage->getFixedTuples();
+            std::shared_ptr<FixedTupleListAdress> fixedtupleList=system.storage->getFixedTuples();
             CellList realCells = system.storage->getRealCells();
 
             for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {  // Iterate over all (CG) particles.              
@@ -267,7 +267,7 @@ namespace espressopp {
     void XDensity::registerPython() {
       using namespace espressopp::python;
       class_<XDensity, bases< Observable > >
-        ("analysis_XDensity", init< shared_ptr< System > >())
+        ("analysis_XDensity", init< std::shared_ptr< System > >())
         .def("compute", &XDensity::computeArray)
       ;
     }

--- a/src/analysis/XDensity.hpp
+++ b/src/analysis/XDensity.hpp
@@ -34,7 +34,7 @@ namespace espressopp {
     // Class to compute the density profile along slabs in the x-direction of the system.
     class XDensity : public Observable {
     public:
-      XDensity(shared_ptr< System > system) : Observable(system) {}
+      XDensity(std::shared_ptr< System > system) : Observable(system) {}
       ~XDensity() {}
       virtual real compute() const;
       virtual python::list computeArray(int) const;

--- a/src/analysis/XPressure.cpp
+++ b/src/analysis/XPressure.cpp
@@ -57,7 +57,7 @@ namespace espressopp {
       for(int i=0; i<n; i++) vvlocal[i] = 0.0;
       
       // compute the kinetic contribution (2/3 \sum 1/2mv^2)
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
       CellList realCells = system.storage->getRealCells();
       for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {
           
@@ -196,7 +196,7 @@ namespace espressopp {
     void XPressure::registerPython() {
       using namespace espressopp::python;
       class_<XPressure, bases< Observable > >
-        ("analysis_XPressure", init< shared_ptr< System > >())
+        ("analysis_XPressure", init< std::shared_ptr< System > >())
         .def("compute", &XPressure::computeArray)
       ;
     }

--- a/src/analysis/XPressure.hpp
+++ b/src/analysis/XPressure.hpp
@@ -34,7 +34,7 @@ namespace espressopp {
     // Class to compute the pressure profile along slabs in the x-direction of the system.
     class XPressure : public Observable {
     public:
-      XPressure(shared_ptr< System > system) : Observable(system) {}
+      XPressure(std::shared_ptr< System > system) : Observable(system) {}
       ~XPressure() {}
       virtual real compute() const;
       virtual python::list computeArray(int) const;

--- a/src/analysis/XTemperature.cpp
+++ b/src/analysis/XTemperature.cpp
@@ -66,7 +66,7 @@ namespace espressopp {
       }
       
       // compute the kinetic contribution (2/3 \sum 1/2mv^2)
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
       CellList realCells = system.storage->getRealCells();
       for (CellListIterator cit(realCells); !cit.isDone(); ++cit) {
           
@@ -219,7 +219,7 @@ namespace espressopp {
     void XTemperature::registerPython() {
       using namespace espressopp::python;
       class_<XTemperature, bases< Observable > >
-        ("analysis_XTemperature", init< shared_ptr< System > >())
+        ("analysis_XTemperature", init< std::shared_ptr< System > >())
         .def("compute", &XTemperature::computeArray)
       ;
     }

--- a/src/analysis/XTemperature.hpp
+++ b/src/analysis/XTemperature.hpp
@@ -34,7 +34,7 @@ namespace espressopp {
     // Class to compute the pressure profile along slabs in the x-direction of the system.
     class XTemperature : public Observable {
     public:
-      XTemperature(shared_ptr< System > system) : Observable(system) {}
+      XTemperature(std::shared_ptr< System > system) : Observable(system) {}
       ~XTemperature() {}
       virtual real compute() const;
       virtual python::list computeArray(int) const;

--- a/src/bc/BC.hpp
+++ b/src/bc/BC.hpp
@@ -37,7 +37,7 @@ namespace espressopp {
     /** Abstract base class for boundary conditions. */
     class BC {
     public:
-      BC(shared_ptr< esutil::RNG > _rng) : rng(_rng) {}
+      BC(std::shared_ptr< esutil::RNG > _rng) : rng(_rng) {}
 
       /** Virtual destructor for boundary conditions. */
       virtual ~BC() {}
@@ -47,9 +47,9 @@ namespace espressopp {
       virtual void scaleVolume(real s) = 0;
       virtual void scaleVolume(Real3D s) = 0;
       /** Getter for the RNG. */
-      virtual shared_ptr< esutil::RNG > getRng() { return rng; }
+      virtual std::shared_ptr< esutil::RNG > getRng() { return rng; }
       /** Setter for RNG. */
-      virtual void setRng(shared_ptr< esutil::RNG > _rng) { rng = _rng; }
+      virtual void setRng(std::shared_ptr< esutil::RNG > _rng) { rng = _rng; }
 
       /** Computes the minimum image distance vector between two
 	  positions.
@@ -154,7 +154,7 @@ namespace espressopp {
       static void registerPython();
 
      protected:
-      shared_ptr< esutil::RNG > rng;
+      std::shared_ptr< esutil::RNG > rng;
 
       static LOG4ESPP_DECL_LOGGER(logger);
 

--- a/src/bc/OrthorhombicBC.cpp
+++ b/src/bc/OrthorhombicBC.cpp
@@ -31,7 +31,7 @@ namespace espressopp {
   namespace bc {
     /* Constructor */
     OrthorhombicBC::
-    OrthorhombicBC(shared_ptr< esutil::RNG > _rng,
+    OrthorhombicBC(std::shared_ptr< esutil::RNG > _rng,
 		   const Real3D& _boxL) 
       : BC(_rng)
     { setBoxL(_boxL); }
@@ -173,7 +173,7 @@ namespace espressopp {
     registerPython() {
       using namespace espressopp::python;
       class_<OrthorhombicBC, bases< BC >, boost::noncopyable >
-	("bc_OrthorhombicBC", init< shared_ptr< esutil::RNG >, Real3D& >())
+	("bc_OrthorhombicBC", init< std::shared_ptr< esutil::RNG >, Real3D& >())
 	.add_property("boxL", &OrthorhombicBC::getBoxL, &OrthorhombicBC::setBoxL)
       ;
     }

--- a/src/bc/OrthorhombicBC.hpp
+++ b/src/bc/OrthorhombicBC.hpp
@@ -41,7 +41,7 @@ namespace espressopp {
       ~OrthorhombicBC() {}
 
       /** Constructor */
-      OrthorhombicBC(shared_ptr< esutil::RNG > _rng, 
+      OrthorhombicBC(std::shared_ptr< esutil::RNG > _rng,
 		     const Real3D& _boxL);
 
       /** Method to set the length of the side of the cubic simulation cell */

--- a/src/bc/SlabBC.cpp
+++ b/src/bc/SlabBC.cpp
@@ -33,7 +33,7 @@ namespace espressopp {
   namespace bc {
     /* Constructor */
     SlabBC::
-    SlabBC(shared_ptr< esutil::RNG > _rng, const Real3D& _boxL) : BC(_rng) {
+    SlabBC(std::shared_ptr< esutil::RNG > _rng, const Real3D& _boxL) : BC(_rng) {
       setBoxL(_boxL);
       slabDir=0;
     }
@@ -173,7 +173,7 @@ namespace espressopp {
     registerPython() {
       using namespace espressopp::python;
       class_<SlabBC, bases< BC >, boost::noncopyable >
-	("bc_SlabBC", init< shared_ptr< esutil::RNG >, Real3D& >())
+	("bc_SlabBC", init< std::shared_ptr< esutil::RNG >, Real3D& >())
 	.add_property("boxL", &SlabBC::getBoxL, &SlabBC::setBoxL)
       ;
     }

--- a/src/bc/SlabBC.hpp
+++ b/src/bc/SlabBC.hpp
@@ -44,7 +44,7 @@ namespace espressopp {
       ~SlabBC() {}
 
       /** Constructor */
-      SlabBC(shared_ptr< esutil::RNG > _rng,
+      SlabBC(std::shared_ptr< esutil::RNG > _rng,
 		     const Real3D& _boxL);
 
       /** Method to set the length of the side of the cubic simulation cell */

--- a/src/esutil/Error.cpp
+++ b/src/esutil/Error.cpp
@@ -32,7 +32,7 @@ namespace espressopp {
   namespace esutil {
 
     /********************************************************************/
-    Error::Error(shared_ptr< mpi::communicator > _comm)
+    Error::Error(std::shared_ptr< mpi::communicator > _comm)
     {
       comm = _comm;
       noExceptions = 0;

--- a/src/esutil/Error.hpp
+++ b/src/esutil/Error.hpp
@@ -81,7 +81,7 @@ namespace espressopp {
           this constrcutor.
       */
 
-      Error(boost::shared_ptr< boost::mpi::communicator > comm);
+      Error(std::shared_ptr< boost::mpi::communicator > comm);
 
       /** Destructor; will also test for pending exceptions. */
 
@@ -119,7 +119,7 @@ namespace espressopp {
 
     private:    
 
-      boost::shared_ptr< boost::mpi::communicator > comm;
+      std::shared_ptr< boost::mpi::communicator > comm;
 
       std::string exceptionMessage;
 

--- a/src/esutil/GammaVariate.cpp
+++ b/src/esutil/GammaVariate.cpp
@@ -28,7 +28,7 @@ using namespace boost;
 
 namespace espressopp {
   namespace esutil {
-    GammaVariate::GammaVariate(shared_ptr< RNG > _rng,
+    GammaVariate::GammaVariate(std::shared_ptr< RNG > _rng,
 				 const int alpha,
 				 const real beta)
       : Super(*(_rng->getBoostRNG()), DistType(alpha, beta)), rng(_rng)
@@ -45,7 +45,7 @@ namespace espressopp {
       	= &GammaVariate::operator();
 
       class_< GammaVariate >("esutil_GammaVariate",
-			      init< shared_ptr< RNG > >())
+			      init< std::shared_ptr< RNG > >())
       	.def("__call__", pyCall)
       	;
     }

--- a/src/esutil/GammaVariate.hpp
+++ b/src/esutil/GammaVariate.hpp
@@ -40,10 +40,10 @@ namespace espressopp {
       typedef variate_generator< RNGType&, DistType > Super;
 
       /// store the shared pointer to the RNG
-      shared_ptr< RNG > rng;
+      std::shared_ptr< RNG > rng;
 
     public:
-      GammaVariate(shared_ptr< RNG > _rng,
+      GammaVariate(std::shared_ptr< RNG > _rng,
 		    const int alpha = 1,
 		    const real beta = 1.0);
       using Super::operator();

--- a/src/esutil/NormalVariate.cpp
+++ b/src/esutil/NormalVariate.cpp
@@ -28,7 +28,7 @@ using namespace boost;
 
 namespace espressopp {
   namespace esutil {
-    NormalVariate::NormalVariate(shared_ptr< RNG > _rng,
+    NormalVariate::NormalVariate(std::shared_ptr< RNG > _rng,
 				 const real mean, 
 				 const real sigma) 
       : Super(*(_rng->getBoostRNG()), DistType(mean, sigma)), rng(_rng)
@@ -45,7 +45,7 @@ namespace espressopp {
       	= &NormalVariate::operator();
 
       class_< NormalVariate >("esutil_NormalVariate",
-			      init< shared_ptr< RNG > >())
+			      init< std::shared_ptr< RNG > >())
       	.def("__call__", pyCall)
       	;
     }

--- a/src/esutil/NormalVariate.hpp
+++ b/src/esutil/NormalVariate.hpp
@@ -40,10 +40,10 @@ namespace espressopp {
       typedef variate_generator< RNGType&, DistType > Super;
 
       /// store the shared pointer to the RNG
-      shared_ptr< RNG > rng;
+      std::shared_ptr< RNG > rng;
 
     public:
-      NormalVariate(shared_ptr< RNG > _rng,
+      NormalVariate(std::shared_ptr< RNG > _rng,
 		    const real mean = 0.0, 
 		    const real sigma = 1.0);
       using Super::operator();

--- a/src/esutil/RNG.cpp
+++ b/src/esutil/RNG.cpp
@@ -36,7 +36,7 @@ using namespace boost;
 namespace espressopp {
   namespace esutil {
 
-    RNG::RNG(long _seed): boostRNG(make_shared< RNGType >(_seed + mpiWorld->rank())),
+    RNG::RNG(long _seed): boostRNG(std::make_shared< RNGType >(_seed + mpiWorld->rank())),
             normalVariate(*boostRNG, normal_distribution< real >(0.0, 1.0)),
             uniformOnSphereVariate(*boostRNG, uniform_on_sphere< real, Real3D >(3)),
             seed_(_seed)
@@ -79,7 +79,7 @@ namespace espressopp {
       return uniformOnSphereVariate();
     }
 
-    shared_ptr< RNGType > RNG::getBoostRNG() {
+    std::shared_ptr< RNGType > RNG::getBoostRNG() {
       return boostRNG;
     }
 

--- a/src/esutil/RNG.hpp
+++ b/src/esutil/RNG.hpp
@@ -71,7 +71,7 @@ namespace espressopp {
       /** returns a random 3D vector that is uniformly distributed on a sphere. */
       Real3D uniformOnSphere();
 
-      shared_ptr< RNGType > getBoostRNG();
+      std::shared_ptr< RNGType > getBoostRNG();
 
       void saveState(long long);
 
@@ -94,7 +94,7 @@ namespace espressopp {
       variate_generator< RNGType&, uniform_on_sphere< real, Real3D > >
       UniformOnSphereVariate;
 
-      shared_ptr< RNGType > boostRNG;
+      std::shared_ptr< RNGType > boostRNG;
 
       NormalVariate normalVariate;
 

--- a/src/esutil/UniformOnSphere.cpp
+++ b/src/esutil/UniformOnSphere.cpp
@@ -28,7 +28,7 @@ using namespace boost;
 
 namespace espressopp {
   namespace esutil {
-    UniformOnSphere::UniformOnSphere(shared_ptr< RNG > _rng)
+    UniformOnSphere::UniformOnSphere(std::shared_ptr< RNG > _rng)
       : Super(*(_rng->getBoostRNG()), DistType(3)), rng(_rng)
     {}
 
@@ -43,7 +43,7 @@ namespace espressopp {
       	= &UniformOnSphere::operator();
 
       class_< UniformOnSphere >("esutil_UniformOnSphere",
-      				init< shared_ptr< RNG > >())
+      				init< std::shared_ptr< RNG > >())
       	.def("__call__", pyCall)
       	;
     }

--- a/src/esutil/UniformOnSphere.hpp
+++ b/src/esutil/UniformOnSphere.hpp
@@ -39,10 +39,10 @@ namespace espressopp {
       typedef variate_generator< RNGType&, DistType > Super;
       
       /// store the shared pointer to the RNG
-      shared_ptr< RNG > rng;
+      std::shared_ptr< RNG > rng;
       
     public:
-      UniformOnSphere(shared_ptr< RNG > _rng);
+      UniformOnSphere(std::shared_ptr< RNG > _rng);
       using Super::operator();
       static void registerPython();
     };

--- a/src/include/mpi.hpp
+++ b/src/include/mpi.hpp
@@ -24,8 +24,8 @@
 #define _MPI_HPP
 
 #include <boost/mpi.hpp>
-#include <boost/smart_ptr.hpp>
+#include <memory>
 
-extern boost::shared_ptr< boost::mpi::communicator > mpiWorld;
+extern std::shared_ptr< boost::mpi::communicator > mpiWorld;
 
 #endif

--- a/src/include/python.hpp
+++ b/src/include/python.hpp
@@ -60,9 +60,9 @@ namespace espressopp {
       , class X2 = ::boost::python::detail::not_specified
       >
     class class_
-      : public boost::python::class_< W, shared_ptr< W >, X1, X2 > 
+      : public boost::python::class_< W, std::shared_ptr< W >, X1, X2 >
     {
-      typedef typename boost::python::class_< W, shared_ptr< W >, X1, X2 > base;
+      typedef typename boost::python::class_< W, std::shared_ptr< W >, X1, X2 > base;
       
     public:
       // Construct with the class name, with or without docstring, and default __init__() function

--- a/src/include/types.hpp
+++ b/src/include/types.hpp
@@ -23,22 +23,20 @@
 #ifndef _TYPES_HPP
 #define _TYPES_HPP
 
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/mpi.hpp>
 #include <exception>
 #include <limits>
+#include <memory>
 #include "esconfig.hpp"
 
 namespace espressopp {
-  using boost::shared_ptr;
-  using boost::weak_ptr;
-  using boost::make_shared;
-  using boost::enable_shared_from_this;
-  using boost::const_pointer_cast;
-  using boost::static_pointer_cast;
-  using boost::dynamic_pointer_cast;
+  using std::shared_ptr;
+  using std::weak_ptr;
+  using std::make_shared;
+  using std::enable_shared_from_this;
+  using std::const_pointer_cast;
+  using std::static_pointer_cast;
+  using std::dynamic_pointer_cast;
   namespace mpi {
     using namespace boost::mpi;
   }

--- a/src/integrator/Adress.cpp
+++ b/src/integrator/Adress.cpp
@@ -41,7 +41,7 @@ namespace espressopp {
 
     using namespace espressopp::iterator;
 
-    Adress::Adress(shared_ptr<System> _system, shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList, bool _KTI, int _regionupdates, int _multistep)
+    Adress::Adress(std::shared_ptr<System> _system, std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList, bool _KTI, int _regionupdates, int _multistep)
         : Extension(_system), verletList(_verletList), fixedtupleList(_fixedtupleList), KTI(_KTI), regionupdates(_regionupdates), multistep(_multistep){
         LOG4ESPP_INFO(theLogger, "construct Adress");
         type = Extension::Adress;
@@ -638,8 +638,8 @@ namespace espressopp {
     void Adress::registerPython() {
       using namespace espressopp::python;
 
-      class_<Adress, shared_ptr<Adress>, bases<Extension> >
-        ("integrator_Adress", init<shared_ptr<System>, shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress>, bool, int, int >())
+      class_<Adress, std::shared_ptr<Adress>, bases<Extension> >
+        ("integrator_Adress", init<std::shared_ptr<System>, std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress>, bool, int, int >())
         .def("connect", &Adress::connect)
         .def("disconnect", &Adress::disconnect)
         ;

--- a/src/integrator/Adress.hpp
+++ b/src/integrator/Adress.hpp
@@ -44,8 +44,8 @@ namespace espressopp {
       class Adress : public Extension {
 
       public:
-        shared_ptr<VerletListAdress> verletList;
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
+        std::shared_ptr<VerletListAdress> verletList;
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
         bool KTI;
         int regionupdates;
         int multistep;
@@ -57,7 +57,7 @@ namespace espressopp {
         real dexdhy;
         real dexdhy2;
 
-        Adress(shared_ptr<System> _system, shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList, bool _KTI = false, int _regionupdates = 1, int _multistep = 1);
+        Adress(std::shared_ptr<System> _system, std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList, bool _KTI = false, int _regionupdates = 1, int _multistep = 1);
 
         ~Adress();
 

--- a/src/integrator/Adress.py
+++ b/src/integrator/Adress.py
@@ -54,9 +54,9 @@ Finally, when making use of a RESPA Velocity Verlet integrator, then the multist
                 :param KTI: (default: False) update resolution parameter? (Yes: set False, No: set True)
                 :param regionupdates: (default: 1) after how many steps does the AdResS region needs to be updated?
                 :param multistep: (default: 1) when used with VelocityVerletRESPA (otherwise, ignored), after how many steps of the inner integration loop do we update the slow forces? This parameter should be set consistently with multistep in VelocityVerletRESPA.
-                :type _system: shared_ptr<System>
-                :type _verletlist: shared_ptr<VerletListAdress>
-                :type _fixedtuplelist: shared_ptr<FixedTupleListAdress>
+                :type _system: std::shared_ptr<System>
+                :type _verletlist: std::shared_ptr<VerletListAdress>
+                :type _fixedtuplelist: std::shared_ptr<FixedTupleListAdress>
                 :type KTI: bool
                 :type regionupdates: int
                 :type multistep: int

--- a/src/integrator/AssociationReaction.cpp
+++ b/src/integrator/AssociationReaction.cpp
@@ -44,10 +44,10 @@ namespace espressopp {
     LOG4ESPP_LOGGER(AssociationReaction::theLogger, "AssociationReaction");
 
     AssociationReaction::AssociationReaction(
-					     shared_ptr<System> system,
-					     shared_ptr<VerletList> _verletList,
-					     shared_ptr<FixedPairList> _fpl,
-					     shared_ptr<DomainDecomposition> _domdec)
+					     std::shared_ptr<System> system,
+					     std::shared_ptr<VerletList> _verletList,
+					     std::shared_ptr<FixedPairList> _fpl,
+					     std::shared_ptr<DomainDecomposition> _domdec)
       :Extension(system), verletList(_verletList), fpl(_fpl), domdec(_domdec) {
 
       type = Extension::Reaction;
@@ -480,8 +480,8 @@ namespace espressopp {
 
     void AssociationReaction::registerPython() {
       using namespace espressopp::python;
-      class_<AssociationReaction, shared_ptr<AssociationReaction>, bases<Extension> >
-        ("integrator_AssociationReaction", init<shared_ptr<System>, shared_ptr<VerletList>, shared_ptr<FixedPairList>, shared_ptr<DomainDecomposition> >())
+      class_<AssociationReaction, std::shared_ptr<AssociationReaction>, bases<Extension> >
+        ("integrator_AssociationReaction", init<std::shared_ptr<System>, std::shared_ptr<VerletList>, std::shared_ptr<FixedPairList>, std::shared_ptr<DomainDecomposition> >())
         .def("connect", &AssociationReaction::connect)
         .def("disconnect", &AssociationReaction::disconnect)
         .add_property("rate", &AssociationReaction::getRate, &AssociationReaction::setRate)

--- a/src/integrator/AssociationReaction.hpp
+++ b/src/integrator/AssociationReaction.hpp
@@ -69,7 +69,7 @@ namespace espressopp {
 
       public:
 
-      AssociationReaction(shared_ptr<System> system, shared_ptr<VerletList> _verletList, shared_ptr<FixedPairList> _fixedPairList, shared_ptr<DomainDecomposition> _domdec);
+      AssociationReaction(std::shared_ptr<System> system, std::shared_ptr<VerletList> _verletList, std::shared_ptr<FixedPairList> _fixedPairList, std::shared_ptr<DomainDecomposition> _domdec);
       ~AssociationReaction();
 
       void setRate(real rate);
@@ -121,14 +121,14 @@ namespace espressopp {
       int stateAMin; //!< minimum state of reactant A
       int interval; //!< number of steps between reaction loops
       real dt; //!< timestep from the integrator
-      shared_ptr<espressopp::interaction::Potential> potential;
+      std::shared_ptr<espressopp::interaction::Potential> potential;
 
       real current_cutoff;
       real current_cutoff_sqr;
-      shared_ptr<VerletList> verletList;
-      shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
-      shared_ptr<FixedPairList> fpl;
-      shared_ptr<DomainDecomposition> domdec;
+      std::shared_ptr<VerletList> verletList;
+      std::shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
+      std::shared_ptr<FixedPairList> fpl;
+      std::shared_ptr<DomainDecomposition> domdec;
 
       /** container for (A,B) potential partners */
       boost::unordered_multimap<longint, longint> Alist;

--- a/src/integrator/BerendsenBarostat.cpp
+++ b/src/integrator/BerendsenBarostat.cpp
@@ -35,7 +35,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(BerendsenBarostat::theLogger, "BerendsenBarostat");
 
-    BerendsenBarostat::BerendsenBarostat(shared_ptr<System> system): Extension(system){
+    BerendsenBarostat::BerendsenBarostat(std::shared_ptr<System> system): Extension(system){
       tau  = 1.0;
       P0 = 1.0;
       
@@ -137,9 +137,9 @@ namespace espressopp {
 
       using namespace espressopp::python;
 
-      class_<BerendsenBarostat, shared_ptr<BerendsenBarostat>, bases<Extension> >
+      class_<BerendsenBarostat, std::shared_ptr<BerendsenBarostat>, bases<Extension> >
 
-        ("integrator_BerendsenBarostat", init< shared_ptr<System> >())
+        ("integrator_BerendsenBarostat", init< std::shared_ptr<System> >())
 
         .add_property("tau",
               &BerendsenBarostat::getTau,

--- a/src/integrator/BerendsenBarostat.hpp
+++ b/src/integrator/BerendsenBarostat.hpp
@@ -43,7 +43,7 @@ namespace espressopp {
     class BerendsenBarostat: public Extension {
 
       public:
-        BerendsenBarostat(shared_ptr< System > system);
+        BerendsenBarostat(std::shared_ptr< System > system);
         
         void setFixed(Int3D);
         Int3D getFixed();

--- a/src/integrator/BerendsenBarostatAnisotropic.cpp
+++ b/src/integrator/BerendsenBarostatAnisotropic.cpp
@@ -35,7 +35,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(BerendsenBarostatAnisotropic::theLogger, "BerendsenBarostatAnisotropic");
 
-    BerendsenBarostatAnisotropic::BerendsenBarostatAnisotropic(shared_ptr<System> system): Extension(system){
+    BerendsenBarostatAnisotropic::BerendsenBarostatAnisotropic(std::shared_ptr<System> system): Extension(system){
       tau  = 1.0;
       P0 = Real3D(1.0);
       
@@ -121,9 +121,9 @@ namespace espressopp {
 
       using namespace espressopp::python;
 
-      class_<BerendsenBarostatAnisotropic, shared_ptr<BerendsenBarostatAnisotropic>, bases<Extension> >
+      class_<BerendsenBarostatAnisotropic, std::shared_ptr<BerendsenBarostatAnisotropic>, bases<Extension> >
 
-        ("integrator_BerendsenBarostatAnisotropic", init< shared_ptr<System> >())
+        ("integrator_BerendsenBarostatAnisotropic", init< std::shared_ptr<System> >())
 
         .add_property("tau",
               &BerendsenBarostatAnisotropic::getTau,

--- a/src/integrator/BerendsenBarostatAnisotropic.hpp
+++ b/src/integrator/BerendsenBarostatAnisotropic.hpp
@@ -43,7 +43,7 @@ namespace espressopp {
     class BerendsenBarostatAnisotropic: public Extension {
 
       public:
-        BerendsenBarostatAnisotropic(shared_ptr< System > system);
+        BerendsenBarostatAnisotropic(std::shared_ptr< System > system);
         
         void setTau(real);
         real getTau();

--- a/src/integrator/BerendsenThermostat.cpp
+++ b/src/integrator/BerendsenThermostat.cpp
@@ -37,7 +37,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(BerendsenThermostat::theLogger, "BerendsenThermostat");
 
-    BerendsenThermostat::BerendsenThermostat(shared_ptr<System> system): Extension(system){
+    BerendsenThermostat::BerendsenThermostat(std::shared_ptr<System> system): Extension(system){
       tau  = 1.0;
       T0 = 1.0;
       
@@ -128,9 +128,9 @@ namespace espressopp {
 
       using namespace espressopp::python;
 
-      class_<BerendsenThermostat, shared_ptr<BerendsenThermostat>, bases<Extension> >
+      class_<BerendsenThermostat, std::shared_ptr<BerendsenThermostat>, bases<Extension> >
 
-        ("integrator_BerendsenThermostat", init< shared_ptr<System> >())
+        ("integrator_BerendsenThermostat", init< std::shared_ptr<System> >())
 
         .add_property("tau", &BerendsenThermostat::getTau, &BerendsenThermostat::setTau)
         .add_property("temperature", &BerendsenThermostat::getTemperature,

--- a/src/integrator/BerendsenThermostat.hpp
+++ b/src/integrator/BerendsenThermostat.hpp
@@ -43,7 +43,7 @@ namespace espressopp {
     class BerendsenThermostat: public Extension {
 
       public:
-        BerendsenThermostat(shared_ptr< System > system);
+        BerendsenThermostat(std::shared_ptr< System > system);
         
         void setTau(real);
         real getTau();

--- a/src/integrator/CapForce.cpp
+++ b/src/integrator/CapForce.cpp
@@ -36,7 +36,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(CapForce::theLogger, "CapForce");
 
-    CapForce::CapForce(shared_ptr<System> system, const Real3D& _capForce)
+    CapForce::CapForce(std::shared_ptr<System> system, const Real3D& _capForce)
     : Extension(system), capForce(_capForce)
     {
       LOG4ESPP_INFO(theLogger, "Force capping for all particles constructed");
@@ -45,7 +45,7 @@ namespace espressopp {
       adress = false;
     }
 
-    CapForce::CapForce(shared_ptr<System> system, real _absCapForce)
+    CapForce::CapForce(std::shared_ptr<System> system, real _absCapForce)
     : Extension(system), absCapForce(_absCapForce)
     {
       LOG4ESPP_INFO(theLogger, "Force capping for all particles constructed");
@@ -54,7 +54,7 @@ namespace espressopp {
       adress = false;
     }
 
-    CapForce::CapForce(shared_ptr<System> system, const Real3D& _capForce, shared_ptr< ParticleGroup > _particleGroup)
+    CapForce::CapForce(std::shared_ptr<System> system, const Real3D& _capForce, std::shared_ptr< ParticleGroup > _particleGroup)
     : Extension(system), capForce(_capForce), particleGroup(_particleGroup)
     {
       LOG4ESPP_INFO(theLogger, "Force capping for particle group constructed");
@@ -63,7 +63,7 @@ namespace espressopp {
       adress = false;
     }
 
-    CapForce::CapForce(shared_ptr<System> system, real _absCapForce, shared_ptr< ParticleGroup > _particleGroup)
+    CapForce::CapForce(std::shared_ptr<System> system, real _absCapForce, std::shared_ptr< ParticleGroup > _particleGroup)
     : Extension(system), absCapForce(_absCapForce), particleGroup(_particleGroup)
     {
       LOG4ESPP_INFO(theLogger, "Force capping for particle group constructed");
@@ -109,7 +109,7 @@ namespace espressopp {
         return adress;
     }
 
-    void CapForce::setParticleGroup(shared_ptr< ParticleGroup > _particleGroup) {
+    void CapForce::setParticleGroup(std::shared_ptr< ParticleGroup > _particleGroup) {
         particleGroup = _particleGroup;
         if (allParticles) {
      	  disconnect();
@@ -118,7 +118,7 @@ namespace espressopp {
         }
     }
 
-     shared_ptr< ParticleGroup > CapForce::getParticleGroup() {
+     std::shared_ptr< ParticleGroup > CapForce::getParticleGroup() {
     	//if (!allParticles) {
      	  return particleGroup;
     	//}
@@ -210,12 +210,12 @@ namespace espressopp {
 
       using namespace espressopp::python;
 
-      class_<CapForce, shared_ptr<CapForce>, bases<Extension> >
+      class_<CapForce, std::shared_ptr<CapForce>, bases<Extension> >
 
-        ("integrator_CapForce", init< shared_ptr< System >, const Real3D& >())
-        .def(init< shared_ptr< System >, real >())
-        .def(init< shared_ptr< System >, const Real3D&, shared_ptr< ParticleGroup > >())
-        .def(init< shared_ptr< System >, real, shared_ptr< ParticleGroup > >())
+        ("integrator_CapForce", init< std::shared_ptr< System >, const Real3D& >())
+        .def(init< std::shared_ptr< System >, real >())
+        .def(init< std::shared_ptr< System >, const Real3D&, std::shared_ptr< ParticleGroup > >())
+        .def(init< std::shared_ptr< System >, real, std::shared_ptr< ParticleGroup > >())
         .add_property("particleGroup", &CapForce::getParticleGroup, &CapForce::setParticleGroup)
         .add_property("adress", &CapForce::getAdress, &CapForce::setAdress)
         .def("getCapForce", &CapForce::getCapForce, return_value_policy< reference_existing_object >())

--- a/src/integrator/CapForce.hpp
+++ b/src/integrator/CapForce.hpp
@@ -41,13 +41,13 @@ namespace espressopp {
 
       public:
 
-        CapForce(shared_ptr< System > _system, const Real3D& _CapForce);
+        CapForce(std::shared_ptr< System > _system, const Real3D& _CapForce);
 
-        CapForce(shared_ptr< System > _system, real _AbsCapForce);
+        CapForce(std::shared_ptr< System > _system, real _AbsCapForce);
 
-        CapForce(shared_ptr< System > _system, const Real3D& _CapForce, shared_ptr< ParticleGroup > _particleGroup);
+        CapForce(std::shared_ptr< System > _system, const Real3D& _CapForce, std::shared_ptr< ParticleGroup > _particleGroup);
 
-        CapForce(shared_ptr< System > _system, real _AbsCapForce, shared_ptr< ParticleGroup > _particleGroup);
+        CapForce(std::shared_ptr< System > _system, real _AbsCapForce, std::shared_ptr< ParticleGroup > _particleGroup);
 
         void setCapForce(Real3D& _CapForce);
 
@@ -59,9 +59,9 @@ namespace espressopp {
         void setAdress(bool _adress);
         bool getAdress();
         
-        void setParticleGroup(shared_ptr< ParticleGroup > _particleGroup);
+        void setParticleGroup(std::shared_ptr< ParticleGroup > _particleGroup);
 
-        shared_ptr< ParticleGroup > getParticleGroup();
+        std::shared_ptr< ParticleGroup > getParticleGroup();
 
         void applyForceCappingToGroup();
         void applyForceCappingToAll();
@@ -73,7 +73,7 @@ namespace espressopp {
 
       private:
         boost::signals2::connection _aftCalcF;
-        shared_ptr< ParticleGroup > particleGroup;
+        std::shared_ptr< ParticleGroup > particleGroup;
         bool allParticles;
         bool absCapping;
         bool adress;

--- a/src/integrator/DPDThermostat.cpp
+++ b/src/integrator/DPDThermostat.cpp
@@ -39,8 +39,8 @@ namespace espressopp {
     using namespace espressopp::iterator;
 
     DPDThermostat::DPDThermostat(
-    		shared_ptr<System> system,
-    		shared_ptr<VerletList> _verletList)
+    		std::shared_ptr<System> system,
+    		std::shared_ptr<VerletList> _verletList)
     :Extension(system), verletList(_verletList) {
 
       type = Extension::Thermostat;
@@ -257,8 +257,8 @@ namespace espressopp {
 
     void DPDThermostat::registerPython() {
       using namespace espressopp::python;
-      class_<DPDThermostat, shared_ptr<DPDThermostat>, bases<Extension> >
-        ("integrator_DPDThermostat", init<shared_ptr<System>, shared_ptr<VerletList> >())
+      class_<DPDThermostat, std::shared_ptr<DPDThermostat>, bases<Extension> >
+        ("integrator_DPDThermostat", init<std::shared_ptr<System>, std::shared_ptr<VerletList> >())
         .def("connect", &DPDThermostat::connect)
         .def("disconnect", &DPDThermostat::disconnect)
         .add_property("gamma", &DPDThermostat::getGamma, &DPDThermostat::setGamma)

--- a/src/integrator/DPDThermostat.hpp
+++ b/src/integrator/DPDThermostat.hpp
@@ -46,8 +46,8 @@ namespace espressopp {
 
       public:
 
-        DPDThermostat(shared_ptr<System> system,
-						shared_ptr<VerletList> _verletList);
+        DPDThermostat(std::shared_ptr<System> system,
+						std::shared_ptr<VerletList> _verletList);
         ~DPDThermostat();
 
         void setGamma(real gamma);
@@ -98,8 +98,8 @@ namespace espressopp {
 
 		real current_cutoff;
 		real current_cutoff_sqr;
-        shared_ptr<VerletList> verletList;
-        shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
+        std::shared_ptr<VerletList> verletList;
+        std::shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
 
     };
   }

--- a/src/integrator/EmptyExtension.cpp
+++ b/src/integrator/EmptyExtension.cpp
@@ -36,7 +36,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(EmptyExtension::theLogger, "EmptyExtension");
 
-    EmptyExtension::EmptyExtension(shared_ptr<System> system)
+    EmptyExtension::EmptyExtension(std::shared_ptr<System> system)
     : Extension(system)
     {
     }
@@ -61,9 +61,9 @@ namespace espressopp {
 
       using namespace espressopp::python;
 
-      class_<EmptyExtension, shared_ptr<EmptyExtension>, bases<Extension> >
+      class_<EmptyExtension, std::shared_ptr<EmptyExtension>, bases<Extension> >
 
-        ("integrator_EmptyExtension", init< shared_ptr< System > >())
+        ("integrator_EmptyExtension", init< std::shared_ptr< System > >())
         .def("connect", &EmptyExtension::connect)
         .def("disconnect", &EmptyExtension::disconnect)
         ;

--- a/src/integrator/EmptyExtension.hpp
+++ b/src/integrator/EmptyExtension.hpp
@@ -41,7 +41,7 @@ namespace espressopp {
 
       public:
 
-        EmptyExtension(shared_ptr< System > _system);
+        EmptyExtension(std::shared_ptr< System > _system);
 
         void emptyFunction();
 

--- a/src/integrator/ExtAnalyze.cpp
+++ b/src/integrator/ExtAnalyze.cpp
@@ -33,8 +33,8 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(ExtAnalyze::theLogger, "ExtAnalyze");
 
-    //ExtAnalyze::ExtAnalyze(shared_ptr< AnalysisBase > _analysis, int _interval) : Extension(_analysis->getSystem()), interval(_interval)
-    ExtAnalyze::ExtAnalyze(shared_ptr< ParticleAccess > _particle_access, int _interval) : Extension(_particle_access->getSystem()), interval(_interval){
+    //ExtAnalyze::ExtAnalyze(std::shared_ptr< AnalysisBase > _analysis, int _interval) : Extension(_analysis->getSystem()), interval(_interval)
+    ExtAnalyze::ExtAnalyze(std::shared_ptr< ParticleAccess > _particle_access, int _interval) : Extension(_particle_access->getSystem()), interval(_interval){
       LOG4ESPP_INFO(theLogger, "Analyze observable in integrator");
       //analysis     = _analysis;
       particle_access     = _particle_access;
@@ -65,8 +65,8 @@ namespace espressopp {
     ****************************************************/
     void ExtAnalyze::registerPython() {
       using namespace espressopp::python;
-      class_<ExtAnalyze, shared_ptr<ExtAnalyze>, bases<Extension> >
-        ("integrator_ExtAnalyze", init< shared_ptr< ParticleAccess > , int >())
+      class_<ExtAnalyze, std::shared_ptr<ExtAnalyze>, bases<Extension> >
+        ("integrator_ExtAnalyze", init< std::shared_ptr< ParticleAccess > , int >())
         .def("connect", &ExtAnalyze::connect)
         .def("disconnect", &ExtAnalyze::disconnect)
         ;

--- a/src/integrator/ExtAnalyze.hpp
+++ b/src/integrator/ExtAnalyze.hpp
@@ -38,8 +38,8 @@ namespace espressopp {
     /** ExtAnalyze */
     class ExtAnalyze : public Extension {
       public:
-        //ExtAnalyze(shared_ptr< AnalysisBase > _analysis, int _interval);
-        ExtAnalyze(shared_ptr< ParticleAccess > _particle_access, int _interval);
+        //ExtAnalyze(std::shared_ptr< AnalysisBase > _analysis, int _interval);
+        ExtAnalyze(std::shared_ptr< ParticleAccess > _particle_access, int _interval);
         virtual ~ExtAnalyze() {};
         /** Register this class so it can be used from Python. */
         static void registerPython();
@@ -51,7 +51,7 @@ namespace espressopp {
         void perform_action();
         //void performMeasurement();
 
-        shared_ptr< ParticleAccess > particle_access;
+        std::shared_ptr< ParticleAccess > particle_access;
         int interval;
         int counter;
 

--- a/src/integrator/ExtForce.cpp
+++ b/src/integrator/ExtForce.cpp
@@ -36,14 +36,14 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(ExtForce::theLogger, "ExtForce");
 
-    ExtForce::ExtForce(shared_ptr<System> system, const Real3D& _extForce)
+    ExtForce::ExtForce(std::shared_ptr<System> system, const Real3D& _extForce)
     : Extension(system), extForce(_extForce)
     {
       LOG4ESPP_INFO(theLogger, "External Force for all particles constructed");
       allParticles = true;
     }
 
-    ExtForce::ExtForce(shared_ptr<System> system, const Real3D& _extForce, shared_ptr< ParticleGroup > _particleGroup)
+    ExtForce::ExtForce(std::shared_ptr<System> system, const Real3D& _extForce, std::shared_ptr< ParticleGroup > _particleGroup)
     : Extension(system), extForce(_extForce), particleGroup(_particleGroup)
     {
       LOG4ESPP_INFO(theLogger, "External Force for particle group constructed");
@@ -71,7 +71,7 @@ namespace espressopp {
     	return extForce;
     }
 
-    void ExtForce::setParticleGroup(shared_ptr< ParticleGroup > _particleGroup) {
+    void ExtForce::setParticleGroup(std::shared_ptr< ParticleGroup > _particleGroup) {
         particleGroup = _particleGroup;
         if (allParticles) {
      	  disconnect();
@@ -80,7 +80,7 @@ namespace espressopp {
         }
     }
 
-     shared_ptr< ParticleGroup > ExtForce::getParticleGroup() {
+     std::shared_ptr< ParticleGroup > ExtForce::getParticleGroup() {
     	//if (!allParticles) {
      	  return particleGroup;
     	//}
@@ -110,10 +110,10 @@ namespace espressopp {
 
       using namespace espressopp::python;
 
-      class_<ExtForce, shared_ptr<ExtForce>, bases<Extension> >
+      class_<ExtForce, std::shared_ptr<ExtForce>, bases<Extension> >
 
-        ("integrator_ExtForce", init< shared_ptr< System >, const Real3D& >())
-        .def(init< shared_ptr< System >, const Real3D&, shared_ptr< ParticleGroup > >())
+        ("integrator_ExtForce", init< std::shared_ptr< System >, const Real3D& >())
+        .def(init< std::shared_ptr< System >, const Real3D&, std::shared_ptr< ParticleGroup > >())
         .add_property("particleGroup", &ExtForce::getParticleGroup, &ExtForce::setParticleGroup)
         .def("getExtForce", &ExtForce::getExtForce, return_value_policy< reference_existing_object >())
         .def("setExtForce", &ExtForce::setExtForce )

--- a/src/integrator/ExtForce.hpp
+++ b/src/integrator/ExtForce.hpp
@@ -41,17 +41,17 @@ namespace espressopp {
 
       public:
 
-        ExtForce(shared_ptr< System > _system, const Real3D& _extForce);
+        ExtForce(std::shared_ptr< System > _system, const Real3D& _extForce);
 
-        ExtForce(shared_ptr< System > _system, const Real3D& _extForce, shared_ptr< ParticleGroup > _particleGroup);
+        ExtForce(std::shared_ptr< System > _system, const Real3D& _extForce, std::shared_ptr< ParticleGroup > _particleGroup);
 
         void setExtForce(Real3D& _extForce);
 
         Real3D& getExtForce();
 
-        void setParticleGroup(shared_ptr< ParticleGroup > _particleGroup);
+        void setParticleGroup(std::shared_ptr< ParticleGroup > _particleGroup);
 
-        shared_ptr< ParticleGroup > getParticleGroup();
+        std::shared_ptr< ParticleGroup > getParticleGroup();
 
         void applyForceToGroup();
         void applyForceToAll();
@@ -63,7 +63,7 @@ namespace espressopp {
 
       private:
         boost::signals2::connection _aftInitF;
-        shared_ptr< ParticleGroup > particleGroup;
+        std::shared_ptr< ParticleGroup > particleGroup;
         bool allParticles;
         Real3D extForce;
         void connect();

--- a/src/integrator/Extension.cpp
+++ b/src/integrator/Extension.cpp
@@ -30,7 +30,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(Extension::theLogger, "Extension");
 
-    Extension::Extension(shared_ptr<System> system)
+    Extension::Extension(std::shared_ptr<System> system)
       :SystemAccess(system){
 
         if (!system->storage) {
@@ -46,7 +46,7 @@ namespace espressopp {
     }
 
 
-    void Extension::setIntegrator(shared_ptr<MDIntegrator> _integrator) {
+    void Extension::setIntegrator(std::shared_ptr<MDIntegrator> _integrator) {
             integrator = _integrator;
     }
 

--- a/src/integrator/Extension.hpp
+++ b/src/integrator/Extension.hpp
@@ -40,7 +40,7 @@ namespace espressopp {
 
       public:
 
-        Extension(shared_ptr<System> system);
+        Extension(std::shared_ptr<System> system);
 
         virtual ~Extension();
 
@@ -69,9 +69,9 @@ namespace espressopp {
 
       protected:
 
-        shared_ptr<MDIntegrator> integrator; // this is needed for signal connection
+        std::shared_ptr<MDIntegrator> integrator; // this is needed for signal connection
 
-        void setIntegrator(shared_ptr<MDIntegrator> _integrator);
+        void setIntegrator(std::shared_ptr<MDIntegrator> _integrator);
 
 
         // pure virtual functions

--- a/src/integrator/FixPositions.cpp
+++ b/src/integrator/FixPositions.cpp
@@ -36,7 +36,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(FixPositions::theLogger, "FixPositions");
 
-    FixPositions::FixPositions(shared_ptr<System> system, shared_ptr< ParticleGroup > _particleGroup, const Int3D& _fixMask)
+    FixPositions::FixPositions(std::shared_ptr<System> system, std::shared_ptr< ParticleGroup > _particleGroup, const Int3D& _fixMask)
           : Extension(system), particleGroup(_particleGroup), fixMask(_fixMask)
     {
       LOG4ESPP_INFO(theLogger, "Isokinetic constructed");
@@ -53,11 +53,11 @@ namespace espressopp {
       _aftIntP  = integrator->aftIntP.connect( boost::bind(&FixPositions::restorePositions, this));
     }
 
-    void FixPositions::setParticleGroup(shared_ptr< ParticleGroup > _particleGroup) {
+    void FixPositions::setParticleGroup(std::shared_ptr< ParticleGroup > _particleGroup) {
      	particleGroup = _particleGroup;
      }
 
-     shared_ptr< ParticleGroup > FixPositions::getParticleGroup() {
+     std::shared_ptr< ParticleGroup > FixPositions::getParticleGroup() {
      	return particleGroup;
      }
 
@@ -101,9 +101,9 @@ namespace espressopp {
 
       using namespace espressopp::python;
 
-      class_<FixPositions, shared_ptr<FixPositions>, bases<Extension> >
+      class_<FixPositions, std::shared_ptr<FixPositions>, bases<Extension> >
 
-        ("integrator_FixPositions", init< shared_ptr< System >, shared_ptr< ParticleGroup >, const Int3D& >())
+        ("integrator_FixPositions", init< std::shared_ptr< System >, std::shared_ptr< ParticleGroup >, const Int3D& >())
         .add_property("particleGroup", &FixPositions::getParticleGroup, &FixPositions::setParticleGroup)
         .def("getFixMask", &FixPositions::getFixMask, return_value_policy< reference_existing_object >() )
         .def("setFixMask", &FixPositions::setFixMask )

--- a/src/integrator/FixPositions.hpp
+++ b/src/integrator/FixPositions.hpp
@@ -41,11 +41,11 @@ namespace espressopp {
 
       public:
 
-        FixPositions(shared_ptr< System > _system, shared_ptr< ParticleGroup > _particleGroup, const Int3D& _fixMask);
+        FixPositions(std::shared_ptr< System > _system, std::shared_ptr< ParticleGroup > _particleGroup, const Int3D& _fixMask);
 
-        void setParticleGroup(shared_ptr< ParticleGroup > _particleGroup);
+        void setParticleGroup(std::shared_ptr< ParticleGroup > _particleGroup);
 
-        shared_ptr< ParticleGroup > getParticleGroup();
+        std::shared_ptr< ParticleGroup > getParticleGroup();
 
         void setFixMask(Int3D& _fixMask);
 
@@ -61,7 +61,7 @@ namespace espressopp {
 
       private:
         boost::signals2::connection _befIntP, _aftIntP;
-        shared_ptr< ParticleGroup > particleGroup;
+        std::shared_ptr< ParticleGroup > particleGroup;
         Int3D fixMask;
         std::list< std::pair<Particle *, Real3D> > savePos;
         void connect();

--- a/src/integrator/FreeEnergyCompensation.cpp
+++ b/src/integrator/FreeEnergyCompensation.cpp
@@ -38,7 +38,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(FreeEnergyCompensation::theLogger, "FreeEnergyCompensation");
 
-    FreeEnergyCompensation::FreeEnergyCompensation(shared_ptr<System> system, bool _sphereAdr, int _ntrotter, bool _slow)
+    FreeEnergyCompensation::FreeEnergyCompensation(std::shared_ptr<System> system, bool _sphereAdr, int _ntrotter, bool _slow)
     :Extension(system), sphereAdr(_sphereAdr), ntrotter(_ntrotter), slow(_slow), center(0.0,0.0,0.0) {
 
         type = Extension::FreeEnergyCompensation;
@@ -72,17 +72,17 @@ namespace espressopp {
         Table table;
 
         if (itype == 1) { // create a new InterpolationLinear
-            table = make_shared <interaction::InterpolationLinear> ();
+            table = std::make_shared <interaction::InterpolationLinear> ();
             table->read(world, _filename);
         }
 
         else if (itype == 2) { // create a new InterpolationAkima
-            table = make_shared <interaction::InterpolationAkima> ();
+            table = std::make_shared <interaction::InterpolationAkima> ();
             table->read(world, _filename);
         }
 
         else if (itype == 3) { // create a new InterpolationCubic
-            table = make_shared <interaction::InterpolationCubic> ();
+            table = std::make_shared <interaction::InterpolationCubic> ();
             table->read(world, _filename);
         }
 
@@ -99,7 +99,7 @@ namespace espressopp {
           Table table;
           // iterate over CG particles
           CellList cells = system.storage->getRealCells();
-          shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+          std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
           FixedTupleListAdress::iterator it2;
           for(CellListIterator cit(cells); !cit.isDone(); ++cit) {
               tableIt = forces.find(cit->getType());
@@ -196,8 +196,8 @@ namespace espressopp {
 
       using namespace espressopp::python;
 
-      class_<FreeEnergyCompensation, shared_ptr<FreeEnergyCompensation>, bases<Extension> >
-        ("integrator_FreeEnergyCompensation", init< shared_ptr<System>, bool, int, bool >())
+      class_<FreeEnergyCompensation, std::shared_ptr<FreeEnergyCompensation>, bases<Extension> >
+        ("integrator_FreeEnergyCompensation", init< std::shared_ptr<System>, bool, int, bool >())
         .add_property("filename", &FreeEnergyCompensation::getFilename)
         .def("connect", &FreeEnergyCompensation::connect)
         .def("disconnect", &FreeEnergyCompensation::disconnect)

--- a/src/integrator/FreeEnergyCompensation.hpp
+++ b/src/integrator/FreeEnergyCompensation.hpp
@@ -47,7 +47,7 @@ namespace espressopp {
         bool sphereAdr;
         int ntrotter;
         bool slow;
-        FreeEnergyCompensation(shared_ptr<System> system, bool _sphereAdr = false, int _ntrotter = 1, bool _slow = false);
+        FreeEnergyCompensation(std::shared_ptr<System> system, bool _sphereAdr = false, int _ntrotter = 1, bool _slow = false);
         virtual ~FreeEnergyCompensation();
 
         /** Setter for the filename, will read in the table. */
@@ -71,7 +71,7 @@ namespace espressopp {
 
         Real3D center;
         std::string filename;
-        typedef shared_ptr <interaction::Interpolation> Table;
+        typedef std::shared_ptr <interaction::Interpolation> Table;
         std::unordered_map<int, Table> forces; // map type to force
 
         static LOG4ESPP_DECL_LOGGER(theLogger);

--- a/src/integrator/FreeEnergyCompensation.py
+++ b/src/integrator/FreeEnergyCompensation.py
@@ -42,7 +42,7 @@ Example:
         :param sphereAdr: (default: False) Spherical AdResS region (True) vs. slab geometry with resolution change in x-direction (False)
         :param ntrotter: (default: 1) Trotter number when used in Path Integral AdResS. Default leads to normal non-PI-AdResS behaviour.
         :param slow: (default: False) When used with RESPA Velocity Verlet, this flag decides whether the Free Energy Compensation is applied together with the slow, less frequently updated forces (slow=True) or with the fast, more frequently updated (slow=False) forces.
-        :type system: shared_ptr<System>
+        :type system: std::shared_ptr<System>
         :type center: list of reals
         :type sphereAdr: bool
         :type ntrotter: int

--- a/src/integrator/GeneralizedLangevinThermostat.cpp
+++ b/src/integrator/GeneralizedLangevinThermostat.cpp
@@ -38,7 +38,7 @@ namespace espressopp {
     using namespace espressopp::iterator;
 
 
-    GeneralizedLangevinThermostat::GeneralizedLangevinThermostat(shared_ptr<System> system)
+    GeneralizedLangevinThermostat::GeneralizedLangevinThermostat(std::shared_ptr<System> system)
     :Extension(system) {
 
       type = Extension::Thermostat;
@@ -74,17 +74,17 @@ namespace espressopp {
         Table table;
 
         if (itype == 1) { // create a new InterpolationLinear
-            table = make_shared <interaction::InterpolationLinear> ();
+            table = std::make_shared <interaction::InterpolationLinear> ();
             table->read(world, _filename);
         }
 
         else if (itype == 2) { // create a new InterpolationAkima
-            table = make_shared <interaction::InterpolationAkima> ();
+            table = std::make_shared <interaction::InterpolationAkima> ();
             table->read(world, _filename);
         }
 
         else if (itype == 3) { // create a new InterpolationCubic
-            table = make_shared <interaction::InterpolationCubic> ();
+            table = std::make_shared <interaction::InterpolationCubic> ();
             table->read(world, _filename);
         }
 
@@ -146,7 +146,7 @@ namespace espressopp {
 
           // iterate over CG particles
           CellList cells = system.storage->getRealCells();
-          shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+          std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
           FixedTupleListAdress::iterator it2;
           for(CellListIterator cit(cells); !cit.isDone(); ++cit) {                                      
 
@@ -183,8 +183,8 @@ namespace espressopp {
       using namespace espressopp::python;
 
 
-      class_<GeneralizedLangevinThermostat, shared_ptr<GeneralizedLangevinThermostat>, bases<Extension> >
-        ("integrator_GeneralizedLangevinThermostat", init<shared_ptr<System> >())
+      class_<GeneralizedLangevinThermostat, std::shared_ptr<GeneralizedLangevinThermostat>, bases<Extension> >
+        ("integrator_GeneralizedLangevinThermostat", init<std::shared_ptr<System> >())
         .add_property("filename", &GeneralizedLangevinThermostat::getFilename)
         .def("connect", &GeneralizedLangevinThermostat::connect)
         .def("disconnect", &GeneralizedLangevinThermostat::disconnect)

--- a/src/integrator/GeneralizedLangevinThermostat.hpp
+++ b/src/integrator/GeneralizedLangevinThermostat.hpp
@@ -47,7 +47,7 @@ namespace espressopp {
 
       public:
 
-        GeneralizedLangevinThermostat(shared_ptr<System> system);
+        GeneralizedLangevinThermostat(std::shared_ptr<System> system);
         virtual ~GeneralizedLangevinThermostat();
 
                 /** Setter for the filename, will read in the table. */
@@ -96,7 +96,7 @@ namespace espressopp {
         void disconnect();
 
         std::string filename;
-        typedef shared_ptr <interaction::Interpolation> Table;
+        typedef std::shared_ptr <interaction::Interpolation> Table;
         std::map<int, Table> coeffs; // map type to force
 
         //static LOG4ESPP_DECL_LOGGER(theLogger);
@@ -108,7 +108,7 @@ namespace espressopp {
 
         //real pref2buffer; //!< temporary to save value between heatUp/coolDown
 
-        //shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
+        //std::shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
 
     };
   }

--- a/src/integrator/Isokinetic.cpp
+++ b/src/integrator/Isokinetic.cpp
@@ -36,7 +36,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(Isokinetic::theLogger, "Isokinetic");
 
-    Isokinetic::Isokinetic(shared_ptr<System> system) : Extension(system)
+    Isokinetic::Isokinetic(std::shared_ptr<System> system) : Extension(system)
     {
       temperature = 0.0;
       coupling    = 1; // couple to thermostat in every md step
@@ -135,9 +135,9 @@ namespace espressopp {
 
       using namespace espressopp::python;
 
-      class_<Isokinetic, shared_ptr<Isokinetic>, bases<Extension> >
+      class_<Isokinetic, std::shared_ptr<Isokinetic>, bases<Extension> >
 
-        ("integrator_Isokinetic", init< shared_ptr<System> >())
+        ("integrator_Isokinetic", init< std::shared_ptr<System> >())
 
         .add_property("temperature", &Isokinetic::getTemperature, &Isokinetic::setTemperature)
         .add_property("coupling", &Isokinetic::getCoupling, &Isokinetic::setCoupling)

--- a/src/integrator/Isokinetic.hpp
+++ b/src/integrator/Isokinetic.hpp
@@ -37,7 +37,7 @@ namespace espressopp {
     class Isokinetic : public Extension{
 
       public:
-        Isokinetic(shared_ptr< System > system);
+        Isokinetic(std::shared_ptr< System > system);
 
         void setTemperature(real temperature);
 
@@ -60,7 +60,7 @@ namespace espressopp {
         int couplecount;
 
         // not yet needed
-        // shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
+        // std::shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
 
         void rescaleVelocities();
 

--- a/src/integrator/LBInit.hpp
+++ b/src/integrator/LBInit.hpp
@@ -32,8 +32,8 @@ namespace espressopp {
     class LBInit {
     public:
       /* Constructor for the class */
-      LBInit(shared_ptr< System > _system,
-                         shared_ptr< LatticeBoltzmann > _latticeboltzmann) {
+      LBInit(std::shared_ptr< System > _system,
+                         std::shared_ptr< LatticeBoltzmann > _latticeboltzmann) {
                             latticeboltzmann = _latticeboltzmann;
       }
       /* Destructor for the class */
@@ -49,7 +49,7 @@ namespace espressopp {
       static void registerPython();
 
     protected:
-      shared_ptr<LatticeBoltzmann> latticeboltzmann;
+      std::shared_ptr<LatticeBoltzmann> latticeboltzmann;
       real rho0;
       Real3D u0;
     };

--- a/src/integrator/LBInitConstForce.cpp
+++ b/src/integrator/LBInitConstForce.cpp
@@ -27,8 +27,8 @@
 namespace espressopp {
   namespace integrator {
 //    LOG4ESPP_LOGGER(LBInitConstForce::theLogger, "LBInitConstForce");
-    LBInitConstForce::LBInitConstForce(shared_ptr<System> system,
-                                       shared_ptr< LatticeBoltzmann > latticeboltzmann)
+    LBInitConstForce::LBInitConstForce(std::shared_ptr<System> system,
+                                       std::shared_ptr< LatticeBoltzmann > latticeboltzmann)
     : LBInit(system, latticeboltzmann) {
     }
 
@@ -125,8 +125,8 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<LBInitConstForce, bases< LBInit > >
-          ("integrator_LBInit_ConstForce", init<	shared_ptr< System >,
-																							shared_ptr< LatticeBoltzmann > >())
+          ("integrator_LBInit_ConstForce", init<	std::shared_ptr< System >,
+																							std::shared_ptr< LatticeBoltzmann > >())
           .def("setForce", &LBInitConstForce::setForce)
           .def("addForce", &LBInitConstForce::addForce)
       ;

--- a/src/integrator/LBInitConstForce.hpp
+++ b/src/integrator/LBInitConstForce.hpp
@@ -29,8 +29,8 @@ namespace espressopp {
   namespace integrator {
     class LBInitConstForce : public LBInit {
       public:
-      LBInitConstForce(shared_ptr<System> _system,
-											 shared_ptr< LatticeBoltzmann > _latticeboltzmann);
+      LBInitConstForce(std::shared_ptr<System> _system,
+											 std::shared_ptr< LatticeBoltzmann > _latticeboltzmann);
 
         /** Destructor for output. */
 /*        ~LBInitConstForce ();

--- a/src/integrator/LBInitPeriodicForce.cpp
+++ b/src/integrator/LBInitPeriodicForce.cpp
@@ -26,8 +26,8 @@
 
 namespace espressopp {
   namespace integrator {
-    LBInitPeriodicForce::LBInitPeriodicForce(shared_ptr<System> system,
-                                             shared_ptr< LatticeBoltzmann > latticeboltzmann)
+    LBInitPeriodicForce::LBInitPeriodicForce(std::shared_ptr<System> system,
+                                             std::shared_ptr< LatticeBoltzmann > latticeboltzmann)
     : LBInit(system, latticeboltzmann) {
     }
 
@@ -138,8 +138,8 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<LBInitPeriodicForce, bases< LBInit > >
-          ("integrator_LBInit_PeriodicForce",	init< shared_ptr< System >,
-                                                                                        shared_ptr< LatticeBoltzmann > >())
+          ("integrator_LBInit_PeriodicForce",	init< std::shared_ptr< System >,
+                                                                                        std::shared_ptr< LatticeBoltzmann > >())
           .def("setForce", &LBInitPeriodicForce::setForce)
           .def("addForce", &LBInitPeriodicForce::addForce)
       ;

--- a/src/integrator/LBInitPeriodicForce.hpp
+++ b/src/integrator/LBInitPeriodicForce.hpp
@@ -29,8 +29,8 @@ namespace espressopp {
   namespace integrator {
     class LBInitPeriodicForce : public LBInit {
       public:
-      LBInitPeriodicForce(shared_ptr<System> _system,
-                          shared_ptr< LatticeBoltzmann > _latticeboltzmann);
+      LBInitPeriodicForce(std::shared_ptr<System> _system,
+                          std::shared_ptr< LatticeBoltzmann > _latticeboltzmann);
 
         void createDenVel (real _rho0, Real3D _u0);
 

--- a/src/integrator/LBInitPopUniform.cpp
+++ b/src/integrator/LBInitPopUniform.cpp
@@ -26,8 +26,8 @@
 namespace espressopp {
    namespace integrator {
       //    LOG4ESPP_LOGGER(LBInitPopUniform::theLogger, "LBInitPopUniform");
-      LBInitPopUniform::LBInitPopUniform(shared_ptr<System> system,
-                                         shared_ptr< LatticeBoltzmann > latticeboltzmann)
+      LBInitPopUniform::LBInitPopUniform(std::shared_ptr<System> system,
+                                         std::shared_ptr< LatticeBoltzmann > latticeboltzmann)
       : LBInit(system, latticeboltzmann) {
       }
 
@@ -77,8 +77,8 @@ namespace espressopp {
          using namespace espressopp::python;
 
          class_<LBInitPopUniform, bases< LBInit > >
-         ("integrator_LBInit_PopUniform",		init< shared_ptr< System >,
-          shared_ptr< LatticeBoltzmann > >())
+         ("integrator_LBInit_PopUniform",		init< std::shared_ptr< System >,
+          std::shared_ptr< LatticeBoltzmann > >())
          .def("createDenVel", &LBInitPopUniform::createDenVel)
          ;
       }

--- a/src/integrator/LBInitPopUniform.hpp
+++ b/src/integrator/LBInitPopUniform.hpp
@@ -29,8 +29,8 @@ namespace espressopp {
   namespace integrator {
     class LBInitPopUniform : public LBInit {
       public:
-      LBInitPopUniform(shared_ptr<System> _system,
-                       shared_ptr< LatticeBoltzmann > _latticeboltzmann);
+      LBInitPopUniform(std::shared_ptr<System> _system,
+                       std::shared_ptr< LatticeBoltzmann > _latticeboltzmann);
 
       void createDenVel (real _rho0, Real3D _u0);
 

--- a/src/integrator/LBInitPopWave.cpp
+++ b/src/integrator/LBInitPopWave.cpp
@@ -25,8 +25,8 @@
 
 namespace espressopp {
   namespace integrator {
-    LBInitPopWave::LBInitPopWave(shared_ptr<System> system,
-                                                                 shared_ptr< LatticeBoltzmann > latticeboltzmann)
+    LBInitPopWave::LBInitPopWave(std::shared_ptr<System> system,
+                                                                 std::shared_ptr< LatticeBoltzmann > latticeboltzmann)
     : LBInit(system, latticeboltzmann) {
     }
 
@@ -91,8 +91,8 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<LBInitPopWave, bases< LBInit > >
-          ("integrator_LBInit_PopWave", init< shared_ptr< System >,
-           shared_ptr< LatticeBoltzmann > >())
+          ("integrator_LBInit_PopWave", init< std::shared_ptr< System >,
+           std::shared_ptr< LatticeBoltzmann > >())
           .def("createDenVel", &LBInitPopWave::createDenVel)
       ;
     }

--- a/src/integrator/LBInitPopWave.hpp
+++ b/src/integrator/LBInitPopWave.hpp
@@ -29,8 +29,8 @@ namespace espressopp {
   namespace integrator {
     class LBInitPopWave : public LBInit {
       public:
-      LBInitPopWave(shared_ptr<System> _system,
-                    shared_ptr< LatticeBoltzmann > _latticeboltzmann);
+      LBInitPopWave(std::shared_ptr<System> _system,
+                    std::shared_ptr< LatticeBoltzmann > _latticeboltzmann);
 
       void createDenVel (real _rho0, Real3D _u0);
 

--- a/src/integrator/LangevinBarostat.cpp
+++ b/src/integrator/LangevinBarostat.cpp
@@ -49,8 +49,8 @@ namespace espressopp {
 
     // TODO The ensemble is very sensitive to parameters. The manual how to choose the
     // parameters for simple system should be written.
-    LangevinBarostat::LangevinBarostat(shared_ptr<System> _system,
-                                       shared_ptr<esutil::RNG> _rng,
+    LangevinBarostat::LangevinBarostat(std::shared_ptr<System> _system,
+                                       std::shared_ptr<esutil::RNG> _rng,
                                        real _temperature) : Extension(_system), 
                                                             rng(_rng), 
                                                             desiredTemperature(_temperature){
@@ -288,9 +288,9 @@ namespace espressopp {
     void LangevinBarostat::registerPython() {
       using namespace espressopp::python;
 
-      class_<LangevinBarostat, shared_ptr<LangevinBarostat>, bases<Extension> >
+      class_<LangevinBarostat, std::shared_ptr<LangevinBarostat>, bases<Extension> >
 
-        ("integrator_LangevinBarostat", init< shared_ptr<System>, shared_ptr<esutil::RNG>, real >() )
+        ("integrator_LangevinBarostat", init< std::shared_ptr<System>, std::shared_ptr<esutil::RNG>, real >() )
 
         .add_property("gammaP", &LangevinBarostat::getGammaP, &LangevinBarostat::setGammaP)
         .add_property("pressure", &LangevinBarostat::getPressure, &LangevinBarostat::setPressure)

--- a/src/integrator/LangevinBarostat.hpp
+++ b/src/integrator/LangevinBarostat.hpp
@@ -41,7 +41,7 @@ namespace espressopp {
     class LangevinBarostat : public Extension {
 
       public:
-        LangevinBarostat(shared_ptr< System >, shared_ptr< esutil::RNG >, real);
+        LangevinBarostat(std::shared_ptr< System >, std::shared_ptr< esutil::RNG >, real);
 
         void setGammaP(real);
         real getGammaP();
@@ -81,7 +81,7 @@ namespace espressopp {
         real pref5;  // prefactor, for the volume momentum
         real pref6;  // prefactor, for the volume momentum
 
-        shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
+        std::shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
 
         void initialize();    // initialize barostat prefactors
         

--- a/src/integrator/LangevinThermostat.cpp
+++ b/src/integrator/LangevinThermostat.cpp
@@ -36,7 +36,7 @@ namespace espressopp {
     using namespace espressopp::iterator;
 
 
-    LangevinThermostat::LangevinThermostat(shared_ptr<System> system)
+    LangevinThermostat::LangevinThermostat(std::shared_ptr<System> system)
     :Extension(system) {
 
       type = Extension::Thermostat;
@@ -224,8 +224,8 @@ namespace espressopp {
       using namespace espressopp::python;
 
 
-      class_<LangevinThermostat, shared_ptr<LangevinThermostat>, bases<Extension> >
-        ("integrator_LangevinThermostat", init<shared_ptr<System> >())
+      class_<LangevinThermostat, std::shared_ptr<LangevinThermostat>, bases<Extension> >
+        ("integrator_LangevinThermostat", init<std::shared_ptr<System> >())
         .def("connect", &LangevinThermostat::connect)
         .def("disconnect", &LangevinThermostat::disconnect)
         .def("addExclpid", &LangevinThermostat::addExclpid)

--- a/src/integrator/LangevinThermostat.hpp
+++ b/src/integrator/LangevinThermostat.hpp
@@ -46,7 +46,7 @@ namespace espressopp {
 
       public:
 
-        LangevinThermostat(shared_ptr<System> system);
+        LangevinThermostat(std::shared_ptr<System> system);
         virtual ~LangevinThermostat();
 
         void setGamma(real gamma);
@@ -107,7 +107,7 @@ namespace espressopp {
 
         real pref2buffer; //!< temporary to save value between heatUp/coolDown
 
-        shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
+        std::shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
 
     };
   }

--- a/src/integrator/LangevinThermostat.py
+++ b/src/integrator/LangevinThermostat.py
@@ -42,7 +42,7 @@ Example:
 .. function:: espressopp.integrator.LangevinThermostat(system)
 
         :param system: system object
-        :type system: shared_ptr<System>
+        :type system: std::shared_ptr<System>
 
 .. function:: espressopp.integrator.LangevinThermostat.addExclusions(pidlist)
 

--- a/src/integrator/LangevinThermostat1D.cpp
+++ b/src/integrator/LangevinThermostat1D.cpp
@@ -36,7 +36,7 @@ namespace espressopp {
     using namespace espressopp::iterator;
 
 
-    LangevinThermostat1D::LangevinThermostat1D(shared_ptr<System> system)
+    LangevinThermostat1D::LangevinThermostat1D(std::shared_ptr<System> system)
     :Extension(system) {
 
       type = Extension::Thermostat;
@@ -229,8 +229,8 @@ namespace espressopp {
       using namespace espressopp::python;
 
 
-      class_<LangevinThermostat1D, shared_ptr<LangevinThermostat1D>, bases<Extension> >
-        ("integrator_LangevinThermostat1D", init<shared_ptr<System> >())
+      class_<LangevinThermostat1D, std::shared_ptr<LangevinThermostat1D>, bases<Extension> >
+        ("integrator_LangevinThermostat1D", init<std::shared_ptr<System> >())
         .def("connect", &LangevinThermostat1D::connect)
         .def("disconnect", &LangevinThermostat1D::disconnect)
         .add_property("adress", &LangevinThermostat1D::getAdress, &LangevinThermostat1D::setAdress)

--- a/src/integrator/LangevinThermostat1D.hpp
+++ b/src/integrator/LangevinThermostat1D.hpp
@@ -45,7 +45,7 @@ namespace espressopp {
 
       public:
 
-        LangevinThermostat1D(shared_ptr<System> system);
+        LangevinThermostat1D(std::shared_ptr<System> system);
         virtual ~LangevinThermostat1D();
 
         void setGamma(real gamma);
@@ -105,7 +105,7 @@ namespace espressopp {
 
         real pref2buffer; //!< temporary to save value between heatUp/coolDown
 
-        shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
+        std::shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
 
     };
   }

--- a/src/integrator/LangevinThermostatHybrid.cpp
+++ b/src/integrator/LangevinThermostatHybrid.cpp
@@ -36,7 +36,7 @@ namespace espressopp {
     using namespace espressopp::iterator;
 
 
-    LangevinThermostatHybrid::LangevinThermostatHybrid(shared_ptr<System> system,shared_ptr<FixedTupleListAdress> _fixedtupleList)
+    LangevinThermostatHybrid::LangevinThermostatHybrid(std::shared_ptr<System> system,std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
     :Extension(system),fixedtupleList(_fixedtupleList) {
 
       type = Extension::Thermostat;
@@ -249,8 +249,8 @@ namespace espressopp {
       using namespace espressopp::python;
 
 
-      class_<LangevinThermostatHybrid, shared_ptr<LangevinThermostatHybrid>, bases<Extension> >
-        ("integrator_LangevinThermostatHybrid", init<shared_ptr<System>,shared_ptr<FixedTupleListAdress> >())
+      class_<LangevinThermostatHybrid, std::shared_ptr<LangevinThermostatHybrid>, bases<Extension> >
+        ("integrator_LangevinThermostatHybrid", init<std::shared_ptr<System>,std::shared_ptr<FixedTupleListAdress> >())
         .def("connect", &LangevinThermostatHybrid::connect)
         .def("disconnect", &LangevinThermostatHybrid::disconnect)
         .add_property("gamma", &LangevinThermostatHybrid::getGamma, &LangevinThermostatHybrid::setGamma)

--- a/src/integrator/LangevinThermostatHybrid.hpp
+++ b/src/integrator/LangevinThermostatHybrid.hpp
@@ -48,8 +48,8 @@ namespace espressopp {
 
       public:
 
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
-        LangevinThermostatHybrid(shared_ptr<System> system,shared_ptr<FixedTupleListAdress> _fixedtupleList);
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
+        LangevinThermostatHybrid(std::shared_ptr<System> system,std::shared_ptr<FixedTupleListAdress> _fixedtupleList);
         virtual ~LangevinThermostatHybrid();
 
         void setGamma(real gamma);
@@ -112,7 +112,7 @@ namespace espressopp {
         real pref2bufferhy; //!< temporary to save value between heatUp/coolDown
         real pref2buffercg; //!< temporary to save value between heatUp/coolDown
 
-        shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
+        std::shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
 
     };
   }

--- a/src/integrator/LangevinThermostatOnGroup.cpp
+++ b/src/integrator/LangevinThermostatOnGroup.cpp
@@ -33,7 +33,7 @@ namespace integrator {
 using namespace espressopp::iterator;
 
 LangevinThermostatOnGroup::LangevinThermostatOnGroup(
-    shared_ptr<System> system, shared_ptr<ParticleGroup> _pg)
+    std::shared_ptr<System> system, std::shared_ptr<ParticleGroup> _pg)
         : Extension(system), particle_group(_pg) {
   type = Extension::Thermostat;
 
@@ -154,9 +154,9 @@ void LangevinThermostatOnGroup::coolDown() {
 void LangevinThermostatOnGroup::registerPython() {
   using namespace espressopp::python;
 
-  class_<LangevinThermostatOnGroup, shared_ptr<LangevinThermostatOnGroup>, bases<Extension> >
+  class_<LangevinThermostatOnGroup, std::shared_ptr<LangevinThermostatOnGroup>, bases<Extension> >
       ("integrator_LangevinThermostatOnGroup",
-           init<shared_ptr<System>, shared_ptr<ParticleGroup> >())
+           init<std::shared_ptr<System>, std::shared_ptr<ParticleGroup> >())
       .def("connect", &LangevinThermostatOnGroup::connect)
       .def("disconnect", &LangevinThermostatOnGroup::disconnect)
       .add_property("gamma",

--- a/src/integrator/LangevinThermostatOnGroup.hpp
+++ b/src/integrator/LangevinThermostatOnGroup.hpp
@@ -40,7 +40,7 @@ namespace integrator {
 /** Langevin thermostat on ParticleGroup */
 class LangevinThermostatOnGroup: public Extension {
  public:
-  LangevinThermostatOnGroup(shared_ptr<System>, shared_ptr<ParticleGroup> pg);
+  LangevinThermostatOnGroup(std::shared_ptr<System>, std::shared_ptr<ParticleGroup> pg);
   virtual ~LangevinThermostatOnGroup();
 
   void setGamma(real gamma);
@@ -85,9 +85,9 @@ class LangevinThermostatOnGroup: public Extension {
 
   real pref2buffer;  //!< temporary to save value between heatUp/coolDown
 
-  shared_ptr<esutil::RNG> rng;  //!< random number generator used for friction term
+  std::shared_ptr<esutil::RNG> rng;  //!< random number generator used for friction term
 
-  shared_ptr<ParticleGroup> particle_group;
+  std::shared_ptr<ParticleGroup> particle_group;
 };
 }  // end namespace integrator
 }  // end namespace espressopp

--- a/src/integrator/LangevinThermostatOnRadius.cpp
+++ b/src/integrator/LangevinThermostatOnRadius.cpp
@@ -34,7 +34,7 @@ namespace espressopp {
 	using namespace espressopp::iterator;
 	
 	
-	LangevinThermostatOnRadius::LangevinThermostatOnRadius(shared_ptr<System> system, real _dampingmass)
+	LangevinThermostatOnRadius::LangevinThermostatOnRadius(std::shared_ptr<System> system, real _dampingmass)
 	    :Extension(system) {
 	    
 	    type = Extension::Thermostat;
@@ -181,8 +181,8 @@ namespace espressopp {
 	    using namespace espressopp::python;
 	    
 	    
-	    class_<LangevinThermostatOnRadius, shared_ptr<LangevinThermostatOnRadius>, bases<Extension> >
-		("integrator_LangevinThermostatOnRadius", init<shared_ptr<System>, real >())
+	    class_<LangevinThermostatOnRadius, std::shared_ptr<LangevinThermostatOnRadius>, bases<Extension> >
+		("integrator_LangevinThermostatOnRadius", init<std::shared_ptr<System>, real >())
 		.def("connect", &LangevinThermostatOnRadius::connect)
 		.def("disconnect", &LangevinThermostatOnRadius::disconnect)
 		.def("addExclpid", &LangevinThermostatOnRadius::addExclpid)

--- a/src/integrator/LangevinThermostatOnRadius.hpp
+++ b/src/integrator/LangevinThermostatOnRadius.hpp
@@ -43,7 +43,7 @@ namespace espressopp {
 	    
 	public:
 	    
-	    LangevinThermostatOnRadius(shared_ptr<System> system, real _dampingmass);
+	    LangevinThermostatOnRadius(std::shared_ptr<System> system, real _dampingmass);
 	    virtual ~LangevinThermostatOnRadius();
 	    
 	    void setGamma(real gamma);
@@ -99,7 +99,7 @@ namespace espressopp {
 	    
 	    real pref2buffer; //!< temporary to save value between heatUp/coolDown
 	    
-	    shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
+	    std::shared_ptr< esutil::RNG > rng;  //!< random number generator used for friction term
 	    
 	};
     }

--- a/src/integrator/LatticeBoltzmann.cpp
+++ b/src/integrator/LatticeBoltzmann.cpp
@@ -48,7 +48,7 @@ namespace espressopp {
       LOG4ESPP_LOGGER(LatticeBoltzmann::theLogger, "LatticeBoltzmann");
 
       /* LB Constructor; expects 1 Int3D, 2 reals and 2 integers */
-      LatticeBoltzmann::LatticeBoltzmann(shared_ptr<System> _system, Int3D _nodeGrid,
+      LatticeBoltzmann::LatticeBoltzmann(std::shared_ptr<System> _system, Int3D _nodeGrid,
                                          real _a, real _tau, int _numDims, int _numVels)
       : Extension(_system)
       , nodeGrid(_nodeGrid)
@@ -2105,9 +2105,9 @@ namespace espressopp {
       void LatticeBoltzmann::registerPython() {
 
          using namespace espressopp::python;
-         class_<LatticeBoltzmann, shared_ptr<LatticeBoltzmann>, bases<Extension> >
+         class_<LatticeBoltzmann, std::shared_ptr<LatticeBoltzmann>, bases<Extension> >
 
-         ("integrator_LatticeBoltzmann", init<	shared_ptr< System >, Int3D, real, real, int, int >())
+         ("integrator_LatticeBoltzmann", init<	std::shared_ptr< System >, Int3D, real, real, int, int >())
          .add_property("nodeGrid", &LatticeBoltzmann::getNodeGrid, &LatticeBoltzmann::setNodeGrid)
          .add_property("a", &LatticeBoltzmann::getA, &LatticeBoltzmann::setA)
          .add_property("tau", &LatticeBoltzmann::getTau, &LatticeBoltzmann::setTau)

--- a/src/integrator/LatticeBoltzmann.hpp
+++ b/src/integrator/LatticeBoltzmann.hpp
@@ -57,7 +57,7 @@ namespace espressopp {
           straightforward.
           */
       public:
-         LatticeBoltzmann (shared_ptr< System > _system,
+         LatticeBoltzmann (std::shared_ptr< System > _system,
                            Int3D _nodeGrid, real _a, real _tau, int _numDims, int _numVels);
          ~LatticeBoltzmann ();
 
@@ -269,7 +269,7 @@ namespace espressopp {
          int stepNum;                           // step number
          real copyTimestep;                  // copy of the integrator timestep
          bool restart;
-         shared_ptr< esutil::RNG > rng;  //!< random number generator used for fluctuations
+         std::shared_ptr< esutil::RNG > rng;  //!< random number generator used for fluctuations
 
          // EXTERNAL FORCES
          bool extForce;                         // flag for an external force

--- a/src/integrator/LatticeBoltzmann.py
+++ b/src/integrator/LatticeBoltzmann.py
@@ -29,7 +29,7 @@ LB/MD simulations. It is implemented as :py:class:`espressopp.integrator.Extensi
                                                     a = 1., tau = 1., \
                                                     numDims = 3, numVels = 19)
 
-    :param shared_ptr system: system object
+    :param std::shared_ptr system: system object
     :param Int3D nodeGrid: arrangement of CPUs in space
     :param real a: lattice spacing (in lattice units).
     :param real tau: time discretization (in lattice units)

--- a/src/integrator/LatticeSite.cpp
+++ b/src/integrator/LatticeSite.cpp
@@ -292,7 +292,7 @@ namespace espressopp {
 
 /*******************************************************************************************/
 
-        LatticePar::LatticePar (shared_ptr<System> system, int _numVelsLoc, real _a, real _tau) {
+        LatticePar::LatticePar (std::shared_ptr<System> system, int _numVelsLoc, real _a, real _tau) {
             setNumVelsLoc(_numVelsLoc);
             setALoc(_a);
             setTauLoc(_tau);
@@ -354,7 +354,7 @@ namespace espressopp {
 
 /*******************************************************************************************/
 
-        shared_ptr< esutil::RNG > LatticePar::rng;		// initializer
+        std::shared_ptr< esutil::RNG > LatticePar::rng;		// initializer
         int LatticePar::numVelsLoc = 0;								// initializer
         real LatticePar::aLoc = 0.;										// initializer
         real LatticePar::tauLoc = 0.;									// initializer

--- a/src/integrator/LatticeSite.hpp
+++ b/src/integrator/LatticeSite.hpp
@@ -100,7 +100,7 @@ namespace espressopp {
 
       class LatticePar {
       public:
-         LatticePar (shared_ptr<System> system,					// constr of lattice parameters
+         LatticePar (std::shared_ptr<System> system,					// constr of lattice parameters
                      int _numVelsLoc, real _aLoc, real _tauLoc);
          ~LatticePar ();																	// destr of lattice parameters
 
@@ -120,7 +120,7 @@ namespace espressopp {
          void initEqWeights();
          void initInvBLoc();
 
-         static shared_ptr< esutil::RNG > rng;						//!< RNG for fluctuations
+         static std::shared_ptr< esutil::RNG > rng;						//!< RNG for fluctuations
       private:
          static int numVelsLoc;													// local number of vels
          static real aLoc;																// local lattice spacing

--- a/src/integrator/MDIntegrator.cpp
+++ b/src/integrator/MDIntegrator.cpp
@@ -34,7 +34,7 @@ namespace espressopp {
     // Constructor              
     //////////////////////////////////////////////////
 
-    MDIntegrator::MDIntegrator(shared_ptr<System> system) :
+    MDIntegrator::MDIntegrator(std::shared_ptr<System> system) :
     SystemAccess(system)
     {
       LOG4ESPP_INFO(theLogger, "construct Integrator");
@@ -65,7 +65,7 @@ namespace espressopp {
     }
 
 
-    void MDIntegrator::addExtension(shared_ptr<integrator::Extension> extension) {
+    void MDIntegrator::addExtension(std::shared_ptr<integrator::Extension> extension) {
        //extension->setIntegrator(this); // this is done in python
        //std::cout << "type is: " << extension->type << "\n";
 
@@ -89,7 +89,7 @@ namespace espressopp {
     	return exList.size();
     }
 
-    shared_ptr<integrator::Extension> MDIntegrator::getExtension(int k) {
+    std::shared_ptr<integrator::Extension> MDIntegrator::getExtension(int k) {
     	return exList[k];
     }
 

--- a/src/integrator/MDIntegrator.hpp
+++ b/src/integrator/MDIntegrator.hpp
@@ -45,7 +45,7 @@ namespace espressopp {
 
     class Extension; //fwd declaration
 
-    struct ExtensionList : public std::vector<shared_ptr<Extension> > {
+    struct ExtensionList : public std::vector<std::shared_ptr<Extension> > {
           typedef esutil::ESPPIterator<std::vector<Extension> > Iterator;
     };
 
@@ -55,7 +55,7 @@ namespace espressopp {
             \param system is reference to the system.
             Note: This class will keep a weak reference to the system.
         */
-        MDIntegrator(shared_ptr<System> system);
+        MDIntegrator(std::shared_ptr<System> system);
 
         /** Destructor. */
         virtual ~MDIntegrator();
@@ -75,9 +75,9 @@ namespace espressopp {
         /** This method runs the integration for a certain number of steps. */
         virtual void run(int nsteps) = 0;
 
-        void addExtension(shared_ptr<integrator::Extension> extension);
+        void addExtension(std::shared_ptr<integrator::Extension> extension);
 
-        shared_ptr<integrator::Extension> getExtension(int k);
+        std::shared_ptr<integrator::Extension> getExtension(int k);
 
         int getNumberOfExtensions();
 

--- a/src/integrator/MinimizeEnergy.cpp
+++ b/src/integrator/MinimizeEnergy.cpp
@@ -32,7 +32,7 @@ namespace espressopp {
 	
 	LOG4ESPP_LOGGER(MinimizeEnergy::theLogger, "MinimizeEnergy");
 	
-	MinimizeEnergy::MinimizeEnergy(shared_ptr<System> system,
+	MinimizeEnergy::MinimizeEnergy(std::shared_ptr<System> system,
 				       real gamma,
 				       real ftol,
 				       real max_displacement,
@@ -205,7 +205,7 @@ namespace espressopp {
 	    
 	    // Note: use noncopyable and no_init for abstract classes
 	    class_<MinimizeEnergy, boost::noncopyable>
-		("integrator_MinimizeEnergy", init<shared_ptr<System>, real, real, real, bool>())
+		("integrator_MinimizeEnergy", init<std::shared_ptr<System>, real, real, real, bool>())
 		.add_property("f_max", &MinimizeEnergy::getFMax)
 		.add_property("displacement", &MinimizeEnergy::getDpMax)
 		.add_property("step", make_getter(&MinimizeEnergy::nstep_), make_setter(&MinimizeEnergy::nstep_))

--- a/src/integrator/MinimizeEnergy.hpp
+++ b/src/integrator/MinimizeEnergy.hpp
@@ -40,7 +40,7 @@ namespace integrator {
 
 class MinimizeEnergy : public SystemAccess {
  public:
-  MinimizeEnergy(shared_ptr<class espressopp::System> system,
+  MinimizeEnergy(std::shared_ptr<class espressopp::System> system,
                  real gamma,
                  real ftol,
                  real max_displacement,

--- a/src/integrator/OnTheFlyFEC.cpp
+++ b/src/integrator/OnTheFlyFEC.cpp
@@ -38,7 +38,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(OnTheFlyFEC::theLogger, "OnTheFlyFEC");
 
-    OnTheFlyFEC::OnTheFlyFEC(shared_ptr<System> system)
+    OnTheFlyFEC::OnTheFlyFEC(std::shared_ptr<System> system)
     :Extension(system), center(0.0,0.0,0.0) {
 
         type = Extension::FreeEnergyCompensation;
@@ -135,7 +135,7 @@ namespace espressopp {
                   
                   // iterate over CG particles
                   CellList cells = system.storage->getRealCells();
-                  shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+                  std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
                   FixedTupleListAdress::iterator it2;
                   for(CellListIterator cit(cells); !cit.isDone(); ++cit) {
 
@@ -276,8 +276,8 @@ namespace espressopp {
       using namespace espressopp::python;
 
 
-      class_<OnTheFlyFEC, shared_ptr<OnTheFlyFEC>, bases<Extension> >
-        ("integrator_OnTheFlyFEC", init< shared_ptr<System> >())
+      class_<OnTheFlyFEC, std::shared_ptr<OnTheFlyFEC>, bases<Extension> >
+        ("integrator_OnTheFlyFEC", init< std::shared_ptr<System> >())
         .add_property("bins", &OnTheFlyFEC::getBins, &OnTheFlyFEC::setBins)
         .add_property("steps", &OnTheFlyFEC::getSteps, &OnTheFlyFEC::setSteps)
         .add_property("gap", &OnTheFlyFEC::getGap, &OnTheFlyFEC::setGap)

--- a/src/integrator/OnTheFlyFEC.hpp
+++ b/src/integrator/OnTheFlyFEC.hpp
@@ -45,7 +45,7 @@ namespace espressopp {
     class OnTheFlyFEC : public Extension {
 
       public:
-        OnTheFlyFEC(shared_ptr<System> system);
+        OnTheFlyFEC(std::shared_ptr<System> system);
         virtual ~OnTheFlyFEC();
 
         void setBins(int bins);

--- a/src/integrator/PIAdressIntegrator.cpp
+++ b/src/integrator/PIAdressIntegrator.cpp
@@ -37,7 +37,7 @@ namespace espressopp {
     using namespace iterator;
     using namespace esutil;
 
-    PIAdressIntegrator::PIAdressIntegrator(shared_ptr< System > system, shared_ptr<VerletListAdress> _verletList)
+    PIAdressIntegrator::PIAdressIntegrator(std::shared_ptr< System > system, std::shared_ptr<VerletListAdress> _verletList)
       : MDIntegrator(system), verletList(_verletList)
     {
       // Initialize variables
@@ -185,7 +185,7 @@ namespace espressopp {
     void PIAdressIntegrator::initializeSetup() {
       System& system = getSystemRef();
       CellList localCells = system.storage->getLocalCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
 
       for(CellListIterator cit(localCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
@@ -279,7 +279,7 @@ namespace espressopp {
 
       System& system = getSystemRef();
       CellList realCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
 
       for(CellListIterator cit(realCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
@@ -319,7 +319,7 @@ namespace espressopp {
 
       System& system = getSystemRef();
       CellList realCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
       for(CellListIterator cit(realCells); !cit.isDone(); ++cit) {
 
         Particle &vp = *cit;
@@ -476,7 +476,7 @@ namespace espressopp {
     void PIAdressIntegrator::integrateModePos() {
       System& system = getSystemRef();
       CellList realCells = system.storage->getRealCells(); //!!!!
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
       for(CellListIterator cit(realCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
 
@@ -695,7 +695,7 @@ namespace espressopp {
 
       System& system = getSystemRef();
       CellList realCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
 
       for(CellListIterator cit(realCells); !cit.isDone(); ++cit) {
 
@@ -769,7 +769,7 @@ namespace espressopp {
       real maxSqDist = 0.0;
       System& system = getSystemRef();
       CellList localCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
 
       for(CellListIterator cit(localCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
@@ -823,7 +823,7 @@ namespace espressopp {
     void PIAdressIntegrator::transPos2() { // Update the mode positions from real positions
       System& system = getSystemRef();
       CellList localCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
 
       for(CellListIterator cit(localCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
@@ -868,7 +868,7 @@ namespace espressopp {
 
       System& system = getSystemRef();
       CellList localCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
 
       for(CellListIterator cit(localCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
@@ -940,7 +940,7 @@ namespace espressopp {
     void PIAdressIntegrator::transMom2() { // Update the mode momenta from real velocities
       System& system = getSystemRef();
       CellList localCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
 
       for(CellListIterator cit(localCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
@@ -1005,7 +1005,7 @@ namespace espressopp {
     void PIAdressIntegrator::transForces() { // Update the mode forces from real forces
       System& system = getSystemRef();
       CellList localCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
 
       for(CellListIterator cit(localCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
@@ -1072,7 +1072,7 @@ namespace espressopp {
     void PIAdressIntegrator::calcForcesF() { // Calculate fast forces, this is, the intra-ring forces between the path integral beads (purely in mode space)
       System& system = getSystemRef();
       CellList localCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
 
       for(CellListIterator cit(localCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
@@ -1279,7 +1279,7 @@ namespace espressopp {
     void PIAdressIntegrator::distributeForces() { // distribute forces from atomistic particles (path integral beads) to CG particles (physical atoms)
       System& system = getSystemRef();
       CellList localCells = system.storage->getLocalCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
       for(CellListIterator cit(localCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
         FixedTupleListAdress::iterator it3;
@@ -1355,7 +1355,7 @@ namespace espressopp {
       real esum = 0.0;
       System& system = getSystemRef();
       CellList realCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
       for(CellListIterator cit(realCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
         FixedTupleListAdress::iterator it3;
@@ -1412,7 +1412,7 @@ namespace espressopp {
       real esum = 0.0;
       System& system = getSystemRef();
       CellList realCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
       for(CellListIterator cit(realCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
         FixedTupleListAdress::iterator it3;
@@ -1451,7 +1451,7 @@ namespace espressopp {
       real esum = 0.0;
       System& system = getSystemRef();
       CellList realCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
       for(CellListIterator cit(realCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
         FixedTupleListAdress::iterator it3;
@@ -1498,7 +1498,7 @@ namespace espressopp {
       real esum = 0.0;
       System& system = getSystemRef();
       CellList realCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
       for(CellListIterator cit(realCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
         if(vp.type() == parttype) {
@@ -1543,7 +1543,7 @@ namespace espressopp {
       real esum = 0.0;
       System& system = getSystemRef();
       CellList realCells = system.storage->getRealCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
       for(CellListIterator cit(realCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
         if(vp.type() == parttype) {
@@ -1582,7 +1582,7 @@ namespace espressopp {
     void PIAdressIntegrator::setWeights() {
       System& system = getSystemRef();
       CellList localCells = system.storage->getLocalCells();
-      shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList = system.storage->getFixedTuples();
 
       for(CellListIterator cit(localCells); !cit.isDone(); ++cit) {
         Particle &vp = *cit;
@@ -1740,7 +1740,7 @@ namespace espressopp {
     }
 
 
-    void PIAdressIntegrator::setVerletList(shared_ptr<VerletListAdress> _verletList) {
+    void PIAdressIntegrator::setVerletList(std::shared_ptr<VerletListAdress> _verletList) {
       if (!_verletList) {
         throw std::invalid_argument("No Verletlist given in PIAdressIntegrator::setVerletList.");
       }
@@ -1774,7 +1774,7 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<PIAdressIntegrator, bases<MDIntegrator>, boost::noncopyable >
-      ("integrator_PIAdressIntegrator", init< shared_ptr<System>, shared_ptr<VerletListAdress> >())
+      ("integrator_PIAdressIntegrator", init< std::shared_ptr<System>, std::shared_ptr<VerletListAdress> >())
       .def("setTimeStep", &PIAdressIntegrator::setTimeStep)
       .def("getTimeStep", &PIAdressIntegrator::getTimeStep)
       .def("setmStep", &PIAdressIntegrator::setmStep)

--- a/src/integrator/PIAdressIntegrator.hpp
+++ b/src/integrator/PIAdressIntegrator.hpp
@@ -32,11 +32,11 @@ namespace espressopp {
     class PIAdressIntegrator : public MDIntegrator {
 
       public:
-        PIAdressIntegrator(shared_ptr<class espressopp::System> system, shared_ptr<VerletListAdress> _verletList);
+        PIAdressIntegrator(std::shared_ptr<class espressopp::System> system, std::shared_ptr<VerletListAdress> _verletList);
 
         virtual ~PIAdressIntegrator();
 
-        shared_ptr<VerletListAdress> verletList;
+        std::shared_ptr<VerletListAdress> verletList;
 
         void run(int nsteps);
 
@@ -92,8 +92,8 @@ namespace espressopp {
         void setConstKinMass(bool _constkinmass);
         bool getConstKinMass() { return constkinmass; }
 
-        void setVerletList(shared_ptr<VerletListAdress> _verletList);
-        shared_ptr<VerletListAdress> getVerletList() { return verletList; }
+        void setVerletList(std::shared_ptr<VerletListAdress> _verletList);
+        std::shared_ptr<VerletListAdress> getVerletList() { return verletList; }
 
         real computeRingEnergy();
         real computeRingEnergyRaw();
@@ -144,7 +144,7 @@ namespace espressopp {
         std::vector< real > Eigenvalues;
         std::vector<real> tmpvals;
 
-        shared_ptr< esutil::RNG > rng;
+        std::shared_ptr< esutil::RNG > rng;
 
         void integrateV1(int t, bool doubletime);
         void integrateV2();

--- a/src/integrator/PIAdressIntegrator.py
+++ b/src/integrator/PIAdressIntegrator.py
@@ -51,8 +51,8 @@ Example:
         :param CLmassmultiplier: (default: 100.0) multiplier by which the higher modes' spring masses (if constKinMass = False also the kinetic masses) are increased in the classical region
         :param speedup: (default: True) If True, the higher modes' are not integrated in the classical region and also the intraatomistic forces between the Trotter beads are not calculated in the classical region
         :param KTI: (default: False) If True, the particles' resolution parameters and adaptive masses are not updated but can be set by hand everywhere. This is necessary when running Kirkwood Thermodynamic Integration (KTI)
-        :type system: shared_ptr<System>
-        :type verletlist: shared_ptr<VerletListAdress>
+        :type system: std::shared_ptr<System>
+        :type verletlist: std::shared_ptr<VerletListAdress>
         :type timestep: real
         :type sSteps: int
         :type mSteps: int
@@ -81,7 +81,7 @@ Example:
         Gets the VerletList.
 
         :return: the Adress VerletList
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.integrator.PIAdressIntegrator.setTimeStep(timestep)
 

--- a/src/integrator/Rattle.cpp
+++ b/src/integrator/Rattle.cpp
@@ -39,7 +39,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(Rattle::theLogger, "Rattle");
 
-    Rattle::Rattle(shared_ptr<System> _system, 
+    Rattle::Rattle(std::shared_ptr<System> _system,
         real _maxit, real _tol, real _rptol)
     : Extension(_system),
         maxit(_maxit), tol(_tol), rptol(_rptol) {
@@ -306,8 +306,8 @@ namespace espressopp {
 
       using namespace espressopp::python;
 
-      class_<Rattle, shared_ptr<Rattle>, bases<Extension> >
-        ("integrator_Rattle", init<shared_ptr<System>, real, real, real>())
+      class_<Rattle, std::shared_ptr<Rattle>, bases<Extension> >
+        ("integrator_Rattle", init<std::shared_ptr<System>, real, real, real>())
          .def("addBond", &Rattle::addBond)
         ;
     }

--- a/src/integrator/Rattle.hpp
+++ b/src/integrator/Rattle.hpp
@@ -34,7 +34,7 @@ namespace espressopp {
     class Rattle : public Extension {
 
       public:
-        Rattle(shared_ptr<System> _system, real _maxit, real _tol, real _rptol);
+        Rattle(std::shared_ptr<System> _system, real _maxit, real _tol, real _rptol);
         ~Rattle();        
 
         void addBond(int pid1, int pid2, real constraintDist, real mass1, real mass2);

--- a/src/integrator/Settle.cpp
+++ b/src/integrator/Settle.cpp
@@ -37,7 +37,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(Settle::theLogger, "Settle");
 
-    Settle::Settle(shared_ptr<System> _system, shared_ptr<FixedTupleListAdress> _fixedTupleList,
+    Settle::Settle(std::shared_ptr<System> _system, std::shared_ptr<FixedTupleListAdress> _fixedTupleList,
       real _mO, real _mH, real _distHH, real _distOH)
     : Extension(_system), fixedTupleList(_fixedTupleList),
       mO(_mO), mH(_mH), distHH(_distHH), distOH(_distOH){
@@ -385,8 +385,8 @@ namespace espressopp {
 
       void (Settle::*pyAdd)(longint pid) = &Settle::add;
 
-      class_<Settle, shared_ptr<Settle>, bases<Extension> >
-        ("integrator_Settle", init<shared_ptr<System>, shared_ptr<FixedTupleListAdress>, real, real, real, real>())
+      class_<Settle, std::shared_ptr<Settle>, bases<Extension> >
+        ("integrator_Settle", init<std::shared_ptr<System>, std::shared_ptr<FixedTupleListAdress>, real, real, real, real>())
         .def("add", pyAdd)
         ;
     }

--- a/src/integrator/Settle.hpp
+++ b/src/integrator/Settle.hpp
@@ -41,7 +41,7 @@ namespace espressopp {
     class Settle : public Extension {
 
         public:
-            Settle(shared_ptr<System> _system, shared_ptr<FixedTupleListAdress> _fixedTupleList,
+            Settle(std::shared_ptr<System> _system, std::shared_ptr<FixedTupleListAdress> _fixedTupleList,
             		real mO, real mH, real distHH, real distOH);
             ~Settle();
 
@@ -70,7 +70,7 @@ namespace espressopp {
     	    typedef boost::unordered_map<longint, Triple<Real3D, Real3D, Real3D> > OldPos;
     	    OldPos oldPos;
 
-	    shared_ptr<FixedTupleListAdress> fixedTupleList;
+	    std::shared_ptr<FixedTupleListAdress> fixedTupleList;
 	    void connect();
 	    void disconnect();
             static LOG4ESPP_DECL_LOGGER(theLogger);

--- a/src/integrator/StochasticVelocityRescaling.cpp
+++ b/src/integrator/StochasticVelocityRescaling.cpp
@@ -41,7 +41,7 @@ LOG4ESPP_LOGGER(StochasticVelocityRescaling::theLogger,
 		"StochasticVelocityRescaling");
 
 StochasticVelocityRescaling::StochasticVelocityRescaling(
-		shared_ptr<System> system) :
+		std::shared_ptr<System> system) :
 		Extension(system) {
 	temperature = 0.0;
 	coupling = 1; //tau_t coupling
@@ -173,7 +173,7 @@ real StochasticVelocityRescaling::stochasticVR_sumGaussians(const int n) {
 }
 
 real StochasticVelocityRescaling::stochasticVR_pullEkin(real Ekin,
-		real Ekin_ref, int dof, real taut, shared_ptr<esutil::RNG> rng) {
+		real Ekin_ref, int dof, real taut, std::shared_ptr<esutil::RNG> rng) {
 	real factor, rr;
 
 	/*
@@ -258,9 +258,9 @@ void StochasticVelocityRescaling::registerPython() {
 
 	using namespace espressopp::python;
 
-	class_<StochasticVelocityRescaling, shared_ptr<StochasticVelocityRescaling>, bases<Extension> >
+	class_<StochasticVelocityRescaling, std::shared_ptr<StochasticVelocityRescaling>, bases<Extension> >
 
-	("integrator_StochasticVelocityRescaling", init<shared_ptr<System> >())
+	("integrator_StochasticVelocityRescaling", init<std::shared_ptr<System> >())
 
 	.add_property("temperature", &StochasticVelocityRescaling::getTemperature,
 			&StochasticVelocityRescaling::setTemperature).add_property(

--- a/src/integrator/StochasticVelocityRescaling.hpp
+++ b/src/integrator/StochasticVelocityRescaling.hpp
@@ -39,7 +39,7 @@ namespace integrator {
 
 class GammaDistribution {
 public:
-	GammaDistribution(shared_ptr<esutil::RNG> _rng) :
+	GammaDistribution(std::shared_ptr<esutil::RNG> _rng) :
 			rng(_rng) {
 	}
 	virtual ~GammaDistribution() {
@@ -48,13 +48,13 @@ public:
 	virtual real drawNumber(const unsigned int alpha) = 0;
 
 protected:
-	shared_ptr<esutil::RNG> rng;
+	std::shared_ptr<esutil::RNG> rng;
 };
 
 /** Gamma distribution, from Boost */
 class GammaDistributionBoost: public GammaDistribution {
 public:
-	GammaDistributionBoost(shared_ptr<esutil::RNG> _rng) :
+	GammaDistributionBoost(std::shared_ptr<esutil::RNG> _rng) :
 			GammaDistribution(_rng) {
 	}
 	real drawNumber(const unsigned int ia);
@@ -63,7 +63,7 @@ public:
 /** Gamma distribution, from Numerical Recipes, 2nd edition, pages 292 & 293 */
 class GammaDistributionNR2nd: public GammaDistribution {
 public:
-	GammaDistributionNR2nd(shared_ptr<esutil::RNG> _rng) :
+	GammaDistributionNR2nd(std::shared_ptr<esutil::RNG> _rng) :
 			GammaDistribution(_rng) {
 	}
 	real drawNumber(const unsigned int ia);
@@ -72,7 +72,7 @@ public:
 /** Gamma distribution, from Numerical Recipes, 3rd edition, pages 370 & 371 */
 class GammaDistributionNR3rd: public GammaDistribution {
 public:
-	GammaDistributionNR3rd(shared_ptr<esutil::RNG> _rng) :
+	GammaDistributionNR3rd(std::shared_ptr<esutil::RNG> _rng) :
 			GammaDistribution(_rng) {
 	}
 	real drawNumber(const unsigned int ia);
@@ -82,7 +82,7 @@ class StochasticVelocityRescaling: public Extension {
 
 public:
 
-	StochasticVelocityRescaling(shared_ptr<System> system);
+	StochasticVelocityRescaling(std::shared_ptr<System> system);
 
 	void setTemperature(real temperature);
 
@@ -105,7 +105,7 @@ public:
 	 *  taut: coupling time/strength
 	 *  */
 	real stochasticVR_pullEkin(real Ekin, real Ekin_ref, int dof,
-			real taut, shared_ptr<esutil::RNG> rng);
+			real taut, std::shared_ptr<esutil::RNG> rng);
 
 	/** Register this class so it can be used from Python. */
 	static void registerPython();
@@ -122,7 +122,7 @@ private:
 
   void initialize();
 
-	shared_ptr<esutil::RNG> rng; //!< random number generator
+	std::shared_ptr<esutil::RNG> rng; //!< random number generator
 
 	GammaDistribution *gammaDist;
 

--- a/src/integrator/TDforce.cpp
+++ b/src/integrator/TDforce.cpp
@@ -41,7 +41,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(TDforce::theLogger, "TDforce");
 
-    TDforce::TDforce(shared_ptr<System> system, shared_ptr<VerletListAdress> _verletList, real _startdist, real _enddist, int _edgeweightmultiplier, bool _slow)
+    TDforce::TDforce(std::shared_ptr<System> system, std::shared_ptr<VerletListAdress> _verletList, real _startdist, real _enddist, int _edgeweightmultiplier, bool _slow)
     :Extension(system), verletList(_verletList), startdist(_startdist), enddist(_enddist), edgeweightmultiplier(_edgeweightmultiplier), slow(_slow) {
 
         // startdist & enddist are the distances between which the TD force actually acts.
@@ -87,17 +87,17 @@ namespace espressopp {
         Table table;
 
         if (itype == 1) { // create a new InterpolationLinear
-            table = make_shared <interaction::InterpolationLinear> ();
+            table = std::make_shared <interaction::InterpolationLinear> ();
             table->read(world, _filename);
         }
 
         else if (itype == 2) { // create a new InterpolationAkima
-            table = make_shared <interaction::InterpolationAkima> ();
+            table = std::make_shared <interaction::InterpolationAkima> ();
             table->read(world, _filename);
         }
 
         else if (itype == 3) { // create a new InterpolationCubic
-            table = make_shared <interaction::InterpolationCubic> ();
+            table = std::make_shared <interaction::InterpolationCubic> ();
             table->read(world, _filename);
         }
 
@@ -363,8 +363,8 @@ namespace espressopp {
       void (TDforce::*pyAddForce)(int itype, const char* filename, int type)
                         = &TDforce::addForce;
 
-      class_<TDforce, shared_ptr<TDforce>, bases<Extension> >
-        ("integrator_TDforce", init< shared_ptr<System>, shared_ptr<VerletListAdress>, real, real, int, bool >())
+      class_<TDforce, std::shared_ptr<TDforce>, bases<Extension> >
+        ("integrator_TDforce", init< std::shared_ptr<System>, std::shared_ptr<VerletListAdress>, real, real, int, bool >())
         .add_property("filename", &TDforce::getFilename)
         .def("connect", &TDforce::connect)
         .def("disconnect", &TDforce::disconnect)

--- a/src/integrator/TDforce.hpp
+++ b/src/integrator/TDforce.hpp
@@ -47,12 +47,12 @@ namespace espressopp {
     class TDforce : public Extension {
 
       public:
-        shared_ptr<VerletListAdress> verletList;
+        std::shared_ptr<VerletListAdress> verletList;
         real startdist;
         real enddist;
         int edgeweightmultiplier;
         bool slow;
-        TDforce(shared_ptr<System> system, shared_ptr<VerletListAdress> _verletList, real _startdist = 0.0, real _enddist = 0.0, int _edgeweightmultiplier = 1, bool _slow = false);
+        TDforce(std::shared_ptr<System> system, std::shared_ptr<VerletListAdress> _verletList, real _startdist = 0.0, real _enddist = 0.0, int _edgeweightmultiplier = 1, bool _slow = false);
 
         ~TDforce();
 
@@ -76,7 +76,7 @@ namespace espressopp {
         Real3D center; // center of adress zone, from verletlistadress (assumes only one point as center)
         bool sphereAdr; // true: adress region is spherical centered on point x,y,z or particle pid; false: adress region is slab centered on point x or particle pid, from verletlistadres
         std::string filename;
-        typedef shared_ptr <interaction::Interpolation> Table;
+        typedef std::shared_ptr <interaction::Interpolation> Table;
         std::unordered_map<int, Table> forces; // map type to force
 
         static LOG4ESPP_DECL_LOGGER(theLogger);

--- a/src/integrator/TDforce.py
+++ b/src/integrator/TDforce.py
@@ -50,8 +50,8 @@ Example - how to turn on thermodynamic force for multiple moving spherical regio
         :param enddist: (default: 0.0) end distance from center up to which the TD force is actually applied. Needs to be altered when using several moving spherical regions (not used for static or single moving region)
         :param edgeweightmultiplier: (default: 20) interpolation parameter for multiple overlapping spherical regions (see Kreis et al., JCTC doi: 10.1021/acs.jctc.6b00440), the default should be fine for most applications (not used for static or single moving region)
         :param slow: (default: False) When used with RESPA Velocity Verlet, this flag decides whether the TD force is applied together with the slow, less frequently updated forces (slow=True) or with the fast, more frequently updated (slow=False) forces.
-        :type system: shared_ptr<System>
-        :type verletlist: shared_ptr<VerletListAdress>
+        :type system: std::shared_ptr<System>
+        :type verletlist: std::shared_ptr<VerletListAdress>
         :type startdist: real
         :type enddist: real
         :type edgeweightmultiplier: int

--- a/src/integrator/VelocityVerlet.cpp
+++ b/src/integrator/VelocityVerlet.cpp
@@ -48,7 +48,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(VelocityVerlet::theLogger, "VelocityVerlet");
 
-    VelocityVerlet::VelocityVerlet(shared_ptr< System > system) : MDIntegrator(system)
+    VelocityVerlet::VelocityVerlet(std::shared_ptr< System > system) : MDIntegrator(system)
     {
       LOG4ESPP_INFO(theLogger, "construct VelocityVerlet");
       resortFlag = true;
@@ -423,7 +423,7 @@ namespace espressopp {
 
       // Note: use noncopyable and no_init for abstract classes
       class_<VelocityVerlet, bases<MDIntegrator>, boost::noncopyable >
-        ("integrator_VelocityVerlet", init< shared_ptr<System> >())
+        ("integrator_VelocityVerlet", init< std::shared_ptr<System> >())
         .def("getTimers", &wrapGetTimers)
         .def("resetTimers", &VelocityVerlet::resetTimers)
         .def("getNumResorts", &VelocityVerlet::getNumResorts)

--- a/src/integrator/VelocityVerlet.hpp
+++ b/src/integrator/VelocityVerlet.hpp
@@ -39,7 +39,7 @@ namespace espressopp {
 
       public:
 
-        VelocityVerlet(shared_ptr<class espressopp::System> system);
+        VelocityVerlet(std::shared_ptr<class espressopp::System> system);
 
         virtual ~VelocityVerlet();
 

--- a/src/integrator/VelocityVerletOnGroup.cpp
+++ b/src/integrator/VelocityVerletOnGroup.cpp
@@ -40,8 +40,8 @@ namespace espressopp {
     using namespace iterator;
     using namespace esutil;
 
-    VelocityVerletOnGroup::VelocityVerletOnGroup(shared_ptr< System > system,
-            shared_ptr<class espressopp::ParticleGroup> group_) : MDIntegrator(system), group(group_)
+    VelocityVerletOnGroup::VelocityVerletOnGroup(std::shared_ptr< System > system,
+            std::shared_ptr<class espressopp::ParticleGroup> group_) : MDIntegrator(system), group(group_)
     {
       LOG4ESPP_INFO(theLogger, "construct VelocityVerletOnGroup");
 
@@ -58,7 +58,7 @@ namespace espressopp {
 
     /*****************************************************************************/
 
-    void VelocityVerletOnGroup::setLangevin(shared_ptr< LangevinThermostat > _langevin)
+    void VelocityVerletOnGroup::setLangevin(std::shared_ptr< LangevinThermostat > _langevin)
     {
       LOG4ESPP_INFO(theLogger, "set Langevin thermostat");
       langevin = _langevin;
@@ -398,7 +398,7 @@ namespace espressopp {
       // Note: use noncopyable and no_init for abstract classes
 
       class_<VelocityVerletOnGroup, bases<MDIntegrator>, boost::noncopyable >
-        ("integrator_VelocityVerletOnGroup", init< shared_ptr<System>,  shared_ptr<ParticleGroup> >())
+        ("integrator_VelocityVerletOnGroup", init< std::shared_ptr<System>,  std::shared_ptr<ParticleGroup> >())
 
         .add_property("langevin", &VelocityVerletOnGroup::getLangevin, &VelocityVerletOnGroup::setLangevin)
         ;

--- a/src/integrator/VelocityVerletOnGroup.hpp
+++ b/src/integrator/VelocityVerletOnGroup.hpp
@@ -39,13 +39,13 @@ namespace espressopp {
 
       public:
 
-        VelocityVerletOnGroup(shared_ptr<class espressopp::System> system, shared_ptr<class espressopp::ParticleGroup> group_);
+        VelocityVerletOnGroup(std::shared_ptr<class espressopp::System> system, std::shared_ptr<class espressopp::ParticleGroup> group_);
 
         virtual ~VelocityVerletOnGroup();
 
-        void setLangevin(shared_ptr<class LangevinThermostat> langevin);
+        void setLangevin(std::shared_ptr<class LangevinThermostat> langevin);
 
-        shared_ptr<class LangevinThermostat> getLangevin() { return langevin; }
+        std::shared_ptr<class LangevinThermostat> getLangevin() { return langevin; }
 
         void run(int nsteps);
 
@@ -60,8 +60,8 @@ namespace espressopp {
 
         real maxCut;
 
-        shared_ptr< class LangevinThermostat > langevin;  //!< Langevin thermostat if available
-        shared_ptr<class espressopp::ParticleGroup> group;
+        std::shared_ptr< class LangevinThermostat > langevin;  //!< Langevin thermostat if available
+        std::shared_ptr<class espressopp::ParticleGroup> group;
 
         /** Method updates particle positions and velocities.
 

--- a/src/integrator/VelocityVerletOnRadius.cpp
+++ b/src/integrator/VelocityVerletOnRadius.cpp
@@ -36,7 +36,7 @@ namespace espressopp {
 
     LOG4ESPP_LOGGER(VelocityVerletOnRadius::theLogger, "VelocityVerletOnRadius");
 
-    VelocityVerletOnRadius::VelocityVerletOnRadius(shared_ptr<System> system, real _radialDampingMass)
+    VelocityVerletOnRadius::VelocityVerletOnRadius(std::shared_ptr<System> system, real _radialDampingMass)
       : Extension(system), radialDampingMass(_radialDampingMass)
     {
       LOG4ESPP_INFO(theLogger, "VelocityVerletOnRadius constructed");
@@ -107,8 +107,8 @@ namespace espressopp {
 
       using namespace espressopp::python;
 
-      class_<VelocityVerletOnRadius, shared_ptr<VelocityVerletOnRadius>, bases<Extension> >
-        ("integrator_VelocityVerletOnRadius", init< shared_ptr< System >, real >())
+      class_<VelocityVerletOnRadius, std::shared_ptr<VelocityVerletOnRadius>, bases<Extension> >
+        ("integrator_VelocityVerletOnRadius", init< std::shared_ptr< System >, real >())
         .def("connect", &VelocityVerletOnRadius::connect)
         .def("disconnect", &VelocityVerletOnRadius::disconnect)
         .add_property("radialDampingMass" ,&VelocityVerletOnRadius::getRadialDampingMass, &VelocityVerletOnRadius::setRadialDampingMass )

--- a/src/integrator/VelocityVerletOnRadius.hpp
+++ b/src/integrator/VelocityVerletOnRadius.hpp
@@ -36,7 +36,7 @@ namespace espressopp {
 
     class VelocityVerletOnRadius : public Extension {
       public:
-        VelocityVerletOnRadius(shared_ptr< System > _system, real _radialDampingMass);
+        VelocityVerletOnRadius(std::shared_ptr< System > _system, real _radialDampingMass);
         virtual ~VelocityVerletOnRadius() {};
 
         void setRadialDampingMass(real _radialDampingMass) {

--- a/src/integrator/VelocityVerletRESPA.cpp
+++ b/src/integrator/VelocityVerletRESPA.cpp
@@ -37,7 +37,7 @@ namespace espressopp {
     using namespace esutil;
     using namespace boost::python;
 
-    VelocityVerletRESPA::VelocityVerletRESPA(shared_ptr< System > system) : MDIntegrator(system)
+    VelocityVerletRESPA::VelocityVerletRESPA(std::shared_ptr< System > system) : MDIntegrator(system)
     {
       resortFlag = true;
       maxDist    = 0.0;
@@ -232,7 +232,7 @@ namespace espressopp {
 
       // Note: use noncopyable and no_init for abstract classes
       class_<VelocityVerletRESPA, bases<MDIntegrator>, boost::noncopyable >
-      ("integrator_VelocityVerletRESPA", init< shared_ptr<System> >())
+      ("integrator_VelocityVerletRESPA", init< std::shared_ptr<System> >())
       .def("setmultistep", &VelocityVerletRESPA::setmultistep)
       .def("getmultistep", &VelocityVerletRESPA::getmultistep)
       .add_property("multistep", &VelocityVerletRESPA::getmultistep, &VelocityVerletRESPA::setmultistep)

--- a/src/integrator/VelocityVerletRESPA.hpp
+++ b/src/integrator/VelocityVerletRESPA.hpp
@@ -34,7 +34,7 @@ namespace espressopp {
 
       public:
 
-        VelocityVerletRESPA(shared_ptr<class espressopp::System> system);
+        VelocityVerletRESPA(std::shared_ptr<class espressopp::System> system);
 
         virtual ~VelocityVerletRESPA();
 

--- a/src/integrator/VelocityVerletRESPA.py
+++ b/src/integrator/VelocityVerletRESPA.py
@@ -37,7 +37,7 @@ Example:
         Constructs the VelocityVerletRESPA object.
 
         :param system: system object
-        :type system: shared_ptr<System>
+        :type system: std::shared_ptr<System>
 
 .. function:: espressopp.integrator.VelocityVerletRESPA.setmultistep(multistep)
 

--- a/src/interaction/AngularCosineSquared.cpp
+++ b/src/interaction/AngularCosineSquared.cpp
@@ -43,9 +43,9 @@ namespace espressopp {
       FixedTripleListAngularCosineSquared;
       class_< FixedTripleListAngularCosineSquared, bases< Interaction > >
         ("interaction_FixedTripleListAngularCosineSquared",
-                init<shared_ptr<System>,
-                    shared_ptr<FixedTripleList>,
-                    shared_ptr<AngularCosineSquared> >())
+                init<std::shared_ptr<System>,
+                    std::shared_ptr<FixedTripleList>,
+                    std::shared_ptr<AngularCosineSquared> >())
         .def("setPotential", &FixedTripleListAngularCosineSquared::setPotential)
         .def("getFixedTripleList", &FixedTripleListAngularCosineSquared::getFixedTripleList)
       ;

--- a/src/interaction/AngularCosineSquared.py
+++ b/src/interaction/AngularCosineSquared.py
@@ -42,7 +42,7 @@ This is done via:
 
 .. py:class:: espressopp.interaction.FixedTripleListAngularCosineSquared (system, fixed_triple_list, potential)
 
-    :param shared_ptr system: system object
+    :param std::shared_ptr system: system object
     :param list fixed_triple_list: a fixed list of all triples in the system
     :param potential: triple potential (in this case, :py:class:`espressopp.interaction.AngularCosineSquared`).
     :rtype: interaction

--- a/src/interaction/AngularHarmonic.cpp
+++ b/src/interaction/AngularHarmonic.cpp
@@ -44,10 +44,10 @@ namespace espressopp {
         
       class_ <FixedTripleListAngularHarmonic, bases <Interaction> >
         ("interaction_FixedTripleListAngularHarmonic",
-           init<shared_ptr<System>,
-                shared_ptr<FixedTripleList>,
-                shared_ptr<AngularHarmonic> >())
-        .def(init< shared_ptr<System>, shared_ptr<FixedTripleListAdress>, shared_ptr<AngularHarmonic> >())
+           init<std::shared_ptr<System>,
+                std::shared_ptr<FixedTripleList>,
+                std::shared_ptr<AngularHarmonic> >())
+        .def(init< std::shared_ptr<System>, std::shared_ptr<FixedTripleListAdress>, std::shared_ptr<AngularHarmonic> >())
         .def("setPotential", &FixedTripleListAngularHarmonic::setPotential)
         .def("getFixedTripleList", &FixedTripleListAngularHarmonic::getFixedTripleList);
       ;

--- a/src/interaction/AngularHarmonic.py
+++ b/src/interaction/AngularHarmonic.py
@@ -41,7 +41,7 @@ This is done via:
 
 .. py:class:: espressopp.interaction.FixedTripleListAngularHarmonic (system, fixed_triple_list, potential)
 
-    :param shared_ptr system: system object
+    :param std::shared_ptr system: system object
     :param list fixed_triple_list: a fixed list of all triples in the system
     :param potential: triple potential (in this case, :py:class:`espressopp.interaction.AngularHarmonic`).
     :rtype: interaction

--- a/src/interaction/AngularPotential.hpp
+++ b/src/interaction/AngularPotential.hpp
@@ -53,12 +53,12 @@ namespace espressopp {
       virtual void setCutoff(real _cutoff) = 0;
       virtual real getCutoff() const = 0;
 
-      virtual void setColVarBondList(const shared_ptr<FixedPairList>& fpl) = 0;
-      virtual shared_ptr<FixedPairList> getColVarBondList() const = 0;
-      virtual void setColVarAngleList(const shared_ptr<FixedTripleList>& fpl) = 0;
-      virtual shared_ptr<FixedTripleList> getColVarAngleList() const = 0;
-      virtual void setColVarDihedList(const shared_ptr<FixedQuadrupleList>& fpl) = 0;
-      virtual shared_ptr<FixedQuadrupleList> getColVarDihedList() const = 0;
+      virtual void setColVarBondList(const std::shared_ptr<FixedPairList>& fpl) = 0;
+      virtual std::shared_ptr<FixedPairList> getColVarBondList() const = 0;
+      virtual void setColVarAngleList(const std::shared_ptr<FixedTripleList>& fpl) = 0;
+      virtual std::shared_ptr<FixedTripleList> getColVarAngleList() const = 0;
+      virtual void setColVarDihedList(const std::shared_ptr<FixedQuadrupleList>& fpl) = 0;
+      virtual std::shared_ptr<FixedQuadrupleList> getColVarDihedList() const = 0;
 
       virtual void setColVar(const RealND& cv) = 0;
       virtual void setColVar(const Real3D& dist12,
@@ -102,12 +102,12 @@ namespace espressopp {
       virtual void setCutoff(real _cutoff);
       virtual real getCutoff() const;
 
-      virtual void setColVarBondList(const shared_ptr<FixedPairList>& fpl);
-      virtual shared_ptr<FixedPairList> getColVarBondList() const;
-      virtual void setColVarAngleList(const shared_ptr<FixedTripleList>& fpl);
-      virtual shared_ptr<FixedTripleList> getColVarAngleList() const;
-      virtual void setColVarDihedList(const shared_ptr<FixedQuadrupleList>& fpl);
-      virtual shared_ptr<FixedQuadrupleList> getColVarDihedList() const;
+      virtual void setColVarBondList(const std::shared_ptr<FixedPairList>& fpl);
+      virtual std::shared_ptr<FixedPairList> getColVarBondList() const;
+      virtual void setColVarAngleList(const std::shared_ptr<FixedTripleList>& fpl);
+      virtual std::shared_ptr<FixedTripleList> getColVarAngleList() const;
+      virtual void setColVarDihedList(const std::shared_ptr<FixedQuadrupleList>& fpl);
+      virtual std::shared_ptr<FixedQuadrupleList> getColVarDihedList() const;
 
       virtual void setColVar(const RealND& cv);
       virtual void setColVar(const Real3D& dist12,
@@ -143,11 +143,11 @@ namespace espressopp {
       real cutoff;
       real cutoffSqr;
       // List of bonds that correlate with the angle potential
-      shared_ptr<FixedPairList> colVarBondList;
+      std::shared_ptr<FixedPairList> colVarBondList;
       // List of angles that correlate with the bond potential
-      shared_ptr<FixedTripleList> colVarAngleList;
+      std::shared_ptr<FixedTripleList> colVarAngleList;
       // List of dihedrals that correlate with the dihedral potential
-      shared_ptr<FixedQuadrupleList> colVarDihedList;
+      std::shared_ptr<FixedQuadrupleList> colVarDihedList;
       // Collective variables: first itself, then bonds and dihedrals
       RealND colVar;
 
@@ -188,12 +188,12 @@ namespace espressopp {
     template < class Derived >
     inline void
     AngularPotentialTemplate< Derived >::
-    setColVarBondList(const shared_ptr < FixedPairList >& _fpl) {
+    setColVarBondList(const std::shared_ptr < FixedPairList >& _fpl) {
       colVarBondList = _fpl;
     }
 
     template < class Derived >
-    inline shared_ptr < FixedPairList >
+    inline std::shared_ptr < FixedPairList >
     AngularPotentialTemplate< Derived >::
     getColVarBondList() const
     { return colVarBondList; }
@@ -202,12 +202,12 @@ namespace espressopp {
     template < class Derived >
     inline void
     AngularPotentialTemplate< Derived >::
-    setColVarAngleList(const shared_ptr < FixedTripleList >& _fpl) {
+    setColVarAngleList(const std::shared_ptr < FixedTripleList >& _fpl) {
       colVarAngleList = _fpl;
     }
 
     template < class Derived >
-    inline shared_ptr < FixedTripleList >
+    inline std::shared_ptr < FixedTripleList >
     AngularPotentialTemplate< Derived >::
     getColVarAngleList() const
     { return colVarAngleList; }
@@ -216,12 +216,12 @@ namespace espressopp {
     template < class Derived >
     inline void
     AngularPotentialTemplate< Derived >::
-    setColVarDihedList(const shared_ptr < FixedQuadrupleList >& _fpl) {
+    setColVarDihedList(const std::shared_ptr < FixedQuadrupleList >& _fpl) {
       colVarDihedList = _fpl;
     }
 
     template < class Derived >
-    inline shared_ptr < FixedQuadrupleList >
+    inline std::shared_ptr < FixedQuadrupleList >
     AngularPotentialTemplate< Derived >::
     getColVarDihedList() const
     { return colVarDihedList; }

--- a/src/interaction/CellListAllPairsInteractionTemplate.hpp
+++ b/src/interaction/CellListAllPairsInteractionTemplate.hpp
@@ -40,7 +40,7 @@ namespace espressopp {
       typedef _Potential Potential;
     public:
       CellListAllPairsInteractionTemplate
-      (shared_ptr < storage::Storage > _storage)
+      (std::shared_ptr < storage::Storage > _storage)
       : storage(_storage){
         potentialArray = esutil::Array2D<Potential, esutil::enlarge>(0, 0, Potential());
         ntypes=0;
@@ -82,7 +82,7 @@ namespace espressopp {
     protected:
       int ntypes;
       esutil::Array2D< Potential, esutil::enlarge > potentialArray;
-      shared_ptr< storage::Storage > storage;
+      std::shared_ptr< storage::Storage > storage;
     };
 
     //////////////////////////////////////////////////

--- a/src/interaction/CellListAllParticlesInteractionTemplate.hpp
+++ b/src/interaction/CellListAllParticlesInteractionTemplate.hpp
@@ -38,10 +38,10 @@ namespace espressopp {
       typedef _Potential Potential;
     public:
       CellListAllParticlesInteractionTemplate
-      (shared_ptr < storage::Storage > _storage, shared_ptr < Potential > _potential)
+      (std::shared_ptr < storage::Storage > _storage, std::shared_ptr < Potential > _potential)
         : storage(_storage), potential(_potential) {}
 
-      shared_ptr< Potential > getPotential() {
+      std::shared_ptr< Potential > getPotential() {
         return potential;
       }
 
@@ -62,8 +62,8 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr< storage::Storage > storage;
-      shared_ptr< Potential > potential;
+      std::shared_ptr< storage::Storage > storage;
+      std::shared_ptr< Potential > potential;
     };
 
     //////////////////////////////////////////////////

--- a/src/interaction/ConstrainCOM.cpp
+++ b/src/interaction/ConstrainCOM.cpp
@@ -45,7 +45,7 @@ namespace espressopp {
 	    
 	    class_< FixedLocalTupleListConstrainCOM, bases< Interaction > >
 		("interaction_FixedLocalTupleListConstrainCOM",
-		 init< shared_ptr<System>, shared_ptr<FixedLocalTupleList>, shared_ptr<ConstrainCOM> >())
+		 init< std::shared_ptr<System>, std::shared_ptr<FixedLocalTupleList>, std::shared_ptr<ConstrainCOM> >())
 		.def("getPotential", &FixedLocalTupleListConstrainCOM::getPotential)
 		.def("setCom", &FixedLocalTupleListConstrainCOM::setCom)
 		;

--- a/src/interaction/ConstrainRG.cpp
+++ b/src/interaction/ConstrainRG.cpp
@@ -45,7 +45,7 @@ namespace espressopp {
 	    
 	    class_< FixedLocalTupleListConstrainRG, bases< Interaction > >
 		("interaction_FixedLocalTupleListConstrainRG",
-		 init< shared_ptr<System>, shared_ptr<FixedLocalTupleList>, shared_ptr<ConstrainRG> >())
+		 init< std::shared_ptr<System>, std::shared_ptr<FixedLocalTupleList>, std::shared_ptr<ConstrainRG> >())
 		.def("getPotential", &FixedLocalTupleListConstrainRG::getPotential)
 		.def("setRG", &FixedLocalTupleListConstrainRG::setRG)
 		;

--- a/src/interaction/Cosine.cpp
+++ b/src/interaction/Cosine.cpp
@@ -43,9 +43,9 @@ namespace espressopp {
         FixedTripleListCosine;
       class_< FixedTripleListCosine, bases< Interaction > >
         ("interaction_FixedTripleListCosine",
-           init<shared_ptr<System>,
-                shared_ptr<FixedTripleList>,
-                shared_ptr<Cosine> >())
+           init<std::shared_ptr<System>,
+                std::shared_ptr<FixedTripleList>,
+                std::shared_ptr<Cosine> >())
         .def("setPotential", &FixedTripleListCosine::setPotential)
         .def("getFixedTripleList", &FixedTripleListCosine::getFixedTripleList);
       ;

--- a/src/interaction/CoulombKSpaceEwald.cpp
+++ b/src/interaction/CoulombKSpaceEwald.cpp
@@ -30,7 +30,7 @@ namespace espressopp {
 
     typedef class CellListAllParticlesInteractionTemplate <CoulombKSpaceEwald> CellListCoulombKSpaceEwald;
 
-    CoulombKSpaceEwald::CoulombKSpaceEwald(shared_ptr< System > _system, real _prefactor, real _alpha, int _kmax){
+    CoulombKSpaceEwald::CoulombKSpaceEwald(std::shared_ptr< System > _system, real _prefactor, real _alpha, int _kmax){
       system = _system;
       prefactor = _prefactor;
       alpha = _alpha;
@@ -67,14 +67,14 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_< CoulombKSpaceEwald, bases< Potential > >
-    	("interaction_CoulombKSpaceEwald", init< shared_ptr< System >, real, real, int >())
+    	("interaction_CoulombKSpaceEwald", init< std::shared_ptr< System >, real, real, int >())
     	.add_property("prefactor", &CoulombKSpaceEwald::getPrefactor, &CoulombKSpaceEwald::setPrefactor)
     	.add_property("alpha", &CoulombKSpaceEwald::getAlpha, &CoulombKSpaceEwald::setAlpha)
     	.add_property("kmax", &CoulombKSpaceEwald::getKMax, &CoulombKSpaceEwald::setKMax)
       ;
 
       class_< CellListCoulombKSpaceEwald, bases< Interaction > >
-        ("interaction_CellListCoulombKSpaceEwald",	init< shared_ptr< storage::Storage >, shared_ptr< CoulombKSpaceEwald > >())
+        ("interaction_CellListCoulombKSpaceEwald",	init< std::shared_ptr< storage::Storage >, std::shared_ptr< CoulombKSpaceEwald > >())
         .def("getPotential", &CellListCoulombKSpaceEwald::getPotential)
 	  ;
 

--- a/src/interaction/CoulombKSpaceEwald.hpp
+++ b/src/interaction/CoulombKSpaceEwald.hpp
@@ -74,7 +74,7 @@ namespace espressopp {
       real alpha; // Ewald parameter
       int kmax; // cutoff in k space
       
-      shared_ptr< System > system; // we need the system object to be able to access the box
+      std::shared_ptr< System > system; // we need the system object to be able to access the box
                                    // dimensions, communicator, number of particles, signals
       
       real Lx, Ly, Lz; // local variable for system size
@@ -113,7 +113,7 @@ namespace espressopp {
     public:
       static void registerPython();
 
-      CoulombKSpaceEwald(shared_ptr< System > _system, real _prefactor, real _alpha, int _kmax);
+      CoulombKSpaceEwald(std::shared_ptr< System > _system, real _prefactor, real _alpha, int _kmax);
       
       ~CoulombKSpaceEwald();
       

--- a/src/interaction/CoulombKSpaceP3M.cpp
+++ b/src/interaction/CoulombKSpaceP3M.cpp
@@ -32,7 +32,7 @@ namespace espressopp {
     CellListCoulombKSpaceP3M;
 
     CoulombKSpaceP3M::
-    CoulombKSpaceP3M(shared_ptr< System > _system,
+    CoulombKSpaceP3M(std::shared_ptr< System > _system,
                      real _coulomb_prefactor,
                      real _alpha,
                      Int3D _M,
@@ -232,7 +232,7 @@ namespace espressopp {
 
       class_< CoulombKSpaceP3M, bases< Potential > >
       ("interaction_CoulombKSpaceP3M", 
-              init< shared_ptr<System>, real, real, Int3D, int, real, int >() )
+              init< std::shared_ptr<System>, real, real, Int3D, int, real, int >() )
     	.add_property("prefactor", &CoulombKSpaceP3M::getPrefactor, 
                                    &CoulombKSpaceP3M::setPrefactor);
     	//.add_property("alpha", &CoulombKSpaceP3M::getAlpha, &CoulombKSpaceP3M::setAlpha)
@@ -241,8 +241,8 @@ namespace espressopp {
 
       class_< CellListCoulombKSpaceP3M, bases< Interaction > >
         ("interaction_CellListCoulombKSpaceP3M",
-              init< shared_ptr< storage::Storage >,
-                    shared_ptr< CoulombKSpaceP3M > >())
+              init< std::shared_ptr< storage::Storage >,
+                    std::shared_ptr< CoulombKSpaceP3M > >())
         .def("getPotential", &CellListCoulombKSpaceP3M::getPotential)
 	  ;
 

--- a/src/interaction/CoulombKSpaceP3M.hpp
+++ b/src/interaction/CoulombKSpaceP3M.hpp
@@ -68,7 +68,7 @@ namespace espressopp {
     
     class CoulombKSpaceP3M : public PotentialTemplate< CoulombKSpaceP3M > {
     private:
-      shared_ptr< System > system; // we need the system object to be able to access the box
+      std::shared_ptr< System > system; // we need the system object to be able to access the box
                                    // dimensions, communicator, number of particles, signals
       
       Real3D d_mesh; // distance between two meshpoints
@@ -123,7 +123,7 @@ namespace espressopp {
     public:
       static void registerPython();
 
-      CoulombKSpaceP3M(shared_ptr< System > _system,
+      CoulombKSpaceP3M(std::shared_ptr< System > _system,
                        real _coulomb_prefactor,
                        real _alpha,
                        Int3D _M,

--- a/src/interaction/CoulombRSpace.cpp
+++ b/src/interaction/CoulombRSpace.cpp
@@ -46,7 +46,7 @@ namespace espressopp {
       ;
 
       class_< VerletListCoulombRSpace, bases< Interaction > >
-        ("interaction_VerletListCoulombRSpace", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListCoulombRSpace", init< std::shared_ptr<VerletList> >())
         .def("getVerletList", &VerletListCoulombRSpace::getVerletList)
         .def("setPotential", &VerletListCoulombRSpace::setPotential, return_value_policy< reference_existing_object >())
         .def("getPotential", &VerletListCoulombRSpace::getPotential, return_value_policy< reference_existing_object >())

--- a/src/interaction/CoulombTruncated.cpp
+++ b/src/interaction/CoulombTruncated.cpp
@@ -50,15 +50,15 @@ namespace espressopp {
       ;
 
       class_< VerletListCoulombTruncated, bases< Interaction > >
-        ("interaction_VerletListCoulombTruncated", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListCoulombTruncated", init< std::shared_ptr<VerletList> >())
         .def("setPotential", &VerletListCoulombTruncated::setPotential)
         .def("getPotential", &VerletListCoulombTruncated::getPotentialPtr)
         ;
 
       class_< FixedPairListTypesCoulombTruncated, bases< Interaction > >
         ("interaction_FixedPairListTypesCoulombTruncated",
-          init< shared_ptr<System>, shared_ptr<FixedPairList> >())
-        .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList> >())
+        .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress> >())
         .def("setPotential", &FixedPairListTypesCoulombTruncated::setPotential)
         ;
     }

--- a/src/interaction/CoulombTruncatedUniqueCharge.cpp
+++ b/src/interaction/CoulombTruncatedUniqueCharge.cpp
@@ -50,19 +50,19 @@ namespace espressopp {
     	;
 
       class_< VerletListCoulombTruncatedUniqueCharge, bases< Interaction > > 
-        ("interaction_VerletListCoulombTruncatedUniqueCharge", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListCoulombTruncatedUniqueCharge", init< std::shared_ptr<VerletList> >())
         .def("setPotential", &VerletListCoulombTruncatedUniqueCharge::setPotential)
         .def("getPotential", &VerletListCoulombTruncatedUniqueCharge::getPotentialPtr)
         ;
 
       class_< CellListCoulombTruncatedUniqueCharge, bases< Interaction > > 
-        ("interaction_CellListCoulombTruncatedUniqueCharge", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListCoulombTruncatedUniqueCharge", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListCoulombTruncatedUniqueCharge::setPotential)
 	;
 
       class_< FixedPairListCoulombTruncatedUniqueCharge, bases< Interaction > >
         ("interaction_FixedPairListCoulombTruncatedUniqueCharge",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<CoulombTruncatedUniqueCharge> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<CoulombTruncatedUniqueCharge> >())
         .def("setPotential", &FixedPairListCoulombTruncatedUniqueCharge::setPotential)
         ;
     }

--- a/src/interaction/DihedralHarmonic.cpp
+++ b/src/interaction/DihedralHarmonic.cpp
@@ -46,9 +46,9 @@ namespace espressopp {
       FixedQuadrupleListDihedralHarmonic;
       class_ <FixedQuadrupleListDihedralHarmonic, bases <Interaction> >
         ("interaction_FixedQuadrupleListDihedralHarmonic",
-                  init< shared_ptr<System>,
-                        shared_ptr<FixedQuadrupleList>,
-                        shared_ptr<DihedralHarmonic> >())
+                  init< std::shared_ptr<System>,
+                        std::shared_ptr<FixedQuadrupleList>,
+                        std::shared_ptr<DihedralHarmonic> >())
         .def("setPotential", &FixedQuadrupleListDihedralHarmonic::setPotential)
         .def("getFixedQuadrupleList", &FixedQuadrupleListDihedralHarmonic::getFixedQuadrupleList)
         ;
@@ -56,7 +56,7 @@ namespace espressopp {
         FixedQuadrupleListTypesDihedralHarmonic;
       class_< FixedQuadrupleListTypesDihedralHarmonic, bases< Interaction > >
         ("interaction_FixedQuadrupleListTypesDihedralHarmonic",
-         init< shared_ptr<System>, shared_ptr<FixedQuadrupleList> >())
+         init< std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleList> >())
         .def("setPotential", &FixedQuadrupleListTypesDihedralHarmonic::setPotential)
         .def("getPotential", &FixedQuadrupleListTypesDihedralHarmonic::getPotentialPtr)
         .def("setFixedQuadrupleList", &FixedQuadrupleListTypesDihedralHarmonic::setFixedQuadrupleList)

--- a/src/interaction/DihedralHarmonicCos.cpp
+++ b/src/interaction/DihedralHarmonicCos.cpp
@@ -43,9 +43,9 @@ namespace espressopp {
       FixedQuadrupleListDihedralHarmonicCos;
       class_ <FixedQuadrupleListDihedralHarmonicCos, bases <Interaction> >
         ("interaction_FixedQuadrupleListDihedralHarmonicCos",
-                  init< shared_ptr<System>,
-                        shared_ptr<FixedQuadrupleList>,
-                        shared_ptr<DihedralHarmonicCos> >())
+                  init< std::shared_ptr<System>,
+                        std::shared_ptr<FixedQuadrupleList>,
+                        std::shared_ptr<DihedralHarmonicCos> >())
         .def("setPotential", &FixedQuadrupleListDihedralHarmonicCos::setPotential)
         .def("getFixedQuadrupleList", &FixedQuadrupleListDihedralHarmonicCos::getFixedQuadrupleList)
         ;

--- a/src/interaction/DihedralHarmonicNCos.cpp
+++ b/src/interaction/DihedralHarmonicNCos.cpp
@@ -47,12 +47,12 @@ namespace espressopp {
       FixedQuadrupleListDihedralHarmonicNCos;
       class_ <FixedQuadrupleListDihedralHarmonicNCos, bases <Interaction> >
         ("interaction_FixedQuadrupleListDihedralHarmonicNCos",
-                  init< shared_ptr<System>,
-                        shared_ptr<FixedQuadrupleList>,
-                        shared_ptr<DihedralHarmonicNCos> >())
-        .def(init< shared_ptr<System>,
-                   shared_ptr<FixedQuadrupleListAdress>,
-                   shared_ptr<DihedralHarmonicNCos> >())
+                  init< std::shared_ptr<System>,
+                        std::shared_ptr<FixedQuadrupleList>,
+                        std::shared_ptr<DihedralHarmonicNCos> >())
+        .def(init< std::shared_ptr<System>,
+                   std::shared_ptr<FixedQuadrupleListAdress>,
+                   std::shared_ptr<DihedralHarmonicNCos> >())
         .def("setPotential", &FixedQuadrupleListDihedralHarmonicNCos::setPotential)
         .def("getFixedQuadrupleList", &FixedQuadrupleListDihedralHarmonicNCos::getFixedQuadrupleList)
         ;
@@ -61,7 +61,7 @@ namespace espressopp {
           FixedQuadrupleListTypesDihedralHarmonicNCos;
       class_< FixedQuadrupleListTypesDihedralHarmonicNCos, bases< Interaction > >
           ("interaction_FixedQuadrupleListTypesDihedralHarmonicNCos",
-           init< shared_ptr<System>, shared_ptr<FixedQuadrupleList> >())
+           init< std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleList> >())
           .def("setPotential", &FixedQuadrupleListTypesDihedralHarmonicNCos::setPotential)
           .def("getPotential", &FixedQuadrupleListTypesDihedralHarmonicNCos::getPotentialPtr)
           .def("setFixedQuadrupleList", &FixedQuadrupleListTypesDihedralHarmonicNCos::setFixedQuadrupleList)

--- a/src/interaction/DihedralPotential.hpp
+++ b/src/interaction/DihedralPotential.hpp
@@ -57,12 +57,12 @@ namespace espressopp {
       virtual void setCutoff(real _cutoff) = 0;
       virtual real getCutoff() const = 0;
 
-      virtual void setColVarBondList(const shared_ptr<FixedPairList>& fpl) = 0;
-      virtual shared_ptr<FixedPairList> getColVarBondList() const = 0;
-      virtual void setColVarAngleList(const shared_ptr<FixedTripleList>& ftl) = 0;
-      virtual shared_ptr<FixedTripleList> getColVarAngleList() const = 0;
-      virtual void setColVarDihedList(const shared_ptr<FixedQuadrupleList>& fql) = 0;
-      virtual shared_ptr<FixedQuadrupleList> getColVarDihedList() const = 0;
+      virtual void setColVarBondList(const std::shared_ptr<FixedPairList>& fpl) = 0;
+      virtual std::shared_ptr<FixedPairList> getColVarBondList() const = 0;
+      virtual void setColVarAngleList(const std::shared_ptr<FixedTripleList>& ftl) = 0;
+      virtual std::shared_ptr<FixedTripleList> getColVarAngleList() const = 0;
+      virtual void setColVarDihedList(const std::shared_ptr<FixedQuadrupleList>& fql) = 0;
+      virtual std::shared_ptr<FixedQuadrupleList> getColVarDihedList() const = 0;
 
       virtual void setColVar(const RealND& cv) = 0;
       virtual void setColVar(const Real3D& dist21,
@@ -105,12 +105,12 @@ namespace espressopp {
       virtual void setCutoff(real _cutoff);
       virtual real getCutoff() const;
 
-      virtual void setColVarBondList(const shared_ptr<FixedPairList>& fpl);
-      virtual shared_ptr<FixedPairList> getColVarBondList() const;
-      virtual void setColVarAngleList(const shared_ptr<FixedTripleList>& ftl);
-      virtual shared_ptr<FixedTripleList> getColVarAngleList() const;
-      virtual void setColVarDihedList(const shared_ptr<FixedQuadrupleList>& fql);
-      virtual shared_ptr<FixedQuadrupleList> getColVarDihedList() const;
+      virtual void setColVarBondList(const std::shared_ptr<FixedPairList>& fpl);
+      virtual std::shared_ptr<FixedPairList> getColVarBondList() const;
+      virtual void setColVarAngleList(const std::shared_ptr<FixedTripleList>& ftl);
+      virtual std::shared_ptr<FixedTripleList> getColVarAngleList() const;
+      virtual void setColVarDihedList(const std::shared_ptr<FixedQuadrupleList>& fql);
+      virtual std::shared_ptr<FixedQuadrupleList> getColVarDihedList() const;
 
       virtual void setColVar(const RealND& cv);
       virtual void setColVar(const Real3D& dist21,
@@ -143,11 +143,11 @@ namespace espressopp {
       real cutoff;
       real cutoffSqr;
       // List of bonds that correlate with the bond potential
-      shared_ptr<FixedPairList> colVarBondList;
+      std::shared_ptr<FixedPairList> colVarBondList;
       // List of angles that correlate with the bond potential
-      shared_ptr<FixedTripleList> colVarAngleList;
+      std::shared_ptr<FixedTripleList> colVarAngleList;
       // List of dihedrals that correlate with the dihedral potential
-      shared_ptr<FixedQuadrupleList> colVarDihedList;
+      std::shared_ptr<FixedQuadrupleList> colVarDihedList;
       // Collective variables: first itself, then bonds, then angles
       RealND colVar;
 
@@ -189,12 +189,12 @@ namespace espressopp {
     template < class Derived >
     inline void
     DihedralPotentialTemplate< Derived >::
-    setColVarBondList(const shared_ptr < FixedPairList >& _fpl) {
+    setColVarBondList(const std::shared_ptr < FixedPairList >& _fpl) {
       colVarBondList = _fpl;
     }
 
     template < class Derived >
-    inline shared_ptr < FixedPairList >
+    inline std::shared_ptr < FixedPairList >
     DihedralPotentialTemplate< Derived >::
     getColVarBondList() const
     { return colVarBondList; }
@@ -203,12 +203,12 @@ namespace espressopp {
     template < class Derived >
     inline void
     DihedralPotentialTemplate< Derived >::
-    setColVarAngleList(const shared_ptr < FixedTripleList >& _fpl) {
+    setColVarAngleList(const std::shared_ptr < FixedTripleList >& _fpl) {
       colVarAngleList = _fpl;
     }
 
     template < class Derived >
-    inline shared_ptr < FixedTripleList >
+    inline std::shared_ptr < FixedTripleList >
     DihedralPotentialTemplate< Derived >::
     getColVarAngleList() const
     { return colVarAngleList; }
@@ -217,12 +217,12 @@ namespace espressopp {
     template < class Derived >
     inline void
     DihedralPotentialTemplate< Derived >::
-    setColVarDihedList(const shared_ptr < FixedQuadrupleList >& _fql) {
+    setColVarDihedList(const std::shared_ptr < FixedQuadrupleList >& _fql) {
       colVarDihedList = _fql;
     }
 
     template < class Derived >
-    inline shared_ptr < FixedQuadrupleList >
+    inline std::shared_ptr < FixedQuadrupleList >
     DihedralPotentialTemplate< Derived >::
     getColVarDihedList() const
     { return colVarDihedList; }

--- a/src/interaction/DihedralRB.cpp
+++ b/src/interaction/DihedralRB.cpp
@@ -35,9 +35,9 @@ void DihedralRB::registerPython() {
   typedef class FixedQuadrupleListInteractionTemplate<DihedralRB> FixedQuadrupleListDihedralRB;
   class_ <FixedQuadrupleListDihedralRB, bases <Interaction> >
       ("interaction_FixedQuadrupleListDihedralRB",
-          init<shared_ptr<System>, shared_ptr<FixedQuadrupleList>, shared_ptr<DihedralRB> >())
-      .def(init<shared_ptr<System>, shared_ptr<FixedQuadrupleListAdress>,
-                shared_ptr<DihedralRB> >())
+          init<std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleList>, std::shared_ptr<DihedralRB> >())
+      .def(init<std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleListAdress>,
+                std::shared_ptr<DihedralRB> >())
       .def("setPotential", &FixedQuadrupleListDihedralRB::setPotential)
       .def("getFixedQuadrupleList", &FixedQuadrupleListDihedralRB::getFixedQuadrupleList);
 
@@ -45,7 +45,7 @@ void DihedralRB::registerPython() {
     FixedQuadrupleListTypesDihedralRB;
   class_< FixedQuadrupleListTypesDihedralRB, bases< Interaction > >
     ("interaction_FixedQuadrupleListTypesDihedralRB",
-       init< shared_ptr<System>, shared_ptr<FixedQuadrupleList> >())
+       init< std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleList> >())
       .def("setPotential", &FixedQuadrupleListTypesDihedralRB::setPotential)
       .def("getPotential", &FixedQuadrupleListTypesDihedralRB::getPotentialPtr)
       .def("setFixedQuadrupleList", &FixedQuadrupleListTypesDihedralRB::setFixedQuadrupleList)

--- a/src/interaction/FENE.cpp
+++ b/src/interaction/FENE.cpp
@@ -43,8 +43,8 @@ namespace espressopp {
 	  ;
 
       class_< FixedPairListFENE, bases< Interaction > >
-      ("interaction_FixedPairListFENE", init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<FENE> >())
-      .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<FENE> >())
+      ("interaction_FixedPairListFENE", init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<FENE> >())
+      .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<FENE> >())
       .def("setPotential", &FixedPairListFENE::setPotential)
       .def("getPotential", &FixedPairListFENE::getPotential)
       .def("setFixedPairList", &FixedPairListFENE::setFixedPairList)

--- a/src/interaction/FENECapped.cpp
+++ b/src/interaction/FENECapped.cpp
@@ -47,8 +47,8 @@ namespace espressopp {
 
       class_< FixedPairListFENECapped, bases< Interaction > >
       ("interaction_FixedPairListFENECapped",
-        init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<FENECapped> >())
-       .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<FENECapped> >())
+        init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<FENECapped> >())
+       .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<FENECapped> >())
        .def("setPotential", &FixedPairListFENECapped::setPotential)
        .def("getPotential", &FixedPairListFENECapped::getPotential)
        .def("setFixedPairList", &FixedPairListFENECapped::setFixedPairList)

--- a/src/interaction/FixedLocalTupleComListInteractionTemplate.hpp
+++ b/src/interaction/FixedLocalTupleComListInteractionTemplate.hpp
@@ -56,9 +56,9 @@ namespace espressopp {
 
 	public:
 	    FixedLocalTupleComListInteractionTemplate
-	    (shared_ptr < System > _system,
-	     shared_ptr < FixedLocalTupleList > _fixedtupleList,
-	     shared_ptr < Potential > _potential)
+	    (std::shared_ptr < System > _system,
+	     std::shared_ptr < FixedLocalTupleList > _fixedtupleList,
+	     std::shared_ptr < Potential > _potential)
 	      : SystemAccess(_system), fixedtupleList(_fixedtupleList), potential(_potential) {
 		if (! potential) {
 		    LOG4ESPP_ERROR(theLogger, "NULL potential");
@@ -169,16 +169,16 @@ namespace espressopp {
 	    }
 
 	    void
-	    setFixedLocalTupleList(shared_ptr < FixedLocalTupleList > _fixedtupleList) {
+	    setFixedLocalTupleList(std::shared_ptr < FixedLocalTupleList > _fixedtupleList) {
 		fixedtupleList = _fixedtupleList;
 	    }
 
-	    shared_ptr < FixedLocalTupleList > getFixedLocalTupleList() {
+	    std::shared_ptr < FixedLocalTupleList > getFixedLocalTupleList() {
 		return fixedtupleList;
 	    }
 
 	    void
-	    setPotential(shared_ptr < Potential> _potential) {
+	    setPotential(std::shared_ptr < Potential> _potential) {
 		if (_potential) {
 		    potential = _potential;
 		} else {
@@ -186,7 +186,7 @@ namespace espressopp {
 		}
 	    }
 
-	    shared_ptr < Potential > getPotential() {
+	    std::shared_ptr < Potential > getPotential() {
 		return potential;
 	    }
 
@@ -238,8 +238,8 @@ namespace espressopp {
 	    }
 
 	    int ntypes;
-	    shared_ptr < FixedLocalTupleList > fixedtupleList;
-	    shared_ptr < Potential > potential;
+	    std::shared_ptr < FixedLocalTupleList > fixedtupleList;
+	    std::shared_ptr < Potential > potential;
 	};
 
 	//////////////////////////////////////////////////

--- a/src/interaction/FixedLocalTupleRgListInteractionTemplate.hpp
+++ b/src/interaction/FixedLocalTupleRgListInteractionTemplate.hpp
@@ -53,9 +53,9 @@ namespace espressopp {
 
 	public:
 	    FixedLocalTupleRgListInteractionTemplate
-	    (shared_ptr < System > _system,
-	     shared_ptr < FixedLocalTupleList > _fixedtupleList,
-	     shared_ptr < Potential > _potential)
+	    (std::shared_ptr < System > _system,
+	     std::shared_ptr < FixedLocalTupleList > _fixedtupleList,
+	     std::shared_ptr < Potential > _potential)
 	      : SystemAccess(_system), fixedtupleList(_fixedtupleList), potential(_potential) {
 		if (! potential) {
 		    LOG4ESPP_ERROR(theLogger, "NULL potential");
@@ -168,16 +168,16 @@ namespace espressopp {
 	    }
 
 	    void
-	    setFixedLocalTupleList(shared_ptr < FixedLocalTupleList > _fixedtupleList) {
+	    setFixedLocalTupleList(std::shared_ptr < FixedLocalTupleList > _fixedtupleList) {
 		fixedtupleList = _fixedtupleList;
 	    }
 
-	    shared_ptr < FixedLocalTupleList > getFixedLocalTupleList() {
+	    std::shared_ptr < FixedLocalTupleList > getFixedLocalTupleList() {
 		return fixedtupleList;
 	    }
 
 	    void
-	    setPotential(shared_ptr < Potential> _potential) {
+	    setPotential(std::shared_ptr < Potential> _potential) {
 		if (_potential) {
 		    potential = _potential;
 		} else {
@@ -185,7 +185,7 @@ namespace espressopp {
 		}
 	    }
 
-	    shared_ptr < Potential > getPotential() {
+	    std::shared_ptr < Potential > getPotential() {
 		return potential;
 	    }
 
@@ -267,8 +267,8 @@ namespace espressopp {
 	    }
 
 	    int ntypes;
-	    shared_ptr < FixedLocalTupleList > fixedtupleList;
-	    shared_ptr < Potential > potential;
+	    std::shared_ptr < FixedLocalTupleList > fixedtupleList;
+	    std::shared_ptr < Potential > potential;
 	};
 
 	//////////////////////////////////////////////////

--- a/src/interaction/FixedPairDistListInteractionTemplate.hpp
+++ b/src/interaction/FixedPairDistListInteractionTemplate.hpp
@@ -46,9 +46,9 @@ namespace espressopp {
 
     public:
       FixedPairDistListInteractionTemplate
-      (shared_ptr < System > system,
-       shared_ptr < FixedPairDistList > _fixedPairDistList,
-       shared_ptr < Potential > _potential)
+      (std::shared_ptr < System > system,
+       std::shared_ptr < FixedPairDistList > _fixedPairDistList,
+       std::shared_ptr < Potential > _potential)
         : SystemAccess(system), fixedPairDistList(_fixedPairDistList),
           potential(_potential)
       {
@@ -60,16 +60,16 @@ namespace espressopp {
       virtual ~FixedPairDistListInteractionTemplate() {};
 
       void
-      setFixedPairList(shared_ptr < FixedPairDistList > _fixedPairDistList) {
+      setFixedPairList(std::shared_ptr < FixedPairDistList > _fixedPairDistList) {
         fixedPairDistList = _fixedPairDistList;
       }
 
-      shared_ptr < FixedPairDistList > getFixedPairList() {
+      std::shared_ptr < FixedPairDistList > getFixedPairList() {
         return fixedPairDistList;
       }
 
       void
-      setPotential(shared_ptr < Potential> _potential) {
+      setPotential(std::shared_ptr < Potential> _potential) {
         if (_potential) {
           potential = _potential;
         } else {
@@ -77,7 +77,7 @@ namespace espressopp {
         }
       }
 
-      shared_ptr < Potential > getPotential() {
+      std::shared_ptr < Potential > getPotential() {
         return potential;
       }
 
@@ -98,8 +98,8 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr < FixedPairDistList > fixedPairDistList;
-      shared_ptr < Potential > potential;
+      std::shared_ptr < FixedPairDistList > fixedPairDistList;
+      std::shared_ptr < Potential > potential;
     };
 
     //////////////////////////////////////////////////

--- a/src/interaction/FixedPairListInteractionTemplate.hpp
+++ b/src/interaction/FixedPairListInteractionTemplate.hpp
@@ -47,9 +47,9 @@ namespace espressopp {
 
     public:
       FixedPairListInteractionTemplate
-      (shared_ptr < System > system,
-       shared_ptr < FixedPairList > _fixedpairList,
-       shared_ptr < Potential > _potential)
+      (std::shared_ptr < System > system,
+       std::shared_ptr < FixedPairList > _fixedpairList,
+       std::shared_ptr < Potential > _potential)
         : SystemAccess(system), fixedpairList(_fixedpairList),
           potential(_potential)
       {
@@ -61,16 +61,16 @@ namespace espressopp {
       virtual ~FixedPairListInteractionTemplate() {};
 
       void
-      setFixedPairList(shared_ptr < FixedPairList > _fixedpairList) {
+      setFixedPairList(std::shared_ptr < FixedPairList > _fixedpairList) {
         fixedpairList = _fixedpairList;
       }
 
-      shared_ptr < FixedPairList > getFixedPairList() {
+      std::shared_ptr < FixedPairList > getFixedPairList() {
         return fixedpairList;
       }
 
       void
-      setPotential(shared_ptr < Potential> _potential) {
+      setPotential(std::shared_ptr < Potential> _potential) {
         if (_potential) {
           potential = _potential;
         } else {
@@ -78,7 +78,7 @@ namespace espressopp {
         }
       }
 
-      shared_ptr < Potential > getPotential() {
+      std::shared_ptr < Potential > getPotential() {
         return potential;
       }
 
@@ -99,8 +99,8 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr < FixedPairList > fixedpairList;
-      shared_ptr < Potential > potential;
+      std::shared_ptr < FixedPairList > fixedpairList;
+      std::shared_ptr < Potential > potential;
     };
 
     //////////////////////////////////////////////////

--- a/src/interaction/FixedPairListPIadressInteractionTemplate.hpp
+++ b/src/interaction/FixedPairListPIadressInteractionTemplate.hpp
@@ -46,10 +46,10 @@ namespace espressopp {
 
       public:
         FixedPairListPIadressInteractionTemplate
-        (shared_ptr < System > system,
-         shared_ptr < FixedPairList > _fixedpairList,
-         shared_ptr <FixedTupleListAdress> _fixedtupleList,
-         shared_ptr < Potential > _potential,
+        (std::shared_ptr < System > system,
+         std::shared_ptr < FixedPairList > _fixedpairList,
+         std::shared_ptr <FixedTupleListAdress> _fixedtupleList,
+         std::shared_ptr < Potential > _potential,
          int _ntrotter,
          bool _speedup)
           : SystemAccess(system), fixedpairList(_fixedpairList), fixedtupleList(_fixedtupleList),
@@ -63,20 +63,20 @@ namespace espressopp {
         virtual ~FixedPairListPIadressInteractionTemplate() {};
 
         void
-        setFixedPairList(shared_ptr < FixedPairList > _fixedpairList) {
+        setFixedPairList(std::shared_ptr < FixedPairList > _fixedpairList) {
           fixedpairList = _fixedpairList;
         }
 
-        shared_ptr < FixedPairList > getFixedPairList() {
+        std::shared_ptr < FixedPairList > getFixedPairList() {
           return fixedpairList;
         }
 
         void
-        setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+        setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
         }
 
-        shared_ptr < FixedTupleListAdress > getFixedTupleList() {
+        std::shared_ptr < FixedTupleListAdress > getFixedTupleList() {
           return fixedtupleList;
         }
 
@@ -99,7 +99,7 @@ namespace espressopp {
         }
 
         void
-        setPotential(shared_ptr < Potential> _potential) {
+        setPotential(std::shared_ptr < Potential> _potential) {
           if (_potential) {
             potential = _potential;
           } else {
@@ -107,7 +107,7 @@ namespace espressopp {
           }
         }
 
-        shared_ptr < Potential > getPotential() {
+        std::shared_ptr < Potential > getPotential() {
           return potential;
         }
 
@@ -132,9 +132,9 @@ namespace espressopp {
         int ntypes;
         int ntrotter;
         bool speedup; // if true approximate rings in classical region by single particles
-        shared_ptr < FixedPairList > fixedpairList;
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
-        shared_ptr < Potential > potential;
+        std::shared_ptr < FixedPairList > fixedpairList;
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
+        std::shared_ptr < Potential > potential;
     };
 
     //////////////////////////////////////////////////

--- a/src/interaction/FixedPairListTypesInteractionTemplate.hpp
+++ b/src/interaction/FixedPairListTypesInteractionTemplate.hpp
@@ -58,8 +58,8 @@ namespace espressopp {
 
     public:
       FixedPairListTypesInteractionTemplate
-          (shared_ptr < System > system,
-           shared_ptr<FixedPairList> _fixedpairList)
+          (std::shared_ptr < System > system,
+           std::shared_ptr<FixedPairList> _fixedpairList)
           : SystemAccess(system), fixedpairList(_fixedpairList) {
     	  potentialArray    = esutil::Array2D<Potential, esutil::enlarge>(0, 0, Potential());
         ntypes = 0;
@@ -68,11 +68,11 @@ namespace espressopp {
       virtual ~FixedPairListTypesInteractionTemplate() {};
 
       void
-      setFixedPairList(shared_ptr < FixedPairList > _fixedpairList) {
+      setFixedPairList(std::shared_ptr < FixedPairList > _fixedpairList) {
         fixedpairList = _fixedpairList;
       }
 
-      shared_ptr < FixedPairList > getFixedPairList() {
+      std::shared_ptr < FixedPairList > getFixedPairList() {
         return fixedpairList;
       }
 
@@ -92,8 +92,8 @@ namespace espressopp {
       }
 
       // this is mainly used to access the potential from Python (e.g. to change parameters of the potential)
-      shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
-    	return  make_shared<Potential>(potentialArray.at(type1, type2));
+      std::shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
+    	return  std::make_shared<Potential>(potentialArray.at(type1, type2));
       }
 
 
@@ -114,9 +114,9 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr < FixedPairList > fixedpairList;
+      std::shared_ptr < FixedPairList > fixedpairList;
       esutil::Array2D<Potential, esutil::enlarge> potentialArray;
-      esutil::Array2D<shared_ptr<Potential>, esutil::enlarge> potentialArrayPtr;
+      esutil::Array2D<std::shared_ptr<Potential>, esutil::enlarge> potentialArrayPtr;
     };
 
     //////////////////////////////////////////////////
@@ -133,7 +133,7 @@ namespace espressopp {
         int type1 = p1.type();
         int type2 = p2.type();
         Potential &potential = getPotential(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
 
         Real3D force(0.0);
         //if(potential._computeForce(force, p1, p2)) {
@@ -168,7 +168,7 @@ namespace espressopp {
         int type1 = p1.type();
         int type2 = p2.type();
         Potential &potential = getPotential(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
         Real3D r21;
         bc.getMinimumImageVectorBox(r21, p1.position(), p2.position());
         //e   = potential._computeEnergy(p1, p2);
@@ -243,7 +243,7 @@ namespace espressopp {
         int type1 = p1.type();
         int type2 = p2.type();
         Potential &potential = getPotential(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
 
         Real3D force(0.0, 0.0, 0.0);
         Real3D r21;

--- a/src/interaction/FixedQuadrupleAngleListInteractionTemplate.hpp
+++ b/src/interaction/FixedQuadrupleAngleListInteractionTemplate.hpp
@@ -43,9 +43,9 @@ namespace espressopp {
       typedef _DihedralPotential Potential;
     public:
       FixedQuadrupleAngleListInteractionTemplate
-      (shared_ptr < System > _system,
-       shared_ptr < FixedQuadrupleAngleList > _fixedQuadrupleAngleList,
-       shared_ptr < Potential > _potential)
+      (std::shared_ptr < System > _system,
+       std::shared_ptr < FixedQuadrupleAngleList > _fixedQuadrupleAngleList,
+       std::shared_ptr < Potential > _potential)
         : SystemAccess(_system), fixedQuadrupleAngleList(_fixedQuadrupleAngleList),
           potential(_potential)
       {
@@ -55,18 +55,18 @@ namespace espressopp {
       }
 
       void
-      setFixedQuadrupleAngleList(shared_ptr < FixedQuadrupleAngleList > _fixedQuadrupleAngleList) {
+      setFixedQuadrupleAngleList(std::shared_ptr < FixedQuadrupleAngleList > _fixedQuadrupleAngleList) {
         fixedQuadrupleAngleList = _fixedQuadrupleAngleList;
       }
 
       virtual ~FixedQuadrupleAngleListInteractionTemplate() {};
 
-      shared_ptr < FixedQuadrupleAngleList > getFixedQuadrupleAngleList() {
+      std::shared_ptr < FixedQuadrupleAngleList > getFixedQuadrupleAngleList() {
         return fixedQuadrupleAngleList;
       }
 
       void
-      setPotential(shared_ptr < Potential> _potential) {
+      setPotential(std::shared_ptr < Potential> _potential) {
          if (_potential) {
             potential = _potential;
          } else {
@@ -74,7 +74,7 @@ namespace espressopp {
          }
       }
 
-      shared_ptr < Potential > getPotential() {
+      std::shared_ptr < Potential > getPotential() {
         return potential;
       }
 
@@ -95,8 +95,8 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr < FixedQuadrupleAngleList > fixedQuadrupleAngleList;
-      shared_ptr < Potential > potential;
+      std::shared_ptr < FixedQuadrupleAngleList > fixedQuadrupleAngleList;
+      std::shared_ptr < Potential > potential;
     };
 
     //////////////////////////////////////////////////

--- a/src/interaction/FixedQuadrupleListInteractionTemplate.hpp
+++ b/src/interaction/FixedQuadrupleListInteractionTemplate.hpp
@@ -44,9 +44,9 @@ namespace espressopp {
       typedef _DihedralPotential Potential;
     public:
       FixedQuadrupleListInteractionTemplate
-      (shared_ptr < System > _system,
-       shared_ptr < FixedQuadrupleList > _fixedquadrupleList,
-       shared_ptr < Potential > _potential)
+      (std::shared_ptr < System > _system,
+       std::shared_ptr < FixedQuadrupleList > _fixedquadrupleList,
+       std::shared_ptr < Potential > _potential)
         : SystemAccess(_system), fixedquadrupleList(_fixedquadrupleList),
           potential(_potential)
       {
@@ -57,18 +57,18 @@ namespace espressopp {
       }
 
       void
-      setFixedQuadrupleList(shared_ptr < FixedQuadrupleList > _fixedquadrupleList) {
+      setFixedQuadrupleList(std::shared_ptr < FixedQuadrupleList > _fixedquadrupleList) {
         fixedquadrupleList = _fixedquadrupleList;
       }
 
       virtual ~FixedQuadrupleListInteractionTemplate() {};
 
-      shared_ptr < FixedQuadrupleList > getFixedQuadrupleList() {
+      std::shared_ptr < FixedQuadrupleList > getFixedQuadrupleList() {
         return fixedquadrupleList;
       }
 
       void
-      setPotential(shared_ptr < Potential> _potential) {
+      setPotential(std::shared_ptr < Potential> _potential) {
            if (_potential) {
               potential = _potential;
            } else {
@@ -76,7 +76,7 @@ namespace espressopp {
            }
       }
 
-      shared_ptr < Potential > getPotential() {
+      std::shared_ptr < Potential > getPotential() {
         return potential;
       }
 
@@ -97,8 +97,8 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr < FixedQuadrupleList > fixedquadrupleList;
-      shared_ptr < Potential > potential;
+      std::shared_ptr < FixedQuadrupleList > fixedquadrupleList;
+      std::shared_ptr < Potential > potential;
     };
 
     //////////////////////////////////////////////////

--- a/src/interaction/FixedQuadrupleListTypesInteractionTemplate.hpp
+++ b/src/interaction/FixedQuadrupleListTypesInteractionTemplate.hpp
@@ -49,21 +49,21 @@ class FixedQuadrupleListTypesInteractionTemplate: public Interaction, SystemAcce
 
  public:
   FixedQuadrupleListTypesInteractionTemplate
-      (shared_ptr<System> _system,
-       shared_ptr<FixedQuadrupleList> _fixedquadrupleList)
+      (std::shared_ptr<System> _system,
+       std::shared_ptr<FixedQuadrupleList> _fixedquadrupleList)
       : SystemAccess(_system), fixedquadrupleList(_fixedquadrupleList) {
     potentialArray = esutil::Array4D<Potential, esutil::enlarge>(0, 0, 0, 0, Potential());
     ntypes = 0;
   }
 
   void
-  setFixedQuadrupleList(shared_ptr<FixedQuadrupleList> _fixedquadrupleList) {
+  setFixedQuadrupleList(std::shared_ptr<FixedQuadrupleList> _fixedquadrupleList) {
     fixedquadrupleList = _fixedquadrupleList;
   }
 
   virtual ~FixedQuadrupleListTypesInteractionTemplate() { }
 
-  shared_ptr<FixedQuadrupleList> getFixedQuadrupleList() {
+  std::shared_ptr<FixedQuadrupleList> getFixedQuadrupleList() {
     return fixedquadrupleList;
   }
 
@@ -81,8 +81,8 @@ class FixedQuadrupleListTypesInteractionTemplate: public Interaction, SystemAcce
     return potentialArray.at(type1, type2, type3, type4);
   }
 
-  shared_ptr<Potential> getPotentialPtr(int type1, int type2, int type3, int type4) {
-    return make_shared<Potential>(potentialArray.at(type1, type2, type3, type4));
+  std::shared_ptr<Potential> getPotentialPtr(int type1, int type2, int type3, int type4) {
+    return std::make_shared<Potential>(potentialArray.at(type1, type2, type3, type4));
   }
 
   virtual void addForces();
@@ -102,7 +102,7 @@ class FixedQuadrupleListTypesInteractionTemplate: public Interaction, SystemAcce
 
  protected:
   int ntypes;
-  shared_ptr<FixedQuadrupleList> fixedquadrupleList;
+  std::shared_ptr<FixedQuadrupleList> fixedquadrupleList;
   esutil::Array4D<Potential, esutil::enlarge> potentialArray;
 };
 

--- a/src/interaction/FixedTripleAngleListInteractionTemplate.hpp
+++ b/src/interaction/FixedTripleAngleListInteractionTemplate.hpp
@@ -51,9 +51,9 @@ namespace espressopp {
 
     public:
       FixedTripleAngleListInteractionTemplate
-      (shared_ptr < System > _system,
-       shared_ptr < FixedTripleAngleList > _fixedtripleList,
-       shared_ptr < Potential > _potential)
+      (std::shared_ptr < System > _system,
+       std::shared_ptr < FixedTripleAngleList > _fixedtripleList,
+       std::shared_ptr < Potential > _potential)
         : SystemAccess(_system), fixedtripleList(_fixedtripleList), potential(_potential)
       {
         if(! potential){
@@ -64,17 +64,17 @@ namespace espressopp {
       virtual ~FixedTripleAngleListInteractionTemplate() {};
 
       void
-      setFixedTripleAngleList(shared_ptr < FixedTripleAngleList > _fixedtripleList) {
+      setFixedTripleAngleList(std::shared_ptr < FixedTripleAngleList > _fixedtripleList) {
         fixedtripleList = _fixedtripleList;
       }
 
-      shared_ptr < FixedTripleAngleList >
+      std::shared_ptr < FixedTripleAngleList >
       getFixedTripleList() {
         return fixedtripleList;
       }
 
       void
-      setPotential(shared_ptr < Potential> _potential) {
+      setPotential(std::shared_ptr < Potential> _potential) {
         if (_potential) {
           potential = _potential;
         }
@@ -83,7 +83,7 @@ namespace espressopp {
         }
       }
 
-      shared_ptr < Potential >
+      std::shared_ptr < Potential >
       getPotential() {
         return potential;
       }
@@ -105,8 +105,8 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr<FixedTripleAngleList> fixedtripleList;
-      shared_ptr < Potential > potential;
+      std::shared_ptr<FixedTripleAngleList> fixedtripleList;
+      std::shared_ptr < Potential > potential;
     };
 
     //////////////////////////////////////////////////

--- a/src/interaction/FixedTripleListInteractionTemplate.hpp
+++ b/src/interaction/FixedTripleListInteractionTemplate.hpp
@@ -46,9 +46,9 @@ namespace espressopp {
 
     public:
       FixedTripleListInteractionTemplate
-      (shared_ptr < System > _system,
-       shared_ptr < FixedTripleList > _fixedtripleList,
-       shared_ptr < Potential > _potential)
+      (std::shared_ptr < System > _system,
+       std::shared_ptr < FixedTripleList > _fixedtripleList,
+       std::shared_ptr < Potential > _potential)
         : SystemAccess(_system), fixedtripleList(_fixedtripleList),
           potential(_potential)
       {
@@ -61,11 +61,11 @@ namespace espressopp {
       virtual ~FixedTripleListInteractionTemplate() {};
 
       void
-      setFixedTripleList(shared_ptr < FixedTripleList > _fixedtripleList) {
+      setFixedTripleList(std::shared_ptr < FixedTripleList > _fixedtripleList) {
         fixedtripleList = _fixedtripleList;
       }
 
-      shared_ptr < FixedTripleList > getFixedTripleList() {
+      std::shared_ptr < FixedTripleList > getFixedTripleList() {
         return fixedtripleList;
       }
 
@@ -74,7 +74,7 @@ namespace espressopp {
         potentialArray.at(type1, type2) = potential;
       }*/
       void
-      setPotential(shared_ptr < Potential> _potential) {
+      setPotential(std::shared_ptr < Potential> _potential) {
          if (_potential) {
             potential = _potential;
          } else {
@@ -86,7 +86,7 @@ namespace espressopp {
         return potentialArray.at(0, 0);
       }*/
 
-      shared_ptr < Potential > getPotential() {
+      std::shared_ptr < Potential > getPotential() {
         return potential;
       }
 
@@ -107,9 +107,9 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr<FixedTripleList> fixedtripleList;
+      std::shared_ptr<FixedTripleList> fixedtripleList;
       //esutil::Array2D<Potential, esutil::enlarge> potentialArray;
-      shared_ptr < Potential > potential;
+      std::shared_ptr < Potential > potential;
     };
 
     //////////////////////////////////////////////////

--- a/src/interaction/FixedTripleListPIadressInteractionTemplate.hpp
+++ b/src/interaction/FixedTripleListPIadressInteractionTemplate.hpp
@@ -45,10 +45,10 @@ namespace espressopp {
 
       public:
         FixedTripleListPIadressInteractionTemplate
-        (shared_ptr < System > _system,
-         shared_ptr < FixedTripleList > _fixedtripleList,
-         shared_ptr <FixedTupleListAdress> _fixedtupleList,
-         shared_ptr < Potential > _potential,
+        (std::shared_ptr < System > _system,
+         std::shared_ptr < FixedTripleList > _fixedtripleList,
+         std::shared_ptr <FixedTupleListAdress> _fixedtupleList,
+         std::shared_ptr < Potential > _potential,
          int _ntrotter,
          bool _speedup)
           : SystemAccess(_system), fixedtripleList(_fixedtripleList), fixedtupleList(_fixedtupleList),
@@ -62,20 +62,20 @@ namespace espressopp {
         virtual ~FixedTripleListPIadressInteractionTemplate() {};
 
         void
-        setFixedTripleList(shared_ptr < FixedTripleList > _fixedtripleList) {
+        setFixedTripleList(std::shared_ptr < FixedTripleList > _fixedtripleList) {
           fixedtripleList = _fixedtripleList;
         }
 
-        shared_ptr < FixedTripleList > getFixedTripleList() {
+        std::shared_ptr < FixedTripleList > getFixedTripleList() {
           return fixedtripleList;
         }
 
         void
-        setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+        setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
         }
 
-        shared_ptr < FixedTupleListAdress > getFixedTupleList() {
+        std::shared_ptr < FixedTupleListAdress > getFixedTupleList() {
           return fixedtupleList;
         }
 
@@ -98,7 +98,7 @@ namespace espressopp {
         }
 
         void
-        setPotential(shared_ptr < Potential> _potential) {
+        setPotential(std::shared_ptr < Potential> _potential) {
           if (_potential) {
             potential = _potential;
           } else {
@@ -106,7 +106,7 @@ namespace espressopp {
           }
         }
 
-        shared_ptr < Potential > getPotential() {
+        std::shared_ptr < Potential > getPotential() {
           return potential;
         }
 
@@ -131,9 +131,9 @@ namespace espressopp {
         int ntypes;
         int ntrotter;
         bool speedup; // if true approximate rings in classical region by single particles
-        shared_ptr<FixedTripleList> fixedtripleList;
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
-        shared_ptr < Potential > potential;
+        std::shared_ptr<FixedTripleList> fixedtripleList;
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
+        std::shared_ptr < Potential > potential;
     };
 
     //////////////////////////////////////////////////

--- a/src/interaction/FixedTripleListTypesInteractionTemplate.hpp
+++ b/src/interaction/FixedTripleListTypesInteractionTemplate.hpp
@@ -49,8 +49,8 @@ class FixedTripleListTypesInteractionTemplate : public Interaction, SystemAccess
 
  public:
   FixedTripleListTypesInteractionTemplate
-      (shared_ptr<System> system,
-       shared_ptr<FixedTripleList> _fixedtripleList)
+      (std::shared_ptr<System> system,
+       std::shared_ptr<FixedTripleList> _fixedtripleList)
       : SystemAccess(system), fixedtripleList(_fixedtripleList) {
     potentialArray = esutil::Array3D<Potential, esutil::enlarge>(0, 0, 0, Potential());
     ntypes = 0;
@@ -58,11 +58,11 @@ class FixedTripleListTypesInteractionTemplate : public Interaction, SystemAccess
 
   virtual ~FixedTripleListTypesInteractionTemplate() { }
 
-  void setFixedTripleList(shared_ptr<FixedTripleList> _fixedtripleList) {
+  void setFixedTripleList(std::shared_ptr<FixedTripleList> _fixedtripleList) {
     fixedtripleList = _fixedtripleList;
   }
 
-  shared_ptr<FixedTripleList> getFixedTripleList() {
+  std::shared_ptr<FixedTripleList> getFixedTripleList() {
     return fixedtripleList;
   }
 
@@ -80,8 +80,8 @@ class FixedTripleListTypesInteractionTemplate : public Interaction, SystemAccess
     return potentialArray.at(type1, type2, type3);
   }
 
-  shared_ptr<Potential> getPotentialPtr(int type1, int type2, int type3) {
-    return make_shared<Potential>(potentialArray.at(type1, type2, type3));
+  std::shared_ptr<Potential> getPotentialPtr(int type1, int type2, int type3) {
+    return std::make_shared<Potential>(potentialArray.at(type1, type2, type3));
   }
 
   virtual void addForces();
@@ -101,7 +101,7 @@ class FixedTripleListTypesInteractionTemplate : public Interaction, SystemAccess
 
  protected:
   int ntypes;
-  shared_ptr<FixedTripleList> fixedtripleList;
+  std::shared_ptr<FixedTripleList> fixedtripleList;
   esutil::Array3D<Potential, esutil::enlarge> potentialArray;
 };
 

--- a/src/interaction/GravityTruncated.cpp
+++ b/src/interaction/GravityTruncated.cpp
@@ -42,7 +42,7 @@ namespace espressopp {
       ;
 
       class_< VerletListGravityTruncated, bases< Interaction > >
-        ("interaction_VerletListGravityTruncated", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListGravityTruncated", init< std::shared_ptr<VerletList> >())
         .def("getVerletList", &VerletListGravityTruncated::getVerletList)
         .def("setPotential", &VerletListGravityTruncated::setPotential, return_value_policy< reference_existing_object >())
         .def("getPotential", &VerletListGravityTruncated::getPotential, return_value_policy< reference_existing_object >())

--- a/src/interaction/Harmonic.cpp
+++ b/src/interaction/Harmonic.cpp
@@ -63,8 +63,8 @@ namespace espressopp {
 
       class_< FixedPairListHarmonic, bases< Interaction > >
         ("interaction_FixedPairListHarmonic",
-           init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<Harmonic> >())
-        .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<Harmonic> >())
+           init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<Harmonic> >())
+        .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<Harmonic> >())
         .def("setPotential", &FixedPairListHarmonic::setPotential)
         .def("getPotential", &FixedPairListHarmonic::getPotential)
         .def("setFixedPairList", &FixedPairListHarmonic::setFixedPairList)
@@ -72,8 +72,8 @@ namespace espressopp {
       ;
       class_< FixedPairListTypesHarmonic, bases< Interaction > >
         ("interaction_FixedPairListTypesHarmonic",
-           init< shared_ptr<System>, shared_ptr<FixedPairList> >())
-        .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress> >())
+           init< std::shared_ptr<System>, std::shared_ptr<FixedPairList> >())
+        .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress> >())
         .def("setPotential", &FixedPairListTypesHarmonic::setPotential)
         .def("getPotential", &FixedPairListTypesHarmonic::getPotentialPtr)
         .def("setFixedPairList", &FixedPairListTypesHarmonic::setFixedPairList)
@@ -82,15 +82,15 @@ namespace espressopp {
 
       class_< VerletListHarmonic, bases< Interaction > >
         ("interaction_VerletListHarmonic",
-           init< shared_ptr<VerletList> >())
+           init< std::shared_ptr<VerletList> >())
         .def("setPotential", &VerletListHarmonic::setPotential)
         .def("getPotential", &VerletListHarmonic::getPotentialPtr)
       ;
 
             class_< VerletListAdressATHarmonic, bases< Interaction > >
         ("interaction_VerletListAdressATHarmonic",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("getVerletList", &VerletListAdressATHarmonic::getVerletList)
         .def("setPotential", &VerletListAdressATHarmonic::setPotential)
         .def("getPotential", &VerletListAdressATHarmonic::getPotentialPtr)
@@ -98,8 +98,8 @@ namespace espressopp {
 
       class_< VerletListAdressCGHarmonic, bases< Interaction > >
         ("interaction_VerletListAdressCGHarmonic",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("getVerletList", &VerletListAdressCGHarmonic::getVerletList)
         .def("setPotential", &VerletListAdressCGHarmonic::setPotential)
         .def("getPotential", &VerletListAdressCGHarmonic::getPotentialPtr)
@@ -107,8 +107,8 @@ namespace espressopp {
 
             class_< VerletListHadressATHarmonic, bases< Interaction > >
         ("interaction_VerletListHadressATHarmonic",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("getVerletList", &VerletListHadressATHarmonic::getVerletList)
         .def("setPotential", &VerletListHadressATHarmonic::setPotential)
         .def("getPotential", &VerletListHadressATHarmonic::getPotentialPtr)
@@ -116,8 +116,8 @@ namespace espressopp {
 
       class_< VerletListHadressCGHarmonic, bases< Interaction > >
         ("interaction_VerletListHadressCGHarmonic",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("getVerletList", &VerletListHadressCGHarmonic::getVerletList)
         .def("setPotential", &VerletListHadressCGHarmonic::setPotential)
         .def("getPotential", &VerletListHadressCGHarmonic::getPotentialPtr)

--- a/src/interaction/Harmonic.py
+++ b/src/interaction/Harmonic.py
@@ -49,49 +49,49 @@ espressopp.interaction.Harmonic
         :param system: system object
         :param vl: FixedPairList object
         :param potential: Harmonic potential object
-        :type system: shared_ptr<System>
-        :type vl: shared_ptr<FixedPairList>
-        :type potential: shared_ptr<Harmonic>
+        :type system: std::shared_ptr<System>
+        :type vl: std::shared_ptr<FixedPairList>
+        :type potential: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.FixedPairListHarmonic.getFixedPairList()
 
         Gets the FixedPairList.
 
-        :rtype: shared_ptr<FixedPairList>
+        :rtype: std::shared_ptr<FixedPairList>
 
 .. function:: espressopp.interaction.FixedPairListHarmonic.setFixedPairList(fixedpairlist)
 
         Sets the FixedPairList.
 
         :param fixedpairlist: FixedPairList object
-        :type fixedpairlist: shared_ptr<FixedPairList>
+        :type fixedpairlist: std::shared_ptr<FixedPairList>
 
 .. function:: espressopp.interaction.FixedPairListHarmonic.setPotential(potential)
 
         Sets the Harmonic interaction potential.
 
         :param potential: Harmonic potential object
-        :type potential: shared_ptr<Harmonic>
+        :type potential: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.FixedPairListTypesHarmonic(system, vl)
 
         :param system: system object
         :param vl: FixedPairList object
-        :type system: shared_ptr<System>
-        :type vl: shared_ptr<FixedPairList>
+        :type system: std::shared_ptr<System>
+        :type vl: std::shared_ptr<FixedPairList>
 
 .. function:: espressopp.interaction.FixedPairListTypesHarmonic.getFixedPairList()
 
         Gets the FixedPairList.
 
-        :rtype: shared_ptr<FixedPairList>
+        :rtype: std::shared_ptr<FixedPairList>
 
 .. function:: espressopp.interaction.FixedPairListTypesHarmonic.setFixedPairList(fixedpairlist)
 
         Sets the FixedPairList.
 
         :param fixedpairlist: FixedPairList object
-        :type fixedpairlist: shared_ptr<FixedPairList>
+        :type fixedpairlist: std::shared_ptr<FixedPairList>
 
 .. function:: espressopp.interaction.FixedPairListTypesHarmonic.setPotential(type1, type2, potential)
 
@@ -102,7 +102,7 @@ espressopp.interaction.Harmonic
         :param potential: Harmonic potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Harmonic>
+        :type potential: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.FixedPairListTypesHarmonic.getPotential(type1,type2)
 
@@ -112,14 +112,14 @@ espressopp.interaction.Harmonic
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<Harmonic>
+        :rtype: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.VerletListHarmonic(vl)
 
         Defines a verletlist-based interaction using a Harmonic potential.
 
         :param vl: Verletlist object
-        :type vl: shared_ptr<VerletList>
+        :type vl: std::shared_ptr<VerletList>
 
 .. function:: espressopp.interaction.VerletListHarmonic.getPotential(type1, type2)
 
@@ -129,7 +129,7 @@ espressopp.interaction.Harmonic
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<Harmonic>
+        :rtype: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.VerletListHarmonic.setPotential(type1, type2, potential)
 
@@ -140,7 +140,7 @@ espressopp.interaction.Harmonic
         :param potential: Harmonic potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Harmonic>
+        :type potential: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.VerletListAdressATHarmonic(vl, fixedtupleList)
 
@@ -148,8 +148,8 @@ espressopp.interaction.Harmonic
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressATHarmonic.setPotential(type1, type2, potential)
 
@@ -160,7 +160,7 @@ espressopp.interaction.Harmonic
         :param potential: Harmonic potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Harmonic>
+        :type potential: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.VerletListAdressATHarmonic.getPotential(type1, type2)
 
@@ -170,13 +170,13 @@ espressopp.interaction.Harmonic
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<Harmonic>
+        :rtype: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.VerletListAdressATHarmonic.getVerletList()
 
         Gets the verletlist used in VerletListAdressATHarmonic interaction.
 
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressCGHarmonic(vl, fixedtupleList)
 
@@ -184,8 +184,8 @@ espressopp.interaction.Harmonic
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressCGHarmonic.setPotential(type1, type2, potential)
 
@@ -196,7 +196,7 @@ espressopp.interaction.Harmonic
         :param potential: Harmonic potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Harmonic>
+        :type potential: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.VerletListAdressCGHarmonic.getPotential(type1, type2)
 
@@ -206,13 +206,13 @@ espressopp.interaction.Harmonic
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<Harmonic>
+        :rtype: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.VerletListAdressCGHarmonic.getVerletList()
 
         Gets the verletlist used in VerletListAdressCGHarmonic interaction.
 
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressATHarmonic(vl, fixedtupleList)
 
@@ -220,8 +220,8 @@ espressopp.interaction.Harmonic
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressATHarmonic.setPotential(type1, type2, potential)
 
@@ -232,7 +232,7 @@ espressopp.interaction.Harmonic
         :param potential: Harmonic potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Harmonic>
+        :type potential: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.VerletListHadressATHarmonic.getPotential(type1, type2)
 
@@ -242,13 +242,13 @@ espressopp.interaction.Harmonic
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<Harmonic>
+        :rtype: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.VerletListHadressATHarmonic.getVerletList()
 
         Gets the verletlist used in VerletListHadressATHarmonic interaction.
 
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressCGHarmonic(vl, fixedtupleList)
 
@@ -256,8 +256,8 @@ espressopp.interaction.Harmonic
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressCGHarmonic.setPotential(type1, type2, potential)
 
@@ -268,7 +268,7 @@ espressopp.interaction.Harmonic
         :param potential: Harmonic potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Harmonic>
+        :type potential: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.VerletListHadressCGHarmonic.getPotential(type1, type2)
 
@@ -278,13 +278,13 @@ espressopp.interaction.Harmonic
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<Harmonic>
+        :rtype: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.VerletListHadressCGHarmonic.getVerletList()
 
         Gets the verletlist used in VerletListHadressCGHarmonic interaction.
 
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 """
 from espressopp import pmi, infinity
 from espressopp.esutil import *

--- a/src/interaction/HarmonicTrap.cpp
+++ b/src/interaction/HarmonicTrap.cpp
@@ -46,7 +46,7 @@ namespace espressopp {
         ;
 
       class_< SingleParticleHarmonicTrap, bases< Interaction > >
-        ("interaction_SingleParticleHarmonicTrap", init< shared_ptr<System>, shared_ptr<HarmonicTrap> >())
+        ("interaction_SingleParticleHarmonicTrap", init< std::shared_ptr<System>, std::shared_ptr<HarmonicTrap> >())
         .def("setPotential", &SingleParticleHarmonicTrap::setPotential)
         .def("getPotential", &SingleParticleHarmonicTrap::getPotential)
       ;

--- a/src/interaction/Interaction.hpp
+++ b/src/interaction/Interaction.hpp
@@ -67,7 +67,7 @@ namespace espressopp {
     };
 
     struct InteractionList
-      : public std::vector< shared_ptr< Interaction > > {
+      : public std::vector< std::shared_ptr< Interaction > > {
       typedef esutil::ESPPIterator< std::vector< Interaction > > Iterator;
     };
 

--- a/src/interaction/LJcos.cpp
+++ b/src/interaction/LJcos.cpp
@@ -55,7 +55,7 @@ namespace espressopp {
 			;
 			
 			class_< VerletListLJcos, bases< Interaction > >
-			("interaction_VerletListLJcos", init< shared_ptr<VerletList> >())
+			("interaction_VerletListLJcos", init< std::shared_ptr<VerletList> >())
 			.def("getVerletList", &VerletListLJcos::getVerletList)
 			.def("setPotential", &VerletListLJcos::setPotential, return_value_policy< reference_existing_object >())
 			.def("getPotential", &VerletListLJcos::getPotential, return_value_policy< reference_existing_object >())
@@ -63,27 +63,27 @@ namespace espressopp {
 			
 			class_< VerletListAdressLJcos, bases< Interaction > >
 			("interaction_VerletListAdressLJcos",
-			 init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+			 init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
 			.def("setPotentialAT", &VerletListAdressLJcos::setPotentialAT)
 			.def("setPotentialCG", &VerletListAdressLJcos::setPotentialCG);
 			;
 			
 			class_< VerletListHadressLJcos, bases< Interaction > >
 			("interaction_VerletListHadressLJcos",
-			 init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+			 init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
 			.def("setPotentialAT", &VerletListHadressLJcos::setPotentialAT)
 			.def("setPotentialCG", &VerletListHadressLJcos::setPotentialCG);
 			;
 			
 			class_< CellListLJcos, bases< Interaction > >
-			("interaction_CellListLJcos", init< shared_ptr< storage::Storage > >())
+			("interaction_CellListLJcos", init< std::shared_ptr< storage::Storage > >())
 			.def("setPotential", &CellListLJcos::setPotential);
 	  ;
 			
 			class_< FixedPairListLJcos, bases< Interaction > >
 			("interaction_FixedPairListLJcos",
-			 init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<LJcos> >())
-			.def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<LJcos> >())
+			 init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<LJcos> >())
+			.def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<LJcos> >())
 			.def("setPotential", &FixedPairListLJcos::setPotential)
 			.def("setFixedPairList", &FixedPairListLJcos::setFixedPairList)
 			.def("getFixedPairList", &FixedPairListLJcos::getFixedPairList)

--- a/src/interaction/LennardJones.cpp
+++ b/src/interaction/LennardJones.cpp
@@ -103,7 +103,7 @@ namespace espressopp {
       ;
 
       class_< VerletListLennardJones, bases< Interaction > >
-        ("interaction_VerletListLennardJones", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListLennardJones", init< std::shared_ptr<VerletList> >())
         .def("getVerletList", &VerletListLennardJones::getVerletList)
         .def("setPotential", &VerletListLennardJones::setPotential)
         .def("getPotential", &VerletListLennardJones::getPotentialPtr)
@@ -111,8 +111,8 @@ namespace espressopp {
 
       class_< VerletListAdressATLennardJones, bases< Interaction > >
         ("interaction_VerletListAdressATLennardJones",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("getVerletList", &VerletListAdressATLennardJones::getVerletList)
         .def("setPotential", &VerletListAdressATLennardJones::setPotential)
         .def("getPotential", &VerletListAdressATLennardJones::getPotentialPtr)
@@ -120,16 +120,16 @@ namespace espressopp {
 
       class_< VerletListAdressATLenJonesReacFieldGen, bases< Interaction > >
         ("interaction_VerletListAdressATLenJonesReacFieldGen",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotential1", &VerletListAdressATLenJonesReacFieldGen::setPotential1)
         .def("setPotential2", &VerletListAdressATLenJonesReacFieldGen::setPotential2);
       ;
 
       class_< VerletListAdressATLJReacFieldGenTab, bases< Interaction > >
         ("interaction_VerletListAdressATLJReacFieldGenTab",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT1", &VerletListAdressATLJReacFieldGenTab::setPotentialAT1)
         .def("setPotentialAT2", &VerletListAdressATLJReacFieldGenTab::setPotentialAT2)
         .def("setPotentialCG", &VerletListAdressATLJReacFieldGenTab::setPotentialCG);
@@ -137,8 +137,8 @@ namespace espressopp {
 
       class_< VerletListAdressATLJReacFieldGenHarmonic, bases< Interaction > >
         ("interaction_VerletListAdressATLJReacFieldGenHarmonic",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT1", &VerletListAdressATLJReacFieldGenHarmonic::setPotentialAT1)
         .def("setPotentialAT2", &VerletListAdressATLJReacFieldGenHarmonic::setPotentialAT2)
         .def("setPotentialCG", &VerletListAdressATLJReacFieldGenHarmonic::setPotentialCG);
@@ -146,8 +146,8 @@ namespace espressopp {
 
       class_< VerletListAdressCGLennardJones, bases< Interaction > >
         ("interaction_VerletListAdressCGLennardJones",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("getVerletList", &VerletListAdressCGLennardJones::getVerletList)
         .def("setPotential", &VerletListAdressCGLennardJones::setPotential)
         .def("getPotential", &VerletListAdressCGLennardJones::getPotentialPtr)
@@ -155,32 +155,32 @@ namespace espressopp {
 
       class_< VerletListAdressLennardJones, bases< Interaction > >
         ("interaction_VerletListAdressLennardJones",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListAdressLennardJones::setPotentialAT)
         .def("setPotentialCG", &VerletListAdressLennardJones::setPotentialCG);
       ;
 
       class_< VerletListAdressLennardJones2, bases< Interaction > >
         ("interaction_VerletListAdressLennardJones2",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListAdressLennardJones2::setPotentialAT)
         .def("setPotentialCG", &VerletListAdressLennardJones2::setPotentialCG);
       ;
 
       class_< VerletListAdressLennardJonesHarmonic, bases< Interaction > >
         ("interaction_VerletListAdressLennardJonesHarmonic",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListAdressLennardJonesHarmonic::setPotentialAT)
         .def("setPotentialCG", &VerletListAdressLennardJonesHarmonic::setPotentialCG);
       ;
 
       class_< VerletListHadressATLennardJones, bases< Interaction > >
         ("interaction_VerletListHadressATLennardJones",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("getVerletList", &VerletListHadressATLennardJones::getVerletList)
         .def("setPotential", &VerletListHadressATLennardJones::setPotential)
         .def("getPotential", &VerletListHadressATLennardJones::getPotentialPtr)
@@ -188,16 +188,16 @@ namespace espressopp {
 
       class_< VerletListHadressATLenJonesReacFieldGen, bases< Interaction > >
         ("interaction_VerletListHadressATLenJonesReacFieldGen",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotential1", &VerletListHadressATLenJonesReacFieldGen::setPotential1)
         .def("setPotential2", &VerletListHadressATLenJonesReacFieldGen::setPotential2);
       ;
 
       class_< VerletListHadressATLJReacFieldGenTab, bases< Interaction > >
         ("interaction_VerletListHadressATLJReacFieldGenTab",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT1", &VerletListHadressATLJReacFieldGenTab::setPotentialAT1)
         .def("setPotentialAT2", &VerletListHadressATLJReacFieldGenTab::setPotentialAT2)
         .def("setPotentialCG", &VerletListHadressATLJReacFieldGenTab::setPotentialCG);
@@ -205,8 +205,8 @@ namespace espressopp {
 
       class_< VerletListHadressATLJReacFieldGenHarmonic, bases< Interaction > >
         ("interaction_VerletListHadressATLJReacFieldGenHarmonic",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT1", &VerletListHadressATLJReacFieldGenHarmonic::setPotentialAT1)
         .def("setPotentialAT2", &VerletListHadressATLJReacFieldGenHarmonic::setPotentialAT2)
         .def("setPotentialCG", &VerletListHadressATLJReacFieldGenHarmonic::setPotentialCG);
@@ -214,8 +214,8 @@ namespace espressopp {
 
       class_< VerletListHadressCGLennardJones, bases< Interaction > >
         ("interaction_VerletListHadressCGLennardJones",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("getVerletList", &VerletListHadressCGLennardJones::getVerletList)
         .def("setPotential", &VerletListHadressCGLennardJones::setPotential)
         .def("getPotential", &VerletListHadressCGLennardJones::getPotentialPtr)
@@ -223,37 +223,37 @@ namespace espressopp {
 
       class_< VerletListHadressLennardJones, bases< Interaction > >
         ("interaction_VerletListHadressLennardJones",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListHadressLennardJones::setPotentialAT)
         .def("setPotentialCG", &VerletListHadressLennardJones::setPotentialCG);
       ;
 
       class_< VerletListHadressLennardJones2, bases< Interaction > >
         ("interaction_VerletListHadressLennardJones2",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListHadressLennardJones2::setPotentialAT)
         .def("setPotentialCG", &VerletListHadressLennardJones2::setPotentialCG);
       ;
 
       class_< VerletListHadressLennardJonesHarmonic, bases< Interaction > >
         ("interaction_VerletListHadressLennardJonesHarmonic",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListHadressLennardJonesHarmonic::setPotentialAT)
         .def("setPotentialCG", &VerletListHadressLennardJonesHarmonic::setPotentialCG);
       ;
 
       class_< CellListLennardJones, bases< Interaction > >
-        ("interaction_CellListLennardJones", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListLennardJones", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListLennardJones::setPotential);
     ;
 
       class_< FixedPairListLennardJones, bases< Interaction > >
         ("interaction_FixedPairListLennardJones",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<LennardJones> >())
-          .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<LennardJones> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<LennardJones> >())
+          .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<LennardJones> >())
           .def("setPotential", &FixedPairListLennardJones::setPotential)
           .def("getPotential", &FixedPairListLennardJones::getPotential)
           .def("setFixedPairList", &FixedPairListLennardJones::setFixedPairList)
@@ -261,8 +261,8 @@ namespace espressopp {
       ;
 
       class_< FixedPairListTypesLennardJones, bases< Interaction > >
-        ("interaction_FixedPairListTypesLennardJones", init< shared_ptr<System>, shared_ptr<FixedPairList> >())
-         .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress> >())
+        ("interaction_FixedPairListTypesLennardJones", init< std::shared_ptr<System>, std::shared_ptr<FixedPairList> >())
+         .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress> >())
          .def("setFixedPairList", &FixedPairListTypesLennardJones::setFixedPairList)
          .def("getFixedPairList", &FixedPairListTypesLennardJones::getFixedPairList)
          .def("setPotential", &FixedPairListTypesLennardJones::setPotential)

--- a/src/interaction/LennardJones.py
+++ b/src/interaction/LennardJones.py
@@ -46,7 +46,7 @@ espressopp.interaction.LennardJones
         Defines a verletlist-based interaction using a Lennard-Jones potential.
 
         :param vl: Verletlist object
-        :type vl: shared_ptr<VerletList>
+        :type vl: std::shared_ptr<VerletList>
 
 .. function:: espressopp.interaction.VerletListLennardJones.getPotential(type1, type2)
 
@@ -56,13 +56,13 @@ espressopp.interaction.LennardJones
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<LennardJones>
+        :rtype: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListLennardJones.getVerletList()
 
         Gets the verletlist used in VerletListLennardJones interaction.
 
-        :rtype: shared_ptr<VerletList>
+        :rtype: std::shared_ptr<VerletList>
 
 .. function:: espressopp.interaction.VerletListLennardJones.setPotential(type1, type2, potential)
 
@@ -73,7 +73,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListAdressLennardJones(vl, fixedtupleList)
 
@@ -81,8 +81,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressLennardJones.setPotentialAT(type1, type2, potential)
 
@@ -93,7 +93,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListAdressLennardJones.setPotentialCG(type1, type2, potential)
 
@@ -104,7 +104,7 @@ espressopp.interaction.LennardJones
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListAdressLennardJones2(vl, fixedtupleList)
 
@@ -112,8 +112,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressLennardJones2.setPotentialAT(type1, type2, potential)
 
@@ -124,7 +124,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListAdressLennardJones2.setPotentialCG(type1, type2, potential)
 
@@ -135,7 +135,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListAdressLennardJonesHarmonic(vl, fixedtupleList)
 
@@ -143,8 +143,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressLennardJonesHarmonic.setPotentialAT(type1, type2, potential)
 
@@ -155,7 +155,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListAdressLennardJonesHarmonic.setPotentialCG(type1, type2, potential)
 
@@ -166,7 +166,7 @@ espressopp.interaction.LennardJones
         :param potential: Harmonic potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Harmonic>
+        :type potential: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.VerletListHadressLennardJones(vl, fixedtupleList)
 
@@ -174,8 +174,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressLennardJones.setPotentialAT(type1, type2, potential)
 
@@ -186,7 +186,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListHadressLennardJones.setPotentialCG(type1, type2, potential)
 
@@ -197,7 +197,7 @@ espressopp.interaction.LennardJones
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListHadressLennardJones2(vl, fixedtupleList)
 
@@ -205,8 +205,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressLennardJones2.setPotentialAT(type1, type2, potential)
 
@@ -217,7 +217,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListHadressLennardJones2.setPotentialCG(type1, type2, potential)
 
@@ -228,7 +228,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListHadressLennardJonesHarmonic(vl, fixedtupleList)
 
@@ -236,8 +236,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressLennardJonesHarmonic.setPotentialAT(type1, type2, potential)
 
@@ -248,7 +248,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListHadressLennardJonesHarmonic.setPotentialCG(type1, type2, potential)
 
@@ -259,14 +259,14 @@ espressopp.interaction.LennardJones
         :param potential: Harmonic potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Harmonic>
+        :type potential: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.CellListLennardJones(stor)
 
         Defines a CellList-based interaction using a LennardJones potential.
 
         :param stor: storage object
-        :type stor: shared_ptr <storage::Storage>
+        :type stor: std::shared_ptr <storage::Storage>
 
 .. function:: espressopp.interaction.CellListLennardJones.setPotential(type1, type2, potential)
 
@@ -277,7 +277,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.FixedPairListLennardJones(system, vl, potential)
 
@@ -286,35 +286,35 @@ espressopp.interaction.LennardJones
         :param system: system object
         :param vl: FixedPairList object
         :param potential: LennardJones potential object
-        :type system: shared_ptr<System>
-        :type vl: shared_ptr<FixedPairList>
-        :type potential: shared_ptr<LennardJones>
+        :type system: std::shared_ptr<System>
+        :type vl: std::shared_ptr<FixedPairList>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.FixedPairListLennardJones.getFixedPairList()
 
         Gets the FixedPairList.
 
-        :rtype: shared_ptr<FixedPairList>
+        :rtype: std::shared_ptr<FixedPairList>
 
 .. function:: espressopp.interaction.FixedPairListLennardJones.getPotential()
 
         Gets the LennardJones interaction potential.
 
-        :rtype: shared_ptr<LennardJones>
+        :rtype: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.FixedPairListLennardJones.setFixedPairList(fixedpairlist)
 
         Sets the FixedPairList.
 
         :param fixedpairlist: FixedPairList object
-        :type fixedpairlist: shared_ptr<FixedPairList>
+        :type fixedpairlist: std::shared_ptr<FixedPairList>
 
 .. function:: espressopp.interaction.FixedPairListLennardJones.setPotential(potential)
 
         Sets the LennardJones interaction potential.
 
         :param potential: tabulated potential object
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListAdressATLennardJones(vl, fixedtupleList)
 
@@ -322,8 +322,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressATLennardJones.setPotential(type1, type2, potential)
 
@@ -334,7 +334,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListAdressATLennardJones.getPotential(type1, type2)
 
@@ -344,13 +344,13 @@ espressopp.interaction.LennardJones
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<LennardJones>
+        :rtype: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListAdressATLennardJones.getVerletList()
 
         Gets the verletlist used in VerletListAdressATLennardJones interaction.
 
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressATLennardJones(vl, fixedtupleList)
 
@@ -358,8 +358,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressATLennardJones.setPotential(type1, type2, potential)
 
@@ -370,7 +370,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListHadressATLennardJones.getPotential(type1, type2)
 
@@ -380,13 +380,13 @@ espressopp.interaction.LennardJones
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<LennardJones>
+        :rtype: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListHadressATLennardJones.getVerletList()
 
         Gets the verletlist used in VerletListHadressATLennardJones interaction.
 
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressCGLennardJones(vl, fixedtupleList)
 
@@ -394,8 +394,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressCGLennardJones.setPotential(type1, type2, potential)
 
@@ -406,7 +406,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListAdressCGLennardJones.getPotential(type1, type2)
 
@@ -416,13 +416,13 @@ espressopp.interaction.LennardJones
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<LennardJones>
+        :rtype: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListAdressCGLennardJones.getVerletList()
 
         Gets the verletlist used in VerletListAdressCGLennardJones interaction.
 
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressCGLennardJones(vl, fixedtupleList)
 
@@ -430,8 +430,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressCGLennardJones.setPotential(type1, type2, potential)
 
@@ -442,7 +442,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListHadressCGLennardJones.getPotential(type1, type2)
 
@@ -452,13 +452,13 @@ espressopp.interaction.LennardJones
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<LennardJones>
+        :rtype: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListHadressCGLennardJones.getVerletList()
 
         Gets the verletlist used in VerletListHadressCGLennardJones interaction.
 
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressATLenJonesReacFieldGen(vl, fixedtupleList)
 
@@ -466,8 +466,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressATLenJonesReacFieldGen.setPotential1(type1, type2, potential)
 
@@ -478,7 +478,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListAdressATLenJonesReacFieldGen.setPotential2(type1, type2, potential)
 
@@ -489,7 +489,7 @@ espressopp.interaction.LennardJones
         :param potential: ReactionFieldGeneralized potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<ReactionFieldGeneralized>
+        :type potential: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.VerletListHadressATLenJonesReacFieldGen(vl, fixedtupleList)
 
@@ -497,8 +497,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressATLenJonesReacFieldGen.setPotential1(type1, type2, potential)
 
@@ -509,7 +509,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListHadressATLenJonesReacFieldGen.setPotential2(type1, type2, potential)
 
@@ -520,7 +520,7 @@ espressopp.interaction.LennardJones
         :param potential: ReactionFieldGeneralized potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<ReactionFieldGeneralized>
+        :type potential: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.VerletListAdressATLJReacFieldGenTab(vl, fixedtupleList)
 
@@ -528,8 +528,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressATLJReacFieldGenTab.setPotentialAT1(type1, type2, potential)
 
@@ -540,7 +540,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListAdressATLJReacFieldGenTab.setPotentialAT2(type1, type2, potential)
 
@@ -551,7 +551,7 @@ espressopp.interaction.LennardJones
         :param potential: ReactionFieldGeneralized potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<ReactionFieldGeneralized>
+        :type potential: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.VerletListAdressATLJReacFieldGenTab.setPotentialCG(type1, type2, potential)
 
@@ -562,7 +562,7 @@ espressopp.interaction.LennardJones
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListHadressATLJReacFieldGenTab(vl, fixedtupleList)
 
@@ -570,8 +570,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressATLJReacFieldGenTab.setPotentialAT1(type1, type2, potential)
 
@@ -582,7 +582,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListHadressATLJReacFieldGenTab.setPotentialAT2(type1, type2, potential)
 
@@ -593,7 +593,7 @@ espressopp.interaction.LennardJones
         :param potential: ReactionFieldGeneralized potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<ReactionFieldGeneralized>
+        :type potential: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.VerletListHadressATLJReacFieldGenTab.setPotentialCG(type1, type2, potential)
 
@@ -604,7 +604,7 @@ espressopp.interaction.LennardJones
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListAdressATLJReacFieldGenHarmonic(vl, fixedtupleList)
 
@@ -612,8 +612,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressATLJReacFieldGenHarmonic.setPotentialAT1(type1, type2, potential)
 
@@ -624,7 +624,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListAdressATLJReacFieldGenHarmonic.setPotentialAT2(type1, type2, potential)
 
@@ -635,7 +635,7 @@ espressopp.interaction.LennardJones
         :param potential: ReactionFieldGeneralized potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<ReactionFieldGeneralized>
+        :type potential: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.VerletListAdressATLJReacFieldGenHarmonic.setPotentialCG(type1, type2, potential)
 
@@ -646,7 +646,7 @@ espressopp.interaction.LennardJones
         :param potential: Harmonic potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Harmonic>
+        :type potential: std::shared_ptr<Harmonic>
 
 .. function:: espressopp.interaction.VerletListHadressATLJReacFieldGenHarmonic(vl, fixedtupleList)
 
@@ -654,8 +654,8 @@ espressopp.interaction.LennardJones
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressATLJReacFieldGenHarmonic.setPotentialAT1(type1, type2, potential)
 
@@ -666,7 +666,7 @@ espressopp.interaction.LennardJones
         :param potential: LennardJones potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<LennardJones>
+        :type potential: std::shared_ptr<LennardJones>
 
 .. function:: espressopp.interaction.VerletListHadressATLJReacFieldGenHarmonic.setPotentialAT2(type1, type2, potential)
 
@@ -677,7 +677,7 @@ espressopp.interaction.LennardJones
         :param potential: ReactionFieldGeneralized potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<ReactionFieldGeneralized>
+        :type potential: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.VerletListHadressATLJReacFieldGenHarmonic.setPotentialCG(type1, type2, potential)
 
@@ -688,7 +688,7 @@ espressopp.interaction.LennardJones
         :param potential: Harmonic potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Harmonic>
+        :type potential: std::shared_ptr<Harmonic>
 
 """
 from espressopp import pmi, infinity

--- a/src/interaction/LennardJones93Wall.cpp
+++ b/src/interaction/LennardJones93Wall.cpp
@@ -46,7 +46,7 @@ namespace espressopp {
         ;
 
       class_< SingleParticleLennardJones93Wall, bases< Interaction > >
-        ("interaction_SingleParticleLennardJones93Wall", init< shared_ptr<System>, shared_ptr<LennardJones93Wall> >())
+        ("interaction_SingleParticleLennardJones93Wall", init< std::shared_ptr<System>, std::shared_ptr<LennardJones93Wall> >())
         .def("setPotential", &SingleParticleLennardJones93Wall::setPotential)
         .def("getPotential", &SingleParticleLennardJones93Wall::getPotential)
        ;

--- a/src/interaction/LennardJonesAutoBonds.cpp
+++ b/src/interaction/LennardJonesAutoBonds.cpp
@@ -51,15 +51,15 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_< LennardJonesAutoBonds, bases< Potential > >
-    	("interaction_LennardJonesAutoBonds", init< real, real, real, shared_ptr<FixedPairList>, int >())
-	    .def(init< real, real, real, real, shared_ptr<FixedPairList>, int >())
+    	("interaction_LennardJonesAutoBonds", init< real, real, real, std::shared_ptr<FixedPairList>, int >())
+	    .def(init< real, real, real, real, std::shared_ptr<FixedPairList>, int >())
     	.add_property("sigma", &LennardJonesAutoBonds::getSigma, &LennardJonesAutoBonds::setSigma)
     	.add_property("epsilon", &LennardJonesAutoBonds::getEpsilon, &LennardJonesAutoBonds::setEpsilon)
     	.add_property("max_crosslinks", &LennardJonesAutoBonds::getMaxCrosslinks, &LennardJonesAutoBonds::setMaxCrosslinks)
       ;
 
       class_< VerletListLennardJonesAutoBonds, bases< Interaction > >
-        ("interaction_VerletListLennardJonesAutoBonds", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListLennardJonesAutoBonds", init< std::shared_ptr<VerletList> >())
         .def("getVerletList", &VerletListLennardJonesAutoBonds::getVerletList)
         .def("setPotential", &VerletListLennardJonesAutoBonds::setPotential, return_value_policy< reference_existing_object >())
         .def("getPotential", &VerletListLennardJonesAutoBonds::getPotential, return_value_policy< reference_existing_object >())
@@ -67,29 +67,29 @@ namespace espressopp {
 
       class_< VerletListAdressLennardJonesAutoBonds, bases< Interaction > >
         ("interaction_VerletListAdressLennardJonesAutoBonds",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListAdressLennardJonesAutoBonds::setPotentialAT)
         .def("setPotentialCG", &VerletListAdressLennardJonesAutoBonds::setPotentialCG);
       ;
       
       class_< VerletListHadressLennardJonesAutoBonds, bases< Interaction > >
         ("interaction_VerletListHadressLennardJonesAutoBonds",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListHadressLennardJonesAutoBonds::setPotentialAT)
         .def("setPotentialCG", &VerletListHadressLennardJonesAutoBonds::setPotentialCG);
       ;
 
       class_< CellListLennardJonesAutoBonds, bases< Interaction > >
-        ("interaction_CellListLennardJonesAutoBonds", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListLennardJonesAutoBonds", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListLennardJonesAutoBonds::setPotential);
 	  ;
 
       class_< FixedPairListLennardJonesAutoBonds, bases< Interaction > >
         ("interaction_FixedPairListLennardJonesAutoBonds",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<LennardJonesAutoBonds> >())
-          .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<LennardJonesAutoBonds> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<LennardJonesAutoBonds> >())
+          .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<LennardJonesAutoBonds> >())
           .def("setPotential", &FixedPairListLennardJonesAutoBonds::setPotential);
       ;
     }

--- a/src/interaction/LennardJonesAutoBonds.hpp
+++ b/src/interaction/LennardJonesAutoBonds.hpp
@@ -44,7 +44,7 @@ namespace espressopp {
       real sigma;
       real ff1, ff2;
       real ef1, ef2;
-      shared_ptr < FixedPairList > bondlist;
+      std::shared_ptr < FixedPairList > bondlist;
       int max_crosslinks;
 
     public:
@@ -58,7 +58,7 @@ namespace espressopp {
       }
 
       LennardJonesAutoBonds(real _epsilon, real _sigma,
-		   real _cutoff, real _shift, shared_ptr < FixedPairList > _fpl, int _max_crosslinks)
+		   real _cutoff, real _shift, std::shared_ptr < FixedPairList > _fpl, int _max_crosslinks)
 	: epsilon(_epsilon), sigma(_sigma), bondlist(_fpl), max_crosslinks(_max_crosslinks) {
         setShift(_shift);
         setCutoff(_cutoff);
@@ -66,7 +66,7 @@ namespace espressopp {
       }
 
       LennardJonesAutoBonds(real _epsilon, real _sigma,
-		   real _cutoff, shared_ptr < FixedPairList > _fpl, int _max_crosslinks)
+		   real _cutoff, std::shared_ptr < FixedPairList > _fpl, int _max_crosslinks)
 	: epsilon(_epsilon), sigma(_sigma), bondlist(_fpl), max_crosslinks(_max_crosslinks) {
         autoShift = false;
         setCutoff(_cutoff);

--- a/src/interaction/LennardJonesCapped.cpp
+++ b/src/interaction/LennardJonesCapped.cpp
@@ -60,14 +60,14 @@ namespace espressopp {
       ;
 
       class_< VerletListLennardJonesCapped, bases< Interaction > >
-        ("interaction_VerletListLennardJonesCapped", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListLennardJonesCapped", init< std::shared_ptr<VerletList> >())
         .def("setPotential", &VerletListLennardJonesCapped::setPotential, return_value_policy< reference_existing_object >())
         .def("getPotential", &VerletListLennardJonesCapped::getPotential, return_value_policy< reference_existing_object >())
       ;
 
       class_< VerletListAdressLennardJonesCapped, bases< Interaction > >
         ("interaction_VerletListAdressLennardJonesCapped",
-         init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+         init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
          .def("setPotentialAT", &VerletListAdressLennardJonesCapped::setPotentialAT)
          .def("setPotentialCG", &VerletListAdressLennardJonesCapped::setPotentialCG)
          .def("getPotentialAT", &VerletListAdressLennardJonesCapped::getPotentialAT,
@@ -78,7 +78,7 @@ namespace espressopp {
 
       class_< VerletListHadressLennardJonesCapped, bases< Interaction > >
         ("interaction_VerletListHadressLennardJonesCapped",
-         init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+         init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
          .def("setPotentialAT", &VerletListHadressLennardJonesCapped::setPotentialAT)
          .def("setPotentialCG", &VerletListHadressLennardJonesCapped::setPotentialCG)
          .def("getPotentialAT", &VerletListHadressLennardJonesCapped::getPotentialAT,
@@ -88,15 +88,15 @@ namespace espressopp {
       ;
       
       class_< CellListLennardJonesCapped, bases< Interaction > >
-        ("interaction_CellListLennardJonesCapped", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListLennardJonesCapped", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListLennardJonesCapped::setPotential)
         .def("getPotential", &CellListLennardJonesCapped::getPotential, return_value_policy< reference_existing_object >());
 	  ;
 
       class_< FixedPairListLennardJonesCapped, bases< Interaction > >
         ("interaction_FixedPairListLennardJonesCapped",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<LennardJonesCapped> >())
-          .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<LennardJonesCapped> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<LennardJonesCapped> >())
+          .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<LennardJonesCapped> >())
           .def("setPotential", &FixedPairListLennardJonesCapped::setPotential);
       ;
     }

--- a/src/interaction/LennardJonesEnergyCapped.cpp
+++ b/src/interaction/LennardJonesEnergyCapped.cpp
@@ -60,14 +60,14 @@ namespace espressopp {
       ;
 
       class_< VerletListLennardJonesEnergyCapped, bases< Interaction > >
-        ("interaction_VerletListLennardJonesEnergyCapped", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListLennardJonesEnergyCapped", init< std::shared_ptr<VerletList> >())
         .def("setPotential", &VerletListLennardJonesEnergyCapped::setPotential, return_value_policy< reference_existing_object >())
         .def("getPotential", &VerletListLennardJonesEnergyCapped::getPotential, return_value_policy< reference_existing_object >())
       ;
 
       class_< VerletListAdressLennardJonesEnergyCapped, bases< Interaction > >
         ("interaction_VerletListAdressLennardJonesEnergyCapped",
-         init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+         init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
          .def("setPotentialAT", &VerletListAdressLennardJonesEnergyCapped::setPotentialAT)
          .def("setPotentialCG", &VerletListAdressLennardJonesEnergyCapped::setPotentialCG)
          .def("getPotentialAT", &VerletListAdressLennardJonesEnergyCapped::getPotentialAT,
@@ -78,7 +78,7 @@ namespace espressopp {
 
       class_< VerletListHadressLennardJonesEnergyCapped, bases< Interaction > >
         ("interaction_VerletListHadressLennardJonesEnergyCapped",
-         init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+         init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
          .def("setPotentialAT", &VerletListHadressLennardJonesEnergyCapped::setPotentialAT)
          .def("setPotentialCG", &VerletListHadressLennardJonesEnergyCapped::setPotentialCG)
          .def("getPotentialAT", &VerletListHadressLennardJonesEnergyCapped::getPotentialAT,
@@ -88,15 +88,15 @@ namespace espressopp {
       ;
       
       class_< CellListLennardJonesEnergyCapped, bases< Interaction > >
-        ("interaction_CellListLennardJonesEnergyCapped", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListLennardJonesEnergyCapped", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListLennardJonesEnergyCapped::setPotential)
         .def("getPotential", &CellListLennardJonesEnergyCapped::getPotential, return_value_policy< reference_existing_object >());
 	  ;
 
       class_< FixedPairListLennardJonesEnergyCapped, bases< Interaction > >
         ("interaction_FixedPairListLennardJonesEnergyCapped",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<LennardJonesEnergyCapped> >())
-          .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<LennardJonesEnergyCapped> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<LennardJonesEnergyCapped> >())
+          .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<LennardJonesEnergyCapped> >())
           .def("setPotential", &FixedPairListLennardJonesEnergyCapped::setPotential);
       ;
     }

--- a/src/interaction/LennardJonesExpand.cpp
+++ b/src/interaction/LennardJonesExpand.cpp
@@ -52,19 +52,19 @@ namespace espressopp {
     	;
 
       class_< VerletListLennardJonesExpand, bases< Interaction > > 
-        ("interaction_VerletListLennardJonesExpand", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListLennardJonesExpand", init< std::shared_ptr<VerletList> >())
         .def("setPotential", &VerletListLennardJonesExpand::setPotential, return_value_policy< reference_existing_object >())
         .def("getPotential", &VerletListLennardJonesExpand::getPotential, return_value_policy< reference_existing_object >())
         ;
 
       class_< CellListLennardJonesExpand, bases< Interaction > >
-        ("interaction_CellListLennardJonesExpand", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListLennardJonesExpand", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListLennardJonesExpand::setPotential);
 	;
 
       class_< FixedPairListLennardJonesExpand, bases< Interaction > >
         ("interaction_FixedPairListLennardJonesExpand",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<LennardJonesExpand> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<LennardJonesExpand> >())
         .def("setPotential", &FixedPairListLennardJonesExpand::setPotential);
         ;
     }

--- a/src/interaction/LennardJonesGeneric.cpp
+++ b/src/interaction/LennardJonesGeneric.cpp
@@ -66,7 +66,7 @@ namespace espressopp {
       ;
 
       class_< VerletListLennardJonesGeneric, bases< Interaction > > 
-        ("interaction_VerletListLennardJonesGeneric", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListLennardJonesGeneric", init< std::shared_ptr<VerletList> >())
         .def("getVerletList", &VerletListLennardJonesGeneric::getVerletList)
         .def("setPotential", &VerletListLennardJonesGeneric::setPotential)
         .def("getPotential", &VerletListLennardJonesGeneric::getPotentialPtr)
@@ -74,45 +74,45 @@ namespace espressopp {
 
       class_< VerletListAdressLennardJonesGeneric, bases< Interaction > >
         ("interaction_VerletListAdressLennardJonesGeneric",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListAdressLennardJonesGeneric::setPotentialAT)
         .def("setPotentialCG", &VerletListAdressLennardJonesGeneric::setPotentialCG);
       ;
       
       class_< VerletListAdressLennardJonesGeneric2, bases< Interaction > >
         ("interaction_VerletListAdressLennardJonesGeneric2",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListAdressLennardJonesGeneric2::setPotentialAT)
         .def("setPotentialCG", &VerletListAdressLennardJonesGeneric2::setPotentialCG);
       ;
 
       class_< VerletListHadressLennardJonesGeneric, bases< Interaction > >
         ("interaction_VerletListHadressLennardJonesGeneric",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListHadressLennardJonesGeneric::setPotentialAT)
         .def("setPotentialCG", &VerletListHadressLennardJonesGeneric::setPotentialCG);
       ;
       
       class_< VerletListHadressLennardJonesGeneric2, bases< Interaction > >
         ("interaction_VerletListHadressLennardJonesGeneric2",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListHadressLennardJonesGeneric2::setPotentialAT)
         .def("setPotentialCG", &VerletListHadressLennardJonesGeneric2::setPotentialCG);
       ;
       
       class_< CellListLennardJonesGeneric, bases< Interaction > > 
-        ("interaction_CellListLennardJonesGeneric", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListLennardJonesGeneric", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListLennardJonesGeneric::setPotential);
 	  ;
 
       class_< FixedPairListLennardJonesGeneric, bases< Interaction > >
         ("interaction_FixedPairListLennardJonesGeneric",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<LennardJonesGeneric> >())
-          .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<LennardJonesGeneric> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<LennardJonesGeneric> >())
+          .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<LennardJonesGeneric> >())
           .def("setPotential", &FixedPairListLennardJonesGeneric::setPotential)
           .def("getPotential", &FixedPairListLennardJonesGeneric::getPotential)
           .def("setFixedPairList", &FixedPairListLennardJonesGeneric::setFixedPairList)

--- a/src/interaction/LennardJonesGromacs.cpp
+++ b/src/interaction/LennardJonesGromacs.cpp
@@ -52,19 +52,19 @@ namespace espressopp {
     	;
 
       class_< VerletListLennardJonesGromacs, bases< Interaction > > 
-        ("interaction_VerletListLennardJonesGromacs", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListLennardJonesGromacs", init< std::shared_ptr<VerletList> >())
         .def("setPotential", &VerletListLennardJonesGromacs::setPotential, return_value_policy< reference_existing_object >())
         .def("getPotential", &VerletListLennardJonesGromacs::getPotential, return_value_policy< reference_existing_object >())
         ;
 
       class_< CellListLennardJonesGromacs, bases< Interaction > >
-        ("interaction_CellListLennardJonesGromacs", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListLennardJonesGromacs", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListLennardJonesGromacs::setPotential);
 	;
 
       class_< FixedPairListLennardJonesGromacs, bases< Interaction > >
         ("interaction_FixedPairListLennardJonesGromacs",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<LennardJonesGromacs> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<LennardJonesGromacs> >())
         .def("setPotential", &FixedPairListLennardJonesGromacs::setPotential);
         ;
     }

--- a/src/interaction/LennardJonesSoftcoreTI.cpp
+++ b/src/interaction/LennardJonesSoftcoreTI.cpp
@@ -58,7 +58,7 @@ namespace espressopp {
       ;
 
       //class_< VerletListLennardJonesSoftcoreTI, bases< Interaction > > 
-      //  ("interaction_VerletListLennardJonesSoftcoreTI", init< shared_ptr<VerletList> >())
+      //  ("interaction_VerletListLennardJonesSoftcoreTI", init< std::shared_ptr<VerletList> >())
       //  .def("getVerletList", &VerletListLennardJonesSoftcoreTI::getVerletList)
       //  .def("setPotential", &VerletListLennardJonesSoftcoreTI::setPotential)
       //  .def("getPotential", &VerletListLennardJonesSoftcoreTI::getPotentialPtr)
@@ -66,16 +66,16 @@ namespace espressopp {
 
       class_< VerletListAdressLennardJonesSoftcoreTI, bases< Interaction > >
         ("interaction_VerletListAdressLennardJonesSoftcoreTI",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListAdressLennardJonesSoftcoreTI::setPotentialAT)
         .def("setPotentialCG", &VerletListAdressLennardJonesSoftcoreTI::setPotentialCG);
       ;
       
       //class_< VerletListHadressLennardJonesSoftcoreTI, bases< Interaction > >
       //  ("interaction_VerletListHadressLennardJonesSoftcoreTI",
-      //     init< shared_ptr<VerletListAdress>,
-      //            shared_ptr<FixedTupleListAdress> >())
+      //     init< std::shared_ptr<VerletListAdress>,
+      //            std::shared_ptr<FixedTupleListAdress> >())
       //  .def("setPotentialAT", &VerletListHadressLennardJonesSoftcoreTI::setPotentialAT)
       //  .def("setPotentialCG", &VerletListHadressLennardJonesSoftcoreTI::setPotentialCG);
       //;

--- a/src/interaction/MirrorLennardJones.cpp
+++ b/src/interaction/MirrorLennardJones.cpp
@@ -47,8 +47,8 @@ namespace espressopp {
 
       class_< FixedPairListMirrorLennardJones, bases< Interaction > >
       ("interaction_FixedPairListMirrorLennardJones",
-        init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<MirrorLennardJones> >())
-       .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<MirrorLennardJones> >())
+        init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<MirrorLennardJones> >())
+       .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<MirrorLennardJones> >())
        .def("setPotential", &FixedPairListMirrorLennardJones::setPotential)
        .def("getPotential", &FixedPairListMirrorLennardJones::getPotential)
        .def("setFixedPairList", &FixedPairListMirrorLennardJones::setFixedPairList)

--- a/src/interaction/Morse.cpp
+++ b/src/interaction/Morse.cpp
@@ -59,34 +59,34 @@ namespace espressopp {
     	;
 
       class_< VerletListMorse, bases< Interaction > > 
-        ("interaction_VerletListMorse", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListMorse", init< std::shared_ptr<VerletList> >())
         .def("setPotential", &VerletListMorse::setPotential)
         .def("getPotential", &VerletListMorse::getPotentialPtr)
       ;
 
       class_< VerletListAdressMorse, bases< Interaction > >
         ("interaction_VerletListAdressMorse",
-                init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+                init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListAdressMorse::setPotentialAT)
         .def("setPotentialCG", &VerletListAdressMorse::setPotentialCG);
         ;
         
       class_< VerletListHadressMorse, bases< Interaction > >
         ("interaction_VerletListHadressMorse",
-                init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+                init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListHadressMorse::setPotentialAT)
         .def("setPotentialCG", &VerletListHadressMorse::setPotentialCG);
         ;
         
       class_< CellListMorse, bases< Interaction > > 
-        ("interaction_CellListMorse", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListMorse", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListMorse::setPotential);
 	;
 
       class_< FixedPairListMorse, bases< Interaction > >
         ("interaction_FixedPairListMorse",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<Morse> >())
-        .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<Morse> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<Morse> >())
+        .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<Morse> >())
         .def("setPotential", &FixedPairListMorse::setPotential);
         ;
     }

--- a/src/interaction/OPLS.cpp
+++ b/src/interaction/OPLS.cpp
@@ -47,9 +47,9 @@ namespace espressopp {
         FixedQuadrupleListOPLS;
       class_ <FixedQuadrupleListOPLS, bases <Interaction> >
         ("interaction_FixedQuadrupleListOPLS",
-                init< shared_ptr<System>,
-                      shared_ptr<FixedQuadrupleList>,
-                      shared_ptr<OPLS> >())
+                init< std::shared_ptr<System>,
+                      std::shared_ptr<FixedQuadrupleList>,
+                      std::shared_ptr<OPLS> >())
         .def("setPotential", &FixedQuadrupleListOPLS::setPotential);
       ;
     }

--- a/src/interaction/Potential.hpp
+++ b/src/interaction/Potential.hpp
@@ -49,12 +49,12 @@ namespace espressopp {
       virtual void setCutoff(real _cutoff) = 0;
       virtual real getCutoff() const = 0;
 
-      virtual void setColVarBondList(const shared_ptr<FixedPairList>& fpl) = 0;
-      virtual shared_ptr<FixedPairList> getColVarBondList() const = 0;
-      virtual void setColVarAngleList(const shared_ptr<FixedTripleList>& fpl) = 0;
-      virtual shared_ptr<FixedTripleList> getColVarAngleList() const = 0;
-      virtual void setColVarDihedList(const shared_ptr<FixedQuadrupleList>& fpl) = 0;
-      virtual shared_ptr<FixedQuadrupleList> getColVarDihedList() const = 0;
+      virtual void setColVarBondList(const std::shared_ptr<FixedPairList>& fpl) = 0;
+      virtual std::shared_ptr<FixedPairList> getColVarBondList() const = 0;
+      virtual void setColVarAngleList(const std::shared_ptr<FixedTripleList>& fpl) = 0;
+      virtual std::shared_ptr<FixedTripleList> getColVarAngleList() const = 0;
+      virtual void setColVarDihedList(const std::shared_ptr<FixedQuadrupleList>& fpl) = 0;
+      virtual std::shared_ptr<FixedQuadrupleList> getColVarDihedList() const = 0;
 
       virtual void setColVar(const RealND& cv) = 0;
       virtual void setColVar(const Real3D& dist, const bc::BC& bc) = 0;
@@ -101,12 +101,12 @@ namespace espressopp {
       virtual real setAutoShift();
       void updateAutoShift();
 
-      virtual void setColVarBondList(const shared_ptr<FixedPairList>& fpl);
-      virtual shared_ptr<FixedPairList> getColVarBondList() const;
-      virtual void setColVarAngleList(const shared_ptr<FixedTripleList>& fpl);
-      virtual shared_ptr<FixedTripleList> getColVarAngleList() const;
-      virtual void setColVarDihedList(const shared_ptr<FixedQuadrupleList>& fpl);
-      virtual shared_ptr<FixedQuadrupleList> getColVarDihedList() const;
+      virtual void setColVarBondList(const std::shared_ptr<FixedPairList>& fpl);
+      virtual std::shared_ptr<FixedPairList> getColVarBondList() const;
+      virtual void setColVarAngleList(const std::shared_ptr<FixedTripleList>& fpl);
+      virtual std::shared_ptr<FixedTripleList> getColVarAngleList() const;
+      virtual void setColVarDihedList(const std::shared_ptr<FixedQuadrupleList>& fpl);
+      virtual std::shared_ptr<FixedQuadrupleList> getColVarDihedList() const;
 
       virtual void setColVar(const RealND& cv);
       virtual void setColVar(const Real3D& dist, const bc::BC& bc);
@@ -150,11 +150,11 @@ namespace espressopp {
       real shift;
       bool autoShift;
       // List of bonds that correlate with the bond potential
-      shared_ptr<FixedPairList> colVarBondList;
+      std::shared_ptr<FixedPairList> colVarBondList;
       // List of angles that correlate with the bond potential
-      shared_ptr<FixedTripleList> colVarAngleList;
+      std::shared_ptr<FixedTripleList> colVarAngleList;
       // List of dihedrals that correlate with the angle potential
-      shared_ptr<FixedQuadrupleList> colVarDihedList;
+      std::shared_ptr<FixedQuadrupleList> colVarDihedList;
       // Collective variables: first itself, then angles
       RealND colVar;
 
@@ -249,12 +249,12 @@ namespace espressopp {
     template < class Derived >
     inline void
     PotentialTemplate< Derived >::
-    setColVarBondList(const shared_ptr < FixedPairList >& _fpl) {
+    setColVarBondList(const std::shared_ptr < FixedPairList >& _fpl) {
       colVarBondList = _fpl;
     }
 
     template < class Derived >
-    inline shared_ptr < FixedPairList >
+    inline std::shared_ptr < FixedPairList >
     PotentialTemplate< Derived >::
     getColVarBondList() const
     { return colVarBondList; }
@@ -263,12 +263,12 @@ namespace espressopp {
     template < class Derived >
     inline void
     PotentialTemplate< Derived >::
-    setColVarAngleList(const shared_ptr < FixedTripleList >& _fpl) {
+    setColVarAngleList(const std::shared_ptr < FixedTripleList >& _fpl) {
       colVarAngleList = _fpl;
     }
 
     template < class Derived >
-    inline shared_ptr < FixedTripleList >
+    inline std::shared_ptr < FixedTripleList >
     PotentialTemplate< Derived >::
     getColVarAngleList() const
     { return colVarAngleList; }
@@ -277,12 +277,12 @@ namespace espressopp {
     template < class Derived >
     inline void
     PotentialTemplate< Derived >::
-    setColVarDihedList(const shared_ptr < FixedQuadrupleList >& _fpl) {
+    setColVarDihedList(const std::shared_ptr < FixedQuadrupleList >& _fpl) {
       colVarDihedList = _fpl;
     }
 
     template < class Derived >
-    inline shared_ptr < FixedQuadrupleList >
+    inline std::shared_ptr < FixedQuadrupleList >
     PotentialTemplate< Derived >::
     getColVarDihedList() const
     { return colVarDihedList; }

--- a/src/interaction/Quartic.cpp
+++ b/src/interaction/Quartic.cpp
@@ -44,8 +44,8 @@ namespace espressopp {
         FixedPairListQuartic;
       class_< FixedPairListQuartic, bases< Interaction > >
         ("interaction_FixedPairListQuartic",
-           init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<Quartic> >())
-        .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<Quartic> >())
+           init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<Quartic> >())
+        .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<Quartic> >())
         .def("setPotential", &FixedPairListQuartic::setPotential)
         .def("getPotential", &FixedPairListQuartic::getPotential)
         .def("setFixedPairList", &FixedPairListQuartic::setFixedPairList)

--- a/src/interaction/ReactionFieldGeneralized.cpp
+++ b/src/interaction/ReactionFieldGeneralized.cpp
@@ -69,48 +69,48 @@ namespace espressopp {
             ;
 
             class_<VerletListReactionFieldGeneralized, bases<Interaction> >
-                ("interaction_VerletListReactionFieldGeneralized", init< shared_ptr<VerletList> >())
+                ("interaction_VerletListReactionFieldGeneralized", init< std::shared_ptr<VerletList> >())
                 .def("setPotential", &VerletListReactionFieldGeneralized::setPotential)
                 .def("getPotential", &VerletListReactionFieldGeneralized::getPotentialPtr)
             ;
 
             class_<VerletListAdressATReactionFieldGeneralized, bases<Interaction> >
                 ("interaction_VerletListAdressATReactionFieldGeneralized",
-                        init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+                        init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
                 .def("setPotential", &VerletListAdressATReactionFieldGeneralized::setPotential)
                 .def("getPotential", &VerletListAdressATReactionFieldGeneralized::getPotentialPtr)
             ;
 
             class_<VerletListAdressReactionFieldGeneralized, bases<Interaction> >
                 ("interaction_VerletListAdressReactionFieldGeneralized",
-                        init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+                        init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
                 .def("setPotentialAT", &VerletListAdressReactionFieldGeneralized::setPotentialAT)
                 .def("setPotentialCG", &VerletListAdressReactionFieldGeneralized::setPotentialCG);
             ;
 
             class_<VerletListHadressATReactionFieldGeneralized, bases<Interaction> >
                 ("interaction_VerletListHadressATReactionFieldGeneralized",
-                        init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+                        init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
                 .def("setPotential", &VerletListHadressATReactionFieldGeneralized::setPotential)
                 .def("getPotential", &VerletListHadressATReactionFieldGeneralized::getPotentialPtr)
             ;
 
             class_<VerletListHadressReactionFieldGeneralized, bases<Interaction> >
                 ("interaction_VerletListHadressReactionFieldGeneralized",
-                        init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+                        init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
                 .def("setPotentialAT", &VerletListHadressReactionFieldGeneralized::setPotentialAT)
                 .def("setPotentialCG", &VerletListHadressReactionFieldGeneralized::setPotentialCG);
             ;
 
             class_<CellListReactionFieldGeneralized, bases<Interaction> >
-                ("interaction_CellListReactionFieldGeneralized", init<shared_ptr<storage::Storage> >())
+                ("interaction_CellListReactionFieldGeneralized", init<std::shared_ptr<storage::Storage> >())
                 .def("setPotential", &CellListReactionFieldGeneralized::setPotential);
             ;
 
             /*
               class_<FixedPairListReactionFieldGeneralized, bases<Interaction> >
                 ("interaction_FixedPairListReactionFieldGeneralized",
-                  init<shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<ReactionFieldGeneralized> >())
+                  init<std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<ReactionFieldGeneralized> >())
                 .def("setPotential", &FixedPairListReactionFieldGeneralized::setPotential);
                 ;*/
         }

--- a/src/interaction/ReactionFieldGeneralized.py
+++ b/src/interaction/ReactionFieldGeneralized.py
@@ -60,7 +60,7 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
         Defines a verletlist-based interaction using a ReactionFieldGeneralized potential.
 
         :param vl: Verletlist object
-        :type vl: shared_ptr<VerletList>
+        :type vl: std::shared_ptr<VerletList>
 
 .. function:: espressopp.interaction.VerletListReactionFieldGeneralized.getPotential(type1, type2)
 
@@ -70,7 +70,7 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<ReactionFieldGeneralized>
+        :rtype: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.VerletListReactionFieldGeneralized.setPotential(type1, type2, potential)
 
@@ -81,7 +81,7 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
         :param potential: ReactionFieldGeneralized potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<ReactionFieldGeneralized>
+        :type potential: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.VerletListAdressReactionFieldGeneralized(vl, fixedtupleList)
 
@@ -89,8 +89,8 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressReactionFieldGeneralized.setPotentialAT(type1, type2, potential)
 
@@ -101,7 +101,7 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
         :param potential: ReactionFieldGeneralized potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<ReactionFieldGeneralized>
+        :type potential: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.VerletListAdressReactionFieldGeneralized.setPotentialCG(type1, type2, potential)
 
@@ -112,7 +112,7 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListAdressATReactionFieldGeneralized(vl, fixedtupleList)
 
@@ -120,8 +120,8 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressATReactionFieldGeneralized.setPotential(type1, type2, potential)
 
@@ -132,7 +132,7 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
         :param potential: ReactionFieldGeneralized potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<ReactionFieldGeneralized>
+        :type potential: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.VerletListAdressATReactionFieldGeneralized.getPotential(type1, type2)
 
@@ -142,7 +142,7 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<ReactionFieldGeneralized>
+        :rtype: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.VerletListHadressReactionFieldGeneralized(vl, fixedtupleList)
 
@@ -150,8 +150,8 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressReactionFieldGeneralized.setPotentialAT(type1, type2, potential)
 
@@ -162,7 +162,7 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
         :param potential: ReactionFieldGeneralized potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<ReactionFieldGeneralized>
+        :type potential: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.VerletListHadressReactionFieldGeneralized.setPotentialCG(type1, type2, potential)
 
@@ -173,7 +173,7 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListHadressATReactionFieldGeneralized(vl, fixedtupleList)
 
@@ -181,8 +181,8 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressATReactionFieldGeneralized.setPotential(type1, type2, potential)
 
@@ -193,7 +193,7 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
         :param potential: ReactionFieldGeneralized potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<ReactionFieldGeneralized>
+        :type potential: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.VerletListHadressATReactionFieldGeneralized.getPotential(type1, type2)
 
@@ -203,14 +203,14 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<ReactionFieldGeneralized>
+        :rtype: std::shared_ptr<ReactionFieldGeneralized>
 
 .. function:: espressopp.interaction.CellListReactionFieldGeneralized(stor)
 
         Defines a CellList-based interaction using a ReactionFieldGeneralized potential.
 
         :param stor: storage object
-        :type stor: shared_ptr <storage::Storage>
+        :type stor: std::shared_ptr <storage::Storage>
 
 .. function:: espressopp.interaction.CellListReactionFieldGeneralized.setPotential(type1, type2, potential)
 
@@ -221,7 +221,7 @@ where `P` is a prefactor, `Q` is the product of the charges of the two particles
         :param potential: ReactionFieldGeneralized potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<ReactionFieldGeneralized>
+        :type potential: std::shared_ptr<ReactionFieldGeneralized>
 """
 from espressopp import pmi, infinity
 from espressopp.esutil import *

--- a/src/interaction/ReactionFieldGeneralizedTI.cpp
+++ b/src/interaction/ReactionFieldGeneralizedTI.cpp
@@ -55,21 +55,21 @@ namespace espressopp {
             ;
 
             //class_<VerletListReactionFieldGeneralizedTI, bases<Interaction> >
-            //    ("interaction_VerletListReactionFieldGeneralizedTI", init< shared_ptr<VerletList> >())
+            //    ("interaction_VerletListReactionFieldGeneralizedTI", init< std::shared_ptr<VerletList> >())
             //    .def("setPotential", &VerletListReactionFieldGeneralizedTI::setPotential)
             //    .def("getPotential", &VerletListReactionFieldGeneralizedTI::getPotentialPtr)
             //;
 
             class_<VerletListAdressReactionFieldGeneralizedTI, bases<Interaction> >
                 ("interaction_VerletListAdressReactionFieldGeneralizedTI",
-                        init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+                        init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
                 .def("setPotentialAT", &VerletListAdressReactionFieldGeneralizedTI::setPotentialAT)
                 .def("setPotentialCG", &VerletListAdressReactionFieldGeneralizedTI::setPotentialCG);
             ;
 
             //class_<VerletListHadressReactionFieldGeneralizedTI, bases<Interaction> >
             //    ("interaction_VerletListHadressReactionFieldGeneralizedTI",
-            //            init< shared_ptr<VerletListAdress>, shared_ptr<FixedTupleListAdress> >())
+            //            init< std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
             //    .def("setPotentialAT", &VerletListHadressReactionFieldGeneralizedTI::setPotentialAT)
             //    .def("setPotentialCG", &VerletListHadressReactionFieldGeneralizedTI::setPotentialCG);
             //;

--- a/src/interaction/SingleParticleInteractionTemplate.hpp
+++ b/src/interaction/SingleParticleInteractionTemplate.hpp
@@ -55,8 +55,8 @@ namespace espressopp {
 
     public:
       SingleParticleInteractionTemplate
-      (shared_ptr < System > system,
-       shared_ptr < _Potential > _potential)
+      (std::shared_ptr < System > system,
+       std::shared_ptr < _Potential > _potential)
         : SystemAccess(system),
           potential(_potential)
       {
@@ -68,7 +68,7 @@ namespace espressopp {
       virtual ~SingleParticleInteractionTemplate() {};
 
       void
-      setPotential(shared_ptr < _Potential> _potential) {
+      setPotential(std::shared_ptr < _Potential> _potential) {
         if (_potential) {
           potential = _potential;
         } else {
@@ -76,7 +76,7 @@ namespace espressopp {
         }
       }
 
-      shared_ptr < _Potential > getPotential() {
+      std::shared_ptr < _Potential > getPotential() {
         return potential;
       }
 
@@ -97,7 +97,7 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr < Potential > potential;
+      std::shared_ptr < Potential > potential;
     };
 
     //////////////////////////////////////////////////

--- a/src/interaction/SmoothSquareWell.cpp
+++ b/src/interaction/SmoothSquareWell.cpp
@@ -48,7 +48,7 @@ namespace espressopp {
         ;
 
       class_ <VerletListSmoothSquareWell, bases <Interaction> >
-        ("interaction_VerletListSmoothSquareWell", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListSmoothSquareWell", init< std::shared_ptr<VerletList> >())
         .def("getVerletList", &VerletListSmoothSquareWell::getVerletList)
         .def("setPotential", &VerletListSmoothSquareWell::setPotential, return_value_policy< reference_existing_object >())
         .def("getPotential", &VerletListSmoothSquareWell::getPotential, return_value_policy< reference_existing_object >())
@@ -56,8 +56,8 @@ namespace espressopp {
 
       class_ <FixedPairListSmoothSquareWell, bases <Interaction> >
         ("interaction_FixedPairListSmoothSquareWell",
-         init< shared_ptr<System>, shared_ptr<FixedPairList>,  shared_ptr<SmoothSquareWell> >())
-        .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<SmoothSquareWell> >())
+         init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>,  std::shared_ptr<SmoothSquareWell> >())
+        .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<SmoothSquareWell> >())
         .def("setPotential", &FixedPairListSmoothSquareWell::setPotential)
         .def("getPotential", &FixedPairListSmoothSquareWell::getPotential)
         .def("setFixedPairList", &FixedPairListSmoothSquareWell::setFixedPairList)
@@ -66,8 +66,8 @@ namespace espressopp {
 
       class_ <FixedPairListTypesSmoothSquareWell, bases <Interaction> >
         ("interaction_FixedPairListTypesSmoothSquareWell",
-         init< shared_ptr<System>, shared_ptr<FixedPairList> >())
-        .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress> >())
+         init< std::shared_ptr<System>, std::shared_ptr<FixedPairList> >())
+        .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress> >())
         .def("setPotential", &FixedPairListTypesSmoothSquareWell::setPotential)
         .def("getPotential", &FixedPairListTypesSmoothSquareWell::getPotentialPtr)
         .def("setFixedPairList", &FixedPairListTypesSmoothSquareWell::setFixedPairList)

--- a/src/interaction/SoftCosine.cpp
+++ b/src/interaction/SoftCosine.cpp
@@ -50,21 +50,21 @@ namespace espressopp {
     	;
 
       class_< VerletListSoftCosine, bases< Interaction > > 
-        ("interaction_VerletListSoftCosine", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListSoftCosine", init< std::shared_ptr<VerletList> >())
         .def("setPotential", &VerletListSoftCosine::setPotential, return_value_policy< reference_existing_object >())
         .def("getPotential", &VerletListSoftCosine::getPotential, return_value_policy< reference_existing_object >())
         ;
 
       class_< CellListSoftCosine, bases< Interaction > > 
-        ("interaction_CellListSoftCosine", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListSoftCosine", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListSoftCosine::setPotential);
 	;
 
       class_< FixedPairListSoftCosine, bases< Interaction > >
         ("interaction_FixedPairListSoftCosine",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, 
-                shared_ptr<SoftCosine> >())
-        .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<SoftCosine> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>,
+                std::shared_ptr<SoftCosine> >())
+        .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<SoftCosine> >())
         .def("setPotential", &FixedPairListSoftCosine::setPotential);
         ;
     }

--- a/src/interaction/StillingerWeberPairTerm.cpp
+++ b/src/interaction/StillingerWeberPairTerm.cpp
@@ -57,7 +57,7 @@ namespace espressopp {
       ;
 
       class_< VerletListStillingerWeberPairTerm, bases< Interaction > > 
-        ("interaction_VerletListStillingerWeberPairTerm", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListStillingerWeberPairTerm", init< std::shared_ptr<VerletList> >())
         .def("getVerletList", &VerletListStillingerWeberPairTerm::getVerletList)
         .def("setPotential", &VerletListStillingerWeberPairTerm::setPotential, return_value_policy< reference_existing_object >())
         .def("getPotential", &VerletListStillingerWeberPairTerm::getPotential, return_value_policy< reference_existing_object >())
@@ -65,29 +65,29 @@ namespace espressopp {
 
       class_< VerletListAdressStillingerWeberPairTerm, bases< Interaction > >
         ("interaction_VerletListAdressStillingerWeberPairTerm",
-            init< shared_ptr<VerletListAdress>,
-            shared_ptr<FixedTupleListAdress> >())
+            init< std::shared_ptr<VerletListAdress>,
+            std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListAdressStillingerWeberPairTerm::setPotentialAT)
         .def("setPotentialCG", &VerletListAdressStillingerWeberPairTerm::setPotentialCG);
       ;
 
       class_< VerletListHadressStillingerWeberPairTerm, bases< Interaction > >
         ("interaction_VerletListHadressStillingerWeberPairTerm",
-            init< shared_ptr<VerletListAdress>,
-            shared_ptr<FixedTupleListAdress> >())
+            init< std::shared_ptr<VerletListAdress>,
+            std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListHadressStillingerWeberPairTerm::setPotentialAT)
         .def("setPotentialCG", &VerletListHadressStillingerWeberPairTerm::setPotentialCG);
       ;
       
       class_< CellListStillingerWeberPairTerm, bases< Interaction > > 
-        ("interaction_CellListStillingerWeberPairTerm", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListStillingerWeberPairTerm", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListStillingerWeberPairTerm::setPotential);
 	  ;
 
       class_< FixedPairListStillingerWeberPairTerm, bases< Interaction > >
         ("interaction_FixedPairListStillingerWeberPairTerm",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<StillingerWeberPairTerm> >())
-          .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<StillingerWeberPairTerm> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<StillingerWeberPairTerm> >())
+          .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<StillingerWeberPairTerm> >())
           .def("setPotential", &FixedPairListStillingerWeberPairTerm::setPotential);
       ;
     }

--- a/src/interaction/StillingerWeberPairTermCapped.cpp
+++ b/src/interaction/StillingerWeberPairTermCapped.cpp
@@ -59,7 +59,7 @@ namespace espressopp {
       ;
 
       class_< VerletListStillingerWeberPairTermCapped, bases< Interaction > > 
-        ("interaction_VerletListStillingerWeberPairTermCapped", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListStillingerWeberPairTermCapped", init< std::shared_ptr<VerletList> >())
         .def("getVerletList", &VerletListStillingerWeberPairTermCapped::getVerletList)
         .def("setPotential", &VerletListStillingerWeberPairTermCapped::setPotential, return_value_policy< reference_existing_object >())
         .def("getPotential", &VerletListStillingerWeberPairTermCapped::getPotential, return_value_policy< reference_existing_object >())
@@ -67,29 +67,29 @@ namespace espressopp {
 
       class_< VerletListAdressStillingerWeberPairTermCapped, bases< Interaction > >
         ("interaction_VerletListAdressStillingerWeberPairTermCapped",
-            init< shared_ptr<VerletListAdress>,
-            shared_ptr<FixedTupleListAdress> >())
+            init< std::shared_ptr<VerletListAdress>,
+            std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListAdressStillingerWeberPairTermCapped::setPotentialAT)
         .def("setPotentialCG", &VerletListAdressStillingerWeberPairTermCapped::setPotentialCG);
       ;
       
       class_< VerletListHadressStillingerWeberPairTermCapped, bases< Interaction > >
         ("interaction_VerletListHadressStillingerWeberPairTermCapped",
-            init< shared_ptr<VerletListAdress>,
-            shared_ptr<FixedTupleListAdress> >())
+            init< std::shared_ptr<VerletListAdress>,
+            std::shared_ptr<FixedTupleListAdress> >())
         .def("setPotentialAT", &VerletListHadressStillingerWeberPairTermCapped::setPotentialAT)
         .def("setPotentialCG", &VerletListHadressStillingerWeberPairTermCapped::setPotentialCG);
       ;
 
       class_< CellListStillingerWeberPairTermCapped, bases< Interaction > > 
-        ("interaction_CellListStillingerWeberPairTermCapped", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListStillingerWeberPairTermCapped", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListStillingerWeberPairTermCapped::setPotential);
 	  ;
 
       class_< FixedPairListStillingerWeberPairTermCapped, bases< Interaction > >
         ("interaction_FixedPairListStillingerWeberPairTermCapped",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<StillingerWeberPairTermCapped> >())
-          .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<StillingerWeberPairTermCapped> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<StillingerWeberPairTermCapped> >())
+          .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<StillingerWeberPairTermCapped> >())
           .def("setPotential", &FixedPairListStillingerWeberPairTermCapped::setPotential);
       ;
     }

--- a/src/interaction/StillingerWeberTripleTerm.cpp
+++ b/src/interaction/StillingerWeberTripleTerm.cpp
@@ -67,8 +67,8 @@ namespace espressopp {
       
       class_< VerletListStillingerWeberTripleTerm, bases< Interaction > >(
         "interaction_VerletListStillingerWeberTripleTerm",
-        init< shared_ptr<System>, 
-              shared_ptr<VerletListTriple> >()
+        init< std::shared_ptr<System>,
+              std::shared_ptr<VerletListTriple> >()
       )
       .def("getVerletListTriple", &VerletListStillingerWeberTripleTerm::getVerletListTriple)
       .def("setPotential", &VerletListStillingerWeberTripleTerm::setPotential,
@@ -79,7 +79,7 @@ namespace espressopp {
 
       class_< FixedListStillingerWeberTripleTerm, bases< Interaction > >(
           "interaction_FixedTripleListStillingerWeberTripleTerm",
-          init<shared_ptr<System>, shared_ptr<FixedTripleList>, shared_ptr<StillingerWeberTripleTerm> >()
+          init<std::shared_ptr<System>, std::shared_ptr<FixedTripleList>, std::shared_ptr<StillingerWeberTripleTerm> >()
       )
       .def("setPotential", &FixedListStillingerWeberTripleTerm::setPotential)
       .def("getFixedTripleList", &FixedListStillingerWeberTripleTerm::getFixedTripleList)

--- a/src/interaction/Tabulated.cpp
+++ b/src/interaction/Tabulated.cpp
@@ -51,17 +51,17 @@ namespace espressopp {
         filename = _filename;
 
         if (itype == 1) { // create a new InterpolationLinear
-            table = make_shared <InterpolationLinear> ();
+            table = std::make_shared <InterpolationLinear> ();
             table->read(world, _filename);
         }
 
         else if (itype == 2) { // create a new InterpolationAkima
-            table = make_shared <InterpolationAkima> ();
+            table = std::make_shared <InterpolationAkima> ();
             table->read(world, _filename);
         }
 
         else if (itype == 3) { // create a new InterpolationCubic
-            table = make_shared <InterpolationCubic> ();
+            table = std::make_shared <InterpolationCubic> ();
             table->read(world, _filename);
         }
     }
@@ -92,15 +92,15 @@ namespace espressopp {
         ;
 
       class_ <VerletListTabulated, bases <Interaction> >
-        ("interaction_VerletListTabulated", init <shared_ptr<VerletList> >())
+        ("interaction_VerletListTabulated", init <std::shared_ptr<VerletList> >())
             .def("setPotential", &VerletListTabulated::setPotential)
             .def("getPotential", &VerletListTabulated::getPotentialPtr)
         ;
 
       class_< VerletListAdressCGTabulated, bases< Interaction > >
         ("interaction_VerletListAdressCGTabulated",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("getVerletList", &VerletListAdressCGTabulated::getVerletList)
         .def("setPotential", &VerletListAdressCGTabulated::setPotential)
         .def("getPotential", &VerletListAdressCGTabulated::getPotentialPtr)
@@ -108,8 +108,8 @@ namespace espressopp {
 
       class_ <VerletListAdressTabulated, bases <Interaction> >
         ("interaction_VerletListAdressTabulated",
-           init <shared_ptr<VerletListAdress>,
-                 shared_ptr<FixedTupleListAdress> >()
+           init <std::shared_ptr<VerletListAdress>,
+                 std::shared_ptr<FixedTupleListAdress> >()
                 )
             .def("setPotentialAT", &VerletListAdressTabulated::setPotentialAT)
             .def("setPotentialCG", &VerletListAdressTabulated::setPotentialCG);
@@ -117,8 +117,8 @@ namespace espressopp {
 
       class_< VerletListHadressCGTabulated, bases< Interaction > >
         ("interaction_VerletListHadressCGTabulated",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("getVerletList", &VerletListHadressCGTabulated::getVerletList)
         .def("setPotential", &VerletListHadressCGTabulated::setPotential)
         .def("getPotential", &VerletListHadressCGTabulated::getPotentialPtr)
@@ -126,8 +126,8 @@ namespace espressopp {
 
       class_ <VerletListHadressTabulated, bases <Interaction> >
         ("interaction_VerletListHadressTabulated",
-           init <shared_ptr<VerletListAdress>,
-                 shared_ptr<FixedTupleListAdress> >()
+           init <std::shared_ptr<VerletListAdress>,
+                 std::shared_ptr<FixedTupleListAdress> >()
                 )
             .def("setPotentialAT", &VerletListHadressTabulated::setPotentialAT)
             .def("setPotentialCG", &VerletListHadressTabulated::setPotentialCG);
@@ -135,8 +135,8 @@ namespace espressopp {
 
       class_ <VerletListPIadressTabulated, bases <Interaction> >
         ("interaction_VerletListPIadressTabulated",
-           init <shared_ptr<VerletListAdress>,
-                 shared_ptr<FixedTupleListAdress>,
+           init <std::shared_ptr<VerletListAdress>,
+                 std::shared_ptr<FixedTupleListAdress>,
                  int,
                  bool>()
                 )
@@ -154,8 +154,8 @@ namespace espressopp {
 
       class_ <VerletListPIadressTabulatedLJ, bases <Interaction> >
         ("interaction_VerletListPIadressTabulatedLJ",
-           init <shared_ptr<VerletListAdress>,
-                 shared_ptr<FixedTupleListAdress>,
+           init <std::shared_ptr<VerletListAdress>,
+                 std::shared_ptr<FixedTupleListAdress>,
                  int,
                  bool>()
                 )
@@ -173,8 +173,8 @@ namespace espressopp {
 
       class_ <VerletListPIadressNoDriftTabulated, bases <Interaction> >
         ("interaction_VerletListPIadressNoDriftTabulated",
-           init <shared_ptr<VerletListAdress>,
-                 shared_ptr<FixedTupleListAdress>,
+           init <std::shared_ptr<VerletListAdress>,
+                 std::shared_ptr<FixedTupleListAdress>,
                  int,
                  bool>()
                 )
@@ -190,25 +190,25 @@ namespace espressopp {
         ;
 
       class_ <CellListTabulated, bases <Interaction> >
-        ("interaction_CellListTabulated", init <shared_ptr <storage::Storage> >())
+        ("interaction_CellListTabulated", init <std::shared_ptr <storage::Storage> >())
             .def("setPotential", &CellListTabulated::setPotential);
         ;
 
       class_ <FixedPairListTabulated, bases <Interaction> >
         ("interaction_FixedPairListTabulated",
-          init <shared_ptr<System>,
-                shared_ptr<FixedPairList>,
-                shared_ptr<Tabulated> >()
+          init <std::shared_ptr<System>,
+                std::shared_ptr<FixedPairList>,
+                std::shared_ptr<Tabulated> >()
         )
-        .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<Tabulated> >())
+        .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<Tabulated> >())
         .def("setPotential", &FixedPairListTabulated::setPotential)
         .def("setFixedPairList", &FixedPairListTabulated::setFixedPairList)
         .def("getFixedPairList", &FixedPairListTabulated::getFixedPairList);
 
       class_< FixedPairListTypesTabulated, bases< Interaction > >
           ("interaction_FixedPairListTypesTabulated",
-           init< shared_ptr<System>, shared_ptr<FixedPairList> >())
-          .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress> >())
+           init< std::shared_ptr<System>, std::shared_ptr<FixedPairList> >())
+          .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress> >())
           .def("setPotential", &FixedPairListTypesTabulated::setPotential)
           .def("getPotential", &FixedPairListTypesTabulated::getPotentialPtr)
           .def("setFixedPairList", &FixedPairListTypesTabulated::setFixedPairList)
@@ -216,14 +216,14 @@ namespace espressopp {
 
       class_ <FixedPairListPIadressTabulated, bases <Interaction> >
         ("interaction_FixedPairListPIadressTabulated",
-          init <shared_ptr<System>,
-                shared_ptr<FixedPairList>,
-                shared_ptr<FixedTupleListAdress>,
-                shared_ptr<Tabulated>,
+          init <std::shared_ptr<System>,
+                std::shared_ptr<FixedPairList>,
+                std::shared_ptr<FixedTupleListAdress>,
+                std::shared_ptr<Tabulated>,
                 int,
                 bool>()
         )
-        .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<FixedTupleListAdress>, shared_ptr<Tabulated>, int, bool>())
+        .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<FixedTupleListAdress>, std::shared_ptr<Tabulated>, int, bool>())
         .def("setPotential", &FixedPairListPIadressTabulated::setPotential)
         .def("getPotential", &FixedPairListPIadressTabulated::getPotential)
         .def("setFixedPairList", &FixedPairListPIadressTabulated::setFixedPairList)

--- a/src/interaction/Tabulated.hpp
+++ b/src/interaction/Tabulated.hpp
@@ -44,7 +44,7 @@ namespace espressopp {
 
         private:
             std::string filename;
-            shared_ptr <Interpolation> table;
+            std::shared_ptr <Interpolation> table;
             int interpolationType;
 
         public:

--- a/src/interaction/Tabulated.py
+++ b/src/interaction/Tabulated.py
@@ -46,8 +46,8 @@ espressopp.interaction.Tabulated
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressTabulated.setPotentialAT(type1, type2, potential)
 
@@ -58,7 +58,7 @@ espressopp.interaction.Tabulated
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListAdressTabulated.setPotentialCG(type1, type2, potential)
 
@@ -69,7 +69,7 @@ espressopp.interaction.Tabulated
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListAdressCGTabulated(vl, fixedtupleList)
 
@@ -77,8 +77,8 @@ espressopp.interaction.Tabulated
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListAdressCGTabulated.setPotential(type1, type2, potential)
 
@@ -89,7 +89,7 @@ espressopp.interaction.Tabulated
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListAdressCGTabulated.getPotential(type1, type2)
 
@@ -99,13 +99,13 @@ espressopp.interaction.Tabulated
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<Tabulated>
+        :rtype: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListAdressCGTabulated.getVerletList()
 
         Gets the verletlist used in VerletListAdressCGTabulated interaction.
 
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressTabulated(vl, fixedtupleList)
 
@@ -113,8 +113,8 @@ espressopp.interaction.Tabulated
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressTabulated.setPotentialAT(type1, type2, potential)
 
@@ -125,7 +125,7 @@ espressopp.interaction.Tabulated
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListHadressTabulated.setPotentialCG(type1, type2, potential)
 
@@ -136,7 +136,7 @@ espressopp.interaction.Tabulated
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListHadressCGTabulated(vl, fixedtupleList)
 
@@ -144,8 +144,8 @@ espressopp.interaction.Tabulated
 
         :param vl: Verletlist AdResS object
         :param fixedtupleList: FixedTupleList object
-        :type vl: shared_ptr<VerletListAdress>
-        :type fixedtupleList: shared_ptr<FixedTupleListAdress>
+        :type vl: std::shared_ptr<VerletListAdress>
+        :type fixedtupleList: std::shared_ptr<FixedTupleListAdress>
 
 .. function:: espressopp.interaction.VerletListHadressCGTabulated.setPotential(type1, type2, potential)
 
@@ -156,7 +156,7 @@ espressopp.interaction.Tabulated
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListHadressCGTabulated.getPotential(type1, type2)
 
@@ -166,20 +166,20 @@ espressopp.interaction.Tabulated
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<Tabulated>
+        :rtype: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListHadressCGTabulated.getVerletList()
 
         Gets the verletlist used in VerletListHadressCGTabulated interaction.
 
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.interaction.VerletListTabulated(vl)
 
         Defines a verletlist-based interaction using a tabulated potential.
 
         :param vl: Verletlist object
-        :type vl: shared_ptr<VerletList>
+        :type vl: std::shared_ptr<VerletList>
 
 .. function:: espressopp.interaction.VerletListTabulated.getPotential(type1, type2)
 
@@ -189,7 +189,7 @@ espressopp.interaction.Tabulated
         :param type2: particle type 2
         :type type1: int
         :type type2: int
-        :rtype: shared_ptr<Tabulated>
+        :rtype: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.VerletListTabulated.setPotential(type1, type2, potential)
 
@@ -200,14 +200,14 @@ espressopp.interaction.Tabulated
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.CellListTabulated(stor)
 
         Defines a CellList-based interaction using a tabulated potential.
 
         :param stor: storage object
-        :type stor: shared_ptr <storage::Storage>
+        :type stor: std::shared_ptr <storage::Storage>
 
 .. function:: espressopp.interaction.CellListTabulated.setPotential(type1, type2, potential)
 
@@ -218,7 +218,7 @@ espressopp.interaction.Tabulated
         :param potential: tabulated interaction potential object
         :type type1: int
         :type type2: int
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.FixedPairListTabulated(system, vl, potential)
 
@@ -227,16 +227,16 @@ espressopp.interaction.Tabulated
         :param system: system object
         :param vl: FixedPairList list object
         :param potential: tabulated potential object
-        :type system: shared_ptr<System>
-        :type vl: shared_ptr<FixedPairList>
-        :type potential: shared_ptr<Tabulated>
+        :type system: std::shared_ptr<System>
+        :type vl: std::shared_ptr<FixedPairList>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.FixedPairListTabulated.setPotential(potential)
 
         Sets the tabulated interaction potential in FixedPairListTabulated for interacting particles.
 
         :param potential: tabulated potential object
-        :type potential: shared_ptr<Tabulated>
+        :type potential: std::shared_ptr<Tabulated>
 
 .. function:: espressopp.interaction.FixedPairListTypesTabulated(system, fpl)
 
@@ -286,7 +286,7 @@ espressopp.interaction.Tabulated
         Gets the potential.
 
         :return: the potential
-        :rtype: shared_ptr < Potential >
+        :rtype: std::shared_ptr < Potential >
 
 .. function:: espressopp.interaction.FixedPairListPIadressTabulated.setFixedPairList(fpl)
 
@@ -300,7 +300,7 @@ espressopp.interaction.Tabulated
         Gets the FixedPairList.
 
         :return: the FixedPairList
-        :rtype: shared_ptr < FixedPairList >
+        :rtype: std::shared_ptr < FixedPairList >
 
 .. function:: espressopp.interaction.FixedPairListPIadressTabulated.setFixedTupleList(fixedtupleList)
 
@@ -314,7 +314,7 @@ espressopp.interaction.Tabulated
         Gets the FixedTupleList.
 
         :return: the FixedTupleList
-        :rtype: shared_ptr < FixedTupleListAdress >
+        :rtype: std::shared_ptr < FixedTupleListAdress >
 
 .. function:: espressopp.interaction.FixedPairListPIadressTabulated.setNTrotter(ntrotter)
 
@@ -383,7 +383,7 @@ espressopp.interaction.Tabulated
         Gets the VerletList.
 
         :return: the Adress VerletList
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.interaction.VerletListPIadressTabulated.setFixedTupleList(fixedtupleList)
 
@@ -397,7 +397,7 @@ espressopp.interaction.Tabulated
         Gets the FixedTupleList.
 
         :return: the FixedTupleList
-        :rtype: shared_ptr < FixedTupleListAdress >
+        :rtype: std::shared_ptr < FixedTupleListAdress >
 
 .. function:: espressopp.interaction.VerletListPIadressTabulated.setNTrotter(ntrotter)
 
@@ -466,7 +466,7 @@ espressopp.interaction.Tabulated
         Gets the VerletList.
 
         :return: the Adress VerletList
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.interaction.VerletListPIadressTabulatedLJ.setFixedTupleList(fixedtupleList)
 
@@ -480,7 +480,7 @@ espressopp.interaction.Tabulated
         Gets the FixedTupleList.
 
         :return: the FixedTupleList
-        :rtype: shared_ptr < FixedTupleListAdress >
+        :rtype: std::shared_ptr < FixedTupleListAdress >
 
 .. function:: espressopp.interaction.VerletListPIadressTabulatedLJ.setNTrotter(ntrotter)
 
@@ -542,7 +542,7 @@ espressopp.interaction.Tabulated
         Gets the VerletList.
 
         :return: the Adress VerletList
-        :rtype: shared_ptr<VerletListAdress>
+        :rtype: std::shared_ptr<VerletListAdress>
 
 .. function:: espressopp.interaction.VerletListPIadressNoDriftTabulated.setFixedTupleList(fixedtupleList)
 
@@ -556,7 +556,7 @@ espressopp.interaction.Tabulated
         Gets the FixedTupleList.
 
         :return: the FixedTupleList
-        :rtype: shared_ptr < FixedTupleListAdress >
+        :rtype: std::shared_ptr < FixedTupleListAdress >
 
 .. function:: espressopp.interaction.VerletListPIadressNoDriftTabulated.setNTrotter(ntrotter)
 

--- a/src/interaction/TabulatedAngular.cpp
+++ b/src/interaction/TabulatedAngular.cpp
@@ -41,17 +41,17 @@ namespace espressopp {
             filename = _filename;
 
             if (itype == 1) { // create a new InterpolationLinear
-                table = make_shared <InterpolationLinear> ();
+                table = std::make_shared <InterpolationLinear> ();
                 table->read(world, _filename);
             }
 
             else if (itype == 2) { // create a new InterpolationAkima
-                table = make_shared <InterpolationAkima> ();
+                table = std::make_shared <InterpolationAkima> ();
                 table->read(world, _filename);
             }
 
             else if (itype == 3) { // create a new InterpolationCubic
-                table = make_shared <InterpolationCubic> ();
+                table = std::make_shared <InterpolationCubic> ();
                 table->read(world, _filename);
             }
         }
@@ -76,15 +76,15 @@ namespace espressopp {
 
             class_ <FixedTripleListTabulatedAngular, bases <Interaction> >
                 ("interaction_FixedTripleListTabulatedAngular",
-                init <shared_ptr<System>,
-                      shared_ptr <FixedTripleList>,
-                      shared_ptr <TabulatedAngular> >())
+                init <std::shared_ptr<System>,
+                      std::shared_ptr <FixedTripleList>,
+                      std::shared_ptr <TabulatedAngular> >())
                 .def("setPotential", &FixedTripleListTabulatedAngular::setPotential)
                 .def("getFixedTripleList", &FixedTripleListTabulatedAngular::getFixedTripleList);
 
             class_< FixedTripleListTypesTabulatedAngular, bases< Interaction > >
                 ("interaction_FixedTripleListTypesTabulatedAngular",
-                 init< shared_ptr<System>, shared_ptr<FixedTripleList> >())
+                 init< std::shared_ptr<System>, std::shared_ptr<FixedTripleList> >())
                 .def("setPotential", &FixedTripleListTypesTabulatedAngular::setPotential)
                 .def("getPotential", &FixedTripleListTypesTabulatedAngular::getPotentialPtr)
                 .def("setFixedTripleList", &FixedTripleListTypesTabulatedAngular::setFixedTripleList)
@@ -92,10 +92,10 @@ namespace espressopp {
 
             class_ <FixedTripleListPIadressTabulatedAngular, bases <Interaction> >
                 ("interaction_FixedTripleListPIadressTabulatedAngular",
-                init <shared_ptr<System>,
-                      shared_ptr <FixedTripleList>,
-                      shared_ptr<FixedTupleListAdress>,
-                      shared_ptr <TabulatedAngular>,
+                init <std::shared_ptr<System>,
+                      std::shared_ptr <FixedTripleList>,
+                      std::shared_ptr<FixedTupleListAdress>,
+                      std::shared_ptr <TabulatedAngular>,
                       int,
                       bool>())
                 .def("setPotential", &FixedTripleListPIadressTabulatedAngular::setPotential)

--- a/src/interaction/TabulatedAngular.hpp
+++ b/src/interaction/TabulatedAngular.hpp
@@ -36,7 +36,7 @@ namespace espressopp {
          
             private:
                 std::string filename;
-                shared_ptr <Interpolation> table;
+                std::shared_ptr <Interpolation> table;
                 int interpolationType;
          
             public:

--- a/src/interaction/TabulatedAngular.py
+++ b/src/interaction/TabulatedAngular.py
@@ -100,7 +100,7 @@ espressopp.interaction.TabulatedAngular
         Gets the potential.
 
         :return: the potential
-        :rtype: shared_ptr < Potential >
+        :rtype: std::shared_ptr < Potential >
 
 .. function:: espressopp.interaction.FixedTripleListPIadressTabulatedAngular.setFixedTripleList(ftl)
 
@@ -114,7 +114,7 @@ espressopp.interaction.TabulatedAngular
         Gets the FixedTripleList.
 
         :return: the FixedTripleList
-        :rtype: shared_ptr < FixedTripleList >
+        :rtype: std::shared_ptr < FixedTripleList >
 
 .. function:: espressopp.interaction.FixedTripleListPIadressTabulatedAngular.setFixedTupleList(fixedtupleList)
 
@@ -128,7 +128,7 @@ espressopp.interaction.TabulatedAngular
         Gets the FixedTupleList.
 
         :return: the FixedTupleList
-        :rtype: shared_ptr < FixedTupleListAdress >
+        :rtype: std::shared_ptr < FixedTupleListAdress >
 
 .. function:: espressopp.interaction.FixedTripleListPIadressTabulatedAngular.setNTrotter(ntrotter)
 

--- a/src/interaction/TabulatedDihedral.cpp
+++ b/src/interaction/TabulatedDihedral.cpp
@@ -42,17 +42,17 @@ namespace espressopp {
 
 
             if (itype == 1) { // create a new InterpolationLinear
-                table = make_shared <InterpolationLinear> ();
+                table = std::make_shared <InterpolationLinear> ();
                 table->read(world, _filename);
             }
 
             else if (itype == 2) { // create a new InterpolationAkima
-                table = make_shared <InterpolationAkima> ();
+                table = std::make_shared <InterpolationAkima> ();
                 table->read(world, _filename);
             }
 
             else if (itype == 3) { // create a new InterpolationCubic
-                table = make_shared <InterpolationCubic> ();
+                table = std::make_shared <InterpolationCubic> ();
                 table->read(world, _filename);
             }
         }
@@ -77,15 +77,15 @@ namespace espressopp {
 
             class_ <FixedQuadrupleListTabulatedDihedral, bases <Interaction> >
                 ("interaction_FixedQuadrupleListTabulatedDihedral",
-                        init <shared_ptr<System>,
-                              shared_ptr<FixedQuadrupleList>,
-                              shared_ptr<TabulatedDihedral> >())
+                        init <std::shared_ptr<System>,
+                              std::shared_ptr<FixedQuadrupleList>,
+                              std::shared_ptr<TabulatedDihedral> >())
                 .def("setPotential", &FixedQuadrupleListTabulatedDihedral::setPotential)
                 .def("getFixedQuadrupleList", &FixedQuadrupleListTabulatedDihedral::getFixedQuadrupleList);
 
             class_< FixedQuadrupleListTypesTabulatedDihedral, bases< Interaction > >
                 ("interaction_FixedQuadrupleListTypesTabulatedDihedral",
-                 init< shared_ptr<System>, shared_ptr<FixedQuadrupleList> >())
+                 init< std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleList> >())
                 .def("setPotential", &FixedQuadrupleListTypesTabulatedDihedral::setPotential)
                 .def("getPotential", &FixedQuadrupleListTypesTabulatedDihedral::getPotentialPtr)
                 .def("setFixedQuadrupleList", &FixedQuadrupleListTypesTabulatedDihedral::setFixedQuadrupleList)

--- a/src/interaction/TabulatedDihedral.hpp
+++ b/src/interaction/TabulatedDihedral.hpp
@@ -38,7 +38,7 @@ namespace espressopp {
 
             private:
                 std::string filename;
-                shared_ptr <Interpolation> table;
+                std::shared_ptr <Interpolation> table;
                 int interpolationType;
 
             public:

--- a/src/interaction/TabulatedSubEns.cpp
+++ b/src/interaction/TabulatedSubEns.cpp
@@ -45,17 +45,17 @@ namespace espressopp {
           filenames[i] = boost::python::extract<std::string>(_filenames[i]);
           colVarRef[i].setDimension(6);
           if (itype == 1) { // create a new InterpolationLinear
-              tables[i] = make_shared <InterpolationLinear> ();
+              tables[i] = std::make_shared <InterpolationLinear> ();
               tables[i]->read(world, filenames[i].c_str());
           }
 
           else if (itype == 2) { // create a new InterpolationAkima
-              tables[i] = make_shared <InterpolationAkima> ();
+              tables[i] = std::make_shared <InterpolationAkima> ();
               tables[i]->read(world, filenames[i].c_str());
           }
 
           else if (itype == 3) { // create a new InterpolationCubic
-              tables[i] = make_shared <InterpolationCubic> ();
+              tables[i] = std::make_shared <InterpolationCubic> ();
               tables[i]->read(world, filenames[i].c_str());
           }
       }
@@ -75,15 +75,15 @@ namespace espressopp {
         weightSum.push_back(0.);
         targetProb.push_back(0.);
         if (itype == 1) { // create a new InterpolationLinear
-              tables.push_back(make_shared <InterpolationLinear> ());
+              tables.push_back(std::make_shared <InterpolationLinear> ());
               tables[i]->read(world, filenames[i].c_str());
           }
           else if (itype == 2) { // create a new InterpolationAkima
-              tables.push_back(make_shared <InterpolationAkima> ());
+              tables.push_back(std::make_shared <InterpolationAkima> ());
               tables[i]->read(world, filenames[i].c_str());
           }
           else if (itype == 3) { // create a new InterpolationCubic
-              tables.push_back(make_shared <InterpolationCubic> ());
+              tables.push_back(std::make_shared <InterpolationCubic> ());
               tables[i]->read(world, filenames[i].c_str());
           }
     }
@@ -262,15 +262,15 @@ namespace espressopp {
         ;
 
       class_ <VerletListTabulatedSubEns, bases <Interaction> >
-        ("interaction_VerletListTabulatedSubEns", init <shared_ptr<VerletList> >())
+        ("interaction_VerletListTabulatedSubEns", init <std::shared_ptr<VerletList> >())
             .def("setPotential", &VerletListTabulatedSubEns::setPotential)
             .def("getPotential", &VerletListTabulatedSubEns::getPotentialPtr)
         ;
 
       class_ <VerletListAdressTabulatedSubEns, bases <Interaction> >
         ("interaction_VerletListAdressTabulatedSubEns",
-           init <shared_ptr<VerletListAdress>,
-                 shared_ptr<FixedTupleListAdress> >()
+           init <std::shared_ptr<VerletListAdress>,
+                 std::shared_ptr<FixedTupleListAdress> >()
                 )
             .def("setPotentialAT", &VerletListAdressTabulatedSubEns::setPotentialAT)
             .def("setPotentialCG", &VerletListAdressTabulatedSubEns::setPotentialCG);
@@ -278,33 +278,33 @@ namespace espressopp {
 
       class_ <VerletListHadressTabulatedSubEns, bases <Interaction> >
         ("interaction_VerletListHadressTabulatedSubEns",
-           init <shared_ptr<VerletListAdress>,
-                 shared_ptr<FixedTupleListAdress> >()
+           init <std::shared_ptr<VerletListAdress>,
+                 std::shared_ptr<FixedTupleListAdress> >()
                 )
             .def("setPotentialAT", &VerletListHadressTabulatedSubEns::setPotentialAT)
             .def("setPotentialCG", &VerletListHadressTabulatedSubEns::setPotentialCG);
         ;
 
       class_ <CellListTabulatedSubEns, bases <Interaction> >
-        ("interaction_CellListTabulatedSubEns", init <shared_ptr <storage::Storage> >())
+        ("interaction_CellListTabulatedSubEns", init <std::shared_ptr <storage::Storage> >())
             .def("setPotential", &CellListTabulatedSubEns::setPotential);
         ;
 
       class_ <FixedPairListTabulatedSubEns, bases <Interaction> >
         ("interaction_FixedPairListTabulatedSubEns",
-          init <shared_ptr<System>,
-                shared_ptr<FixedPairList>,
-                shared_ptr<TabulatedSubEns> >()
+          init <std::shared_ptr<System>,
+                std::shared_ptr<FixedPairList>,
+                std::shared_ptr<TabulatedSubEns> >()
         )
-        .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<TabulatedSubEns> >())
+        .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<TabulatedSubEns> >())
         .def("setPotential", &FixedPairListTabulatedSubEns::setPotential)
         .def("setFixedPairList", &FixedPairListTabulatedSubEns::setFixedPairList)
         .def("getFixedPairList", &FixedPairListTabulatedSubEns::getFixedPairList);
 
       class_< FixedPairListTypesTabulatedSubEns, bases< Interaction > >
           ("interaction_FixedPairListTypesTabulatedSubEns",
-           init< shared_ptr<System>, shared_ptr<FixedPairList> >())
-          .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress> >())
+           init< std::shared_ptr<System>, std::shared_ptr<FixedPairList> >())
+          .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress> >())
           .def("setPotential", &FixedPairListTypesTabulatedSubEns::setPotential)
           .def("getPotential", &FixedPairListTypesTabulatedSubEns::getPotentialPtr)
           .def("setFixedPairList", &FixedPairListTypesTabulatedSubEns::setFixedPairList)

--- a/src/interaction/TabulatedSubEns.hpp
+++ b/src/interaction/TabulatedSubEns.hpp
@@ -45,7 +45,7 @@ namespace espressopp {
         private:
             int numInteractions;
             std::vector<std::string> filenames;
-            std::vector<shared_ptr <Interpolation>> tables;
+            std::vector<std::shared_ptr <Interpolation>> tables;
             int interpolationType;
             // Reference values of the collective variable centers
             RealNDs colVarRef;

--- a/src/interaction/TabulatedSubEnsAngular.cpp
+++ b/src/interaction/TabulatedSubEnsAngular.cpp
@@ -40,17 +40,17 @@ namespace espressopp {
               filenames[i] = boost::python::extract<std::string>(_filenames[i]);
               colVarRef[i].setDimension(6);
               if (itype == 1) { // create a new InterpolationLinear
-                  tables[i] = make_shared <InterpolationLinear> ();
+                  tables[i] = std::make_shared <InterpolationLinear> ();
                   tables[i]->read(world, filenames[i].c_str());
               }
 
               else if (itype == 2) { // create a new InterpolationAkima
-                  tables[i] = make_shared <InterpolationAkima> ();
+                  tables[i] = std::make_shared <InterpolationAkima> ();
                   tables[i]->read(world, filenames[i].c_str());
               }
 
               else if (itype == 3) { // create a new InterpolationCubic
-                  tables[i] = make_shared <InterpolationCubic> ();
+                  tables[i] = std::make_shared <InterpolationCubic> ();
                   tables[i]->read(world, filenames[i].c_str());
               }
           }
@@ -71,15 +71,15 @@ namespace espressopp {
             weightSum.push_back(0.);
             targetProb.push_back(0.);
             if (itype == 1) { // create a new InterpolationLinear
-                  tables.push_back(make_shared <InterpolationLinear> ());
+                  tables.push_back(std::make_shared <InterpolationLinear> ());
                   tables[i]->read(world, filenames[i].c_str());
               }
               else if (itype == 2) { // create a new InterpolationAkima
-                  tables.push_back(make_shared <InterpolationAkima> ());
+                  tables.push_back(std::make_shared <InterpolationAkima> ());
                   tables[i]->read(world, filenames[i].c_str());
               }
               else if (itype == 3) { // create a new InterpolationCubic
-                  tables.push_back(make_shared <InterpolationCubic> ());
+                  tables.push_back(std::make_shared <InterpolationCubic> ());
                   tables[i]->read(world, filenames[i].c_str());
               }
         }
@@ -262,15 +262,15 @@ namespace espressopp {
 
             class_ <FixedTripleListTabulatedSubEnsAngular, bases <Interaction> >
                 ("interaction_FixedTripleListTabulatedSubEnsAngular",
-                init <shared_ptr<System>,
-                      shared_ptr <FixedTripleList>,
-                      shared_ptr <TabulatedSubEnsAngular> >())
+                init <std::shared_ptr<System>,
+                      std::shared_ptr <FixedTripleList>,
+                      std::shared_ptr <TabulatedSubEnsAngular> >())
                 .def("setPotential", &FixedTripleListTabulatedSubEnsAngular::setPotential)
                 .def("getFixedTripleList", &FixedTripleListTabulatedSubEnsAngular::getFixedTripleList);
 
             class_< FixedTripleListTypesTabulatedSubEnsAngular, bases< Interaction > >
                 ("interaction_FixedTripleListTypesTabulatedSubEnsAngular",
-                 init< shared_ptr<System>, shared_ptr<FixedTripleList> >())
+                 init< std::shared_ptr<System>, std::shared_ptr<FixedTripleList> >())
                 .def("setPotential", &FixedTripleListTypesTabulatedSubEnsAngular::setPotential)
                 .def("getPotential", &FixedTripleListTypesTabulatedSubEnsAngular::getPotentialPtr)
                 .def("setFixedTripleList", &FixedTripleListTypesTabulatedSubEnsAngular::setFixedTripleList)

--- a/src/interaction/TabulatedSubEnsAngular.hpp
+++ b/src/interaction/TabulatedSubEnsAngular.hpp
@@ -35,7 +35,7 @@ namespace espressopp {
             private:
                 int numInteractions;
                 std::vector<std::string> filenames;
-                std::vector<shared_ptr <Interpolation>> tables;
+                std::vector<std::shared_ptr <Interpolation>> tables;
                 int interpolationType;
                 // Reference values of the collective variable centers
                 RealNDs colVarRef;

--- a/src/interaction/TabulatedSubEnsDihedral.cpp
+++ b/src/interaction/TabulatedSubEnsDihedral.cpp
@@ -40,17 +40,17 @@ namespace espressopp {
               filenames[i] = boost::python::extract<std::string>(_filenames[i]);
               colVarRef[i].setDimension(8);
               if (itype == 1) { // create a new InterpolationLinear
-                  tables[i] = make_shared <InterpolationLinear> ();
+                  tables[i] = std::make_shared <InterpolationLinear> ();
                   tables[i]->read(world, filenames[i].c_str());
               }
 
               else if (itype == 2) { // create a new InterpolationAkima
-                  tables[i] = make_shared <InterpolationAkima> ();
+                  tables[i] = std::make_shared <InterpolationAkima> ();
                   tables[i]->read(world, filenames[i].c_str());
               }
 
               else if (itype == 3) { // create a new InterpolationCubic
-                  tables[i] = make_shared <InterpolationCubic> ();
+                  tables[i] = std::make_shared <InterpolationCubic> ();
                   tables[i]->read(world, filenames[i].c_str());
               }
             }
@@ -71,15 +71,15 @@ namespace espressopp {
             weightSum.push_back(0.);
             targetProb.push_back(0.);
             if (itype == 1) { // create a new InterpolationLinear
-                  tables.push_back(make_shared <InterpolationLinear> ());
+                  tables.push_back(std::make_shared <InterpolationLinear> ());
                   tables[i]->read(world, filenames[i].c_str());
               }
               else if (itype == 2) { // create a new InterpolationAkima
-                  tables.push_back(make_shared <InterpolationAkima> ());
+                  tables.push_back(std::make_shared <InterpolationAkima> ());
                   tables[i]->read(world, filenames[i].c_str());
               }
               else if (itype == 3) { // create a new InterpolationCubic
-                  tables.push_back(make_shared <InterpolationCubic> ());
+                  tables.push_back(std::make_shared <InterpolationCubic> ());
                   tables[i]->read(world, filenames[i].c_str());
               }
         }
@@ -262,15 +262,15 @@ namespace espressopp {
 
             class_ <FixedQuadrupleListTabulatedSubEnsDihedral, bases <Interaction> >
                 ("interaction_FixedQuadrupleListTabulatedSubEnsDihedral",
-                        init <shared_ptr<System>,
-                              shared_ptr<FixedQuadrupleList>,
-                              shared_ptr<TabulatedSubEnsDihedral> >())
+                        init <std::shared_ptr<System>,
+                              std::shared_ptr<FixedQuadrupleList>,
+                              std::shared_ptr<TabulatedSubEnsDihedral> >())
                 .def("setPotential", &FixedQuadrupleListTabulatedSubEnsDihedral::setPotential)
                 .def("getFixedQuadrupleList", &FixedQuadrupleListTabulatedSubEnsDihedral::getFixedQuadrupleList);
 
             class_< FixedQuadrupleListTypesTabulatedSubEnsDihedral, bases< Interaction > >
                 ("interaction_FixedQuadrupleListTypesTabulatedSubEnsDihedral",
-                 init< shared_ptr<System>, shared_ptr<FixedQuadrupleList> >())
+                 init< std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleList> >())
                 .def("setPotential", &FixedQuadrupleListTypesTabulatedSubEnsDihedral::setPotential)
                 .def("getPotential", &FixedQuadrupleListTypesTabulatedSubEnsDihedral::getPotentialPtr)
                 .def("setFixedQuadrupleList", &FixedQuadrupleListTypesTabulatedSubEnsDihedral::setFixedQuadrupleList)

--- a/src/interaction/TabulatedSubEnsDihedral.hpp
+++ b/src/interaction/TabulatedSubEnsDihedral.hpp
@@ -35,7 +35,7 @@ namespace espressopp {
             private:
                 int numInteractions;
                 std::vector<std::string> filenames;
-                std::vector<shared_ptr <Interpolation>> tables;
+                std::vector<std::shared_ptr <Interpolation>> tables;
                 int interpolationType;
                 // Reference values of the collective variable centers
                 RealNDs colVarRef;

--- a/src/interaction/TersoffPairTerm.cpp
+++ b/src/interaction/TersoffPairTerm.cpp
@@ -53,21 +53,21 @@ namespace espressopp {
       ;
 
       class_< VerletListTersoffPairTerm, bases< Interaction > > 
-        ("interaction_VerletListTersoffPairTerm", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListTersoffPairTerm", init< std::shared_ptr<VerletList> >())
         .def("getVerletList", &VerletListTersoffPairTerm::getVerletList)
         .def("setPotential", &VerletListTersoffPairTerm::setPotential, return_value_policy< reference_existing_object >())
         .def("getPotential", &VerletListTersoffPairTerm::getPotential, return_value_policy< reference_existing_object >())
       ;
 
       class_< CellListTersoffPairTerm, bases< Interaction > > 
-        ("interaction_CellListTersoffPairTerm", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListTersoffPairTerm", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListTersoffPairTerm::setPotential);
 	  ;
 
       class_< FixedPairListTersoffPairTerm, bases< Interaction > >
         ("interaction_FixedPairListTersoffPairTerm",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<TersoffPairTerm> >())
-          .def(init< shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<TersoffPairTerm> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<TersoffPairTerm> >())
+          .def(init< std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<TersoffPairTerm> >())
           .def("setPotential", &FixedPairListTersoffPairTerm::setPotential);
       ;
     }

--- a/src/interaction/TersoffTripleTerm.cpp
+++ b/src/interaction/TersoffTripleTerm.cpp
@@ -77,8 +77,8 @@ namespace espressopp {
       
       class_< VerletListTersoffTripleTerm, bases< Interaction > >(
         "interaction_VerletListTersoffTripleTerm",
-        init< shared_ptr<System>, 
-              shared_ptr<VerletListTriple> >()
+        init< std::shared_ptr<System>,
+              std::shared_ptr<VerletListTriple> >()
       )
       .def("getVerletListTriple", &VerletListTersoffTripleTerm::getVerletListTriple)
       .def("setPotential", &VerletListTersoffTripleTerm::setPotential,
@@ -89,7 +89,7 @@ namespace espressopp {
 
       class_< FixedListTersoffTripleTerm, bases< Interaction > >(
           "interaction_FixedTripleListTersoffTripleTerm",
-          init<shared_ptr<System>, shared_ptr<FixedTripleList>, shared_ptr<TersoffTripleTerm> >()
+          init<std::shared_ptr<System>, std::shared_ptr<FixedTripleList>, std::shared_ptr<TersoffTripleTerm> >()
       )
       .def("setPotential", &FixedListTersoffTripleTerm::setPotential)
       .def("getFixedTripleList", &FixedListTersoffTripleTerm::getFixedTripleList)

--- a/src/interaction/VSpherePair.cpp
+++ b/src/interaction/VSpherePair.cpp
@@ -46,7 +46,7 @@ namespace espressopp {
       ;
 
       class_< VerletListVSpherePair, bases< Interaction > >
-        ("interaction_VerletListVSpherePair", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListVSpherePair", init< std::shared_ptr<VerletList> >())
         .def("getVerletList", &VerletListVSpherePair::getVerletList)
         .def("setPotential", &VerletListVSpherePair::setPotential)
         .def("getPotential", &VerletListVSpherePair::getPotentialPtr)

--- a/src/interaction/VSphereSelf.cpp
+++ b/src/interaction/VSphereSelf.cpp
@@ -46,7 +46,7 @@ namespace espressopp {
       ;
 
       class_< SelfVSphere, bases< Interaction > >("interaction_SelfVSphere",
-      init< shared_ptr<System>, shared_ptr<VSphereSelf> >())
+      init< std::shared_ptr<System>, std::shared_ptr<VSphereSelf> >())
       .def("setPotential", &SelfVSphere::setPotential)
       .def("getPotential", &SelfVSphere::getPotential)
       ;

--- a/src/interaction/VSphereSelfInteractionTemplate.hpp
+++ b/src/interaction/VSphereSelfInteractionTemplate.hpp
@@ -47,8 +47,8 @@ namespace espressopp {
 
     public:
       VSphereSelfInteractionTemplate
-      (shared_ptr < System > system,
-       shared_ptr < Potential > _potential)
+      (std::shared_ptr < System > system,
+       std::shared_ptr < Potential > _potential)
         : SystemAccess(system), potential(_potential)
       {
         if (! potential) {
@@ -59,7 +59,7 @@ namespace espressopp {
       virtual ~VSphereSelfInteractionTemplate() {};
 
       void
-      setPotential(shared_ptr < Potential> _potential) {
+      setPotential(std::shared_ptr < Potential> _potential) {
         if (_potential) {
           potential = _potential;
         } else {
@@ -67,7 +67,7 @@ namespace espressopp {
         }
       }
 
-      shared_ptr < Potential > getPotential() {
+      std::shared_ptr < Potential > getPotential() {
         return potential;
       }
 
@@ -88,7 +88,7 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr < Potential > potential;
+      std::shared_ptr < Potential > potential;
     };
 
     //////////////////////////////////////////////////

--- a/src/interaction/VerletListAdressATATCGInteractionTemplate.hpp
+++ b/src/interaction/VerletListAdressATATCGInteractionTemplate.hpp
@@ -46,7 +46,7 @@ namespace espressopp {
 
       public:
         VerletListAdressATATCGInteractionTemplate
-        (shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList)
+        (std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
           : verletList(_verletList), fixedtupleList(_fixedtupleList) {
 
           potentialArrayAT1 = esutil::Array2D<PotentialAT1, esutil::enlarge>(0, 0, PotentialAT1());
@@ -65,16 +65,16 @@ namespace espressopp {
         }
 
         void
-        setVerletList(shared_ptr < VerletListAdress > _verletList) {
+        setVerletList(std::shared_ptr < VerletListAdress > _verletList) {
           verletList = _verletList;
         }
 
-        shared_ptr<VerletListAdress> getVerletList() {
+        std::shared_ptr<VerletListAdress> getVerletList() {
           return verletList;
         }
 
         void
-        setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+        setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
         }
 
@@ -142,8 +142,8 @@ namespace espressopp {
 
       protected:
         int ntypes;
-        shared_ptr<VerletListAdress> verletList;
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
+        std::shared_ptr<VerletListAdress> verletList;
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
         esutil::Array2D<PotentialAT1, esutil::enlarge> potentialArrayAT1;
         esutil::Array2D<PotentialAT2, esutil::enlarge> potentialArrayAT2;
         esutil::Array2D<PotentialCG, esutil::enlarge> potentialArrayCG;

--- a/src/interaction/VerletListAdressATATInteractionTemplate.hpp
+++ b/src/interaction/VerletListAdressATATInteractionTemplate.hpp
@@ -47,7 +47,7 @@ namespace espressopp {
 
       public:
         VerletListAdressATATInteractionTemplate
-        (shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList)
+        (std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
           : verletList(_verletList), fixedtupleList(_fixedtupleList) {
 
           potentialArray1 = esutil::Array2D<Potential1, esutil::enlarge>(0, 0, Potential1());
@@ -65,16 +65,16 @@ namespace espressopp {
         }
 
         void
-        setVerletList(shared_ptr < VerletListAdress > _verletList) {
+        setVerletList(std::shared_ptr < VerletListAdress > _verletList) {
           verletList = _verletList;
         }
 
-        shared_ptr<VerletListAdress> getVerletList() {
+        std::shared_ptr<VerletListAdress> getVerletList() {
           return verletList;
         }
 
         void
-        setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+        setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
         }
 
@@ -127,8 +127,8 @@ namespace espressopp {
 
       protected:
         int ntypes;
-        shared_ptr<VerletListAdress> verletList;
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
+        std::shared_ptr<VerletListAdress> verletList;
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
         esutil::Array2D<Potential1, esutil::enlarge> potentialArray1;
         esutil::Array2D<Potential2, esutil::enlarge> potentialArray2;
 

--- a/src/interaction/VerletListAdressATInteractionTemplate.hpp
+++ b/src/interaction/VerletListAdressATInteractionTemplate.hpp
@@ -46,7 +46,7 @@ namespace espressopp {
 
       public:
         VerletListAdressATInteractionTemplate
-        (shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList)
+        (std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
           : verletList(_verletList), fixedtupleList(_fixedtupleList) {
 
           potentialArray = esutil::Array2D<Potential, esutil::enlarge>(0, 0, Potential());
@@ -63,16 +63,16 @@ namespace espressopp {
         }
 
         void
-        setVerletList(shared_ptr < VerletListAdress > _verletList) {
+        setVerletList(std::shared_ptr < VerletListAdress > _verletList) {
           verletList = _verletList;
         }
 
-        shared_ptr<VerletListAdress> getVerletList() {
+        std::shared_ptr<VerletListAdress> getVerletList() {
           return verletList;
         }
 
         void
-        setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+        setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
         }
 
@@ -91,8 +91,8 @@ namespace espressopp {
           return potentialArray.at(type1, type2);
         }
 
-        shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
-          return  make_shared<Potential>(potentialArray.at(type1, type2));
+        std::shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
+          return  std::make_shared<Potential>(potentialArray.at(type1, type2));
         }
 
         virtual void addForces();
@@ -114,8 +114,8 @@ namespace espressopp {
 
       protected:
         int ntypes;
-        shared_ptr<VerletListAdress> verletList;
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
+        std::shared_ptr<VerletListAdress> verletList;
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
         esutil::Array2D<Potential, esutil::enlarge> potentialArray;
 
         // AdResS stuff

--- a/src/interaction/VerletListAdressCGInteractionTemplate.hpp
+++ b/src/interaction/VerletListAdressCGInteractionTemplate.hpp
@@ -46,7 +46,7 @@ namespace espressopp {
 
       public:
         VerletListAdressCGInteractionTemplate
-        (shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList)
+        (std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
           : verletList(_verletList), fixedtupleList(_fixedtupleList) {
 
           potentialArray = esutil::Array2D<Potential, esutil::enlarge>(0, 0, Potential());
@@ -63,16 +63,16 @@ namespace espressopp {
         }
 
         void
-        setVerletList(shared_ptr < VerletListAdress > _verletList) {
+        setVerletList(std::shared_ptr < VerletListAdress > _verletList) {
           verletList = _verletList;
         }
 
-        shared_ptr<VerletListAdress> getVerletList() {
+        std::shared_ptr<VerletListAdress> getVerletList() {
           return verletList;
         }
 
         void
-        setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+        setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
         }
 
@@ -91,8 +91,8 @@ namespace espressopp {
           return potentialArray.at(type1, type2);
         }
 
-        shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
-          return  make_shared<Potential>(potentialArray.at(type1, type2));
+        std::shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
+          return  std::make_shared<Potential>(potentialArray.at(type1, type2));
         }
 
         virtual void addForces();
@@ -114,8 +114,8 @@ namespace espressopp {
 
       protected:
         int ntypes;
-        shared_ptr<VerletListAdress> verletList;
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
+        std::shared_ptr<VerletListAdress> verletList;
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
         esutil::Array2D<Potential, esutil::enlarge> potentialArray;
 
         // AdResS stuff

--- a/src/interaction/VerletListAdressInteractionTemplate.hpp
+++ b/src/interaction/VerletListAdressInteractionTemplate.hpp
@@ -49,7 +49,7 @@ namespace espressopp {
 
     public:
       VerletListAdressInteractionTemplate
-      (shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList)
+      (std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
                 : verletList(_verletList), fixedtupleList(_fixedtupleList) {
 
           potentialArrayAT = esutil::Array2D<PotentialAT, esutil::enlarge>(0, 0, PotentialAT());
@@ -67,16 +67,16 @@ namespace espressopp {
       }
 
       void
-      setVerletList(shared_ptr < VerletListAdress > _verletList) {
+      setVerletList(std::shared_ptr < VerletListAdress > _verletList) {
         verletList = _verletList;
       }
 
-      shared_ptr<VerletListAdress> getVerletList() {
+      std::shared_ptr<VerletListAdress> getVerletList() {
         return verletList;
       }
 
       void
-      setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+      setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
       }
 
@@ -127,8 +127,8 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr<VerletListAdress> verletList;
-      shared_ptr<FixedTupleListAdress> fixedtupleList;
+      std::shared_ptr<VerletListAdress> verletList;
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList;
       esutil::Array2D<PotentialAT, esutil::enlarge> potentialArrayAT;
       esutil::Array2D<PotentialCG, esutil::enlarge> potentialArrayCG;
 

--- a/src/interaction/VerletListHadressATATCGInteractionTemplate.hpp
+++ b/src/interaction/VerletListHadressATATCGInteractionTemplate.hpp
@@ -48,7 +48,7 @@ namespace espressopp {
 
       public:
         VerletListHadressATATCGInteractionTemplate
-        (shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList)
+        (std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
           : verletList(_verletList), fixedtupleList(_fixedtupleList) {
 
           potentialArrayAT1 = esutil::Array2D<PotentialAT1, esutil::enlarge>(0, 0, PotentialAT1());
@@ -67,16 +67,16 @@ namespace espressopp {
         }
 
         void
-        setVerletList(shared_ptr < VerletListAdress > _verletList) {
+        setVerletList(std::shared_ptr < VerletListAdress > _verletList) {
           verletList = _verletList;
         }
 
-        shared_ptr<VerletListAdress> getVerletList() {
+        std::shared_ptr<VerletListAdress> getVerletList() {
           return verletList;
         }
 
         void
-        setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+        setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
         }
 
@@ -144,8 +144,8 @@ namespace espressopp {
 
       protected:
         int ntypes;
-        shared_ptr<VerletListAdress> verletList;
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
+        std::shared_ptr<VerletListAdress> verletList;
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
         esutil::Array2D<PotentialAT1, esutil::enlarge> potentialArrayAT1;
         esutil::Array2D<PotentialAT2, esutil::enlarge> potentialArrayAT2;
         esutil::Array2D<PotentialCG, esutil::enlarge> potentialArrayCG;

--- a/src/interaction/VerletListHadressATATInteractionTemplate.hpp
+++ b/src/interaction/VerletListHadressATATInteractionTemplate.hpp
@@ -47,7 +47,7 @@ namespace espressopp {
 
       public:
         VerletListHadressATATInteractionTemplate
-        (shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList)
+        (std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
           : verletList(_verletList), fixedtupleList(_fixedtupleList) {
 
           potentialArray1 = esutil::Array2D<Potential1, esutil::enlarge>(0, 0, Potential1());
@@ -65,16 +65,16 @@ namespace espressopp {
         }
 
         void
-        setVerletList(shared_ptr < VerletListAdress > _verletList) {
+        setVerletList(std::shared_ptr < VerletListAdress > _verletList) {
           verletList = _verletList;
         }
 
-        shared_ptr<VerletListAdress> getVerletList() {
+        std::shared_ptr<VerletListAdress> getVerletList() {
           return verletList;
         }
 
         void
-        setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+        setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
         }
 
@@ -127,8 +127,8 @@ namespace espressopp {
 
       protected:
         int ntypes;
-        shared_ptr<VerletListAdress> verletList;
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
+        std::shared_ptr<VerletListAdress> verletList;
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
         esutil::Array2D<Potential1, esutil::enlarge> potentialArray1;
         esutil::Array2D<Potential2, esutil::enlarge> potentialArray2;
 

--- a/src/interaction/VerletListHadressATInteractionTemplate.hpp
+++ b/src/interaction/VerletListHadressATInteractionTemplate.hpp
@@ -46,7 +46,7 @@ namespace espressopp {
 
       public:
         VerletListHadressATInteractionTemplate
-        (shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList)
+        (std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
           : verletList(_verletList), fixedtupleList(_fixedtupleList) {
 
           potentialArray = esutil::Array2D<Potential, esutil::enlarge>(0, 0, Potential());
@@ -63,16 +63,16 @@ namespace espressopp {
         }
 
         void
-        setVerletList(shared_ptr < VerletListAdress > _verletList) {
+        setVerletList(std::shared_ptr < VerletListAdress > _verletList) {
           verletList = _verletList;
         }
 
-        shared_ptr<VerletListAdress> getVerletList() {
+        std::shared_ptr<VerletListAdress> getVerletList() {
           return verletList;
         }
 
         void
-        setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+        setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
         }
 
@@ -91,8 +91,8 @@ namespace espressopp {
           return potentialArray.at(type1, type2);
         }
 
-        shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
-          return  make_shared<Potential>(potentialArray.at(type1, type2));
+        std::shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
+          return  std::make_shared<Potential>(potentialArray.at(type1, type2));
         }
 
         virtual void addForces();
@@ -114,8 +114,8 @@ namespace espressopp {
 
       protected:
         int ntypes;
-        shared_ptr<VerletListAdress> verletList;
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
+        std::shared_ptr<VerletListAdress> verletList;
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
         esutil::Array2D<Potential, esutil::enlarge> potentialArray;
 
         // AdResS stuff

--- a/src/interaction/VerletListHadressCGInteractionTemplate.hpp
+++ b/src/interaction/VerletListHadressCGInteractionTemplate.hpp
@@ -46,7 +46,7 @@ namespace espressopp {
 
       public:
         VerletListHadressCGInteractionTemplate
-        (shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList)
+        (std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
           : verletList(_verletList), fixedtupleList(_fixedtupleList) {
 
           potentialArray = esutil::Array2D<Potential, esutil::enlarge>(0, 0, Potential());
@@ -63,16 +63,16 @@ namespace espressopp {
         }
 
         void
-        setVerletList(shared_ptr < VerletListAdress > _verletList) {
+        setVerletList(std::shared_ptr < VerletListAdress > _verletList) {
           verletList = _verletList;
         }
 
-        shared_ptr<VerletListAdress> getVerletList() {
+        std::shared_ptr<VerletListAdress> getVerletList() {
           return verletList;
         }
 
         void
-        setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+        setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
         }
 
@@ -91,8 +91,8 @@ namespace espressopp {
           return potentialArray.at(type1, type2);
         }
 
-        shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
-          return  make_shared<Potential>(potentialArray.at(type1, type2));
+        std::shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
+          return  std::make_shared<Potential>(potentialArray.at(type1, type2));
         }
 
         virtual void addForces();
@@ -114,8 +114,8 @@ namespace espressopp {
 
       protected:
         int ntypes;
-        shared_ptr<VerletListAdress> verletList;
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
+        std::shared_ptr<VerletListAdress> verletList;
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
         esutil::Array2D<Potential, esutil::enlarge> potentialArray;
 
         // AdResS stuff

--- a/src/interaction/VerletListHadressInteractionTemplate.hpp
+++ b/src/interaction/VerletListHadressInteractionTemplate.hpp
@@ -48,7 +48,7 @@ namespace espressopp {
 
     public:
       VerletListHadressInteractionTemplate
-      (shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList)
+      (std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList)
                 : verletList(_verletList), fixedtupleList(_fixedtupleList) {
 
           potentialArrayAT = esutil::Array2D<PotentialAT, esutil::enlarge>(0, 0, PotentialAT());
@@ -66,16 +66,16 @@ namespace espressopp {
       }
 
       void
-      setVerletList(shared_ptr < VerletListAdress > _verletList) {
+      setVerletList(std::shared_ptr < VerletListAdress > _verletList) {
         verletList = _verletList;
       }
 
-      shared_ptr<VerletListAdress> getVerletList() {
+      std::shared_ptr<VerletListAdress> getVerletList() {
         return verletList;
       }
 
       void
-      setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+      setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
       }
 
@@ -126,8 +126,8 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr<VerletListAdress> verletList;
-      shared_ptr<FixedTupleListAdress> fixedtupleList;
+      std::shared_ptr<VerletListAdress> verletList;
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList;
       esutil::Array2D<PotentialAT, esutil::enlarge> potentialArrayAT;
       esutil::Array2D<PotentialCG, esutil::enlarge> potentialArrayCG;
 

--- a/src/interaction/VerletListInteractionTemplate.hpp
+++ b/src/interaction/VerletListInteractionTemplate.hpp
@@ -48,7 +48,7 @@ namespace espressopp {
 
     public:
       VerletListInteractionTemplate
-          (shared_ptr<VerletList> _verletList)
+          (std::shared_ptr<VerletList> _verletList)
           : verletList(_verletList) {
     	  potentialArray    = esutil::Array2D<Potential, esutil::enlarge>(0, 0, Potential());
         ntypes = 0;
@@ -57,11 +57,11 @@ namespace espressopp {
       virtual ~VerletListInteractionTemplate() {};
 
       void
-      setVerletList(shared_ptr < VerletList > _verletList) {
+      setVerletList(std::shared_ptr < VerletList > _verletList) {
         verletList = _verletList;
       }
 
-      shared_ptr<VerletList> getVerletList() {
+      std::shared_ptr<VerletList> getVerletList() {
         return verletList;
       }
 
@@ -83,8 +83,8 @@ namespace espressopp {
       }
 
       // this is mainly used to access the potential from Python (e.g. to change parameters of the potential)
-      shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
-    	return  make_shared<Potential>(potentialArray.at(type1, type2));
+      std::shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
+    	return  std::make_shared<Potential>(potentialArray.at(type1, type2));
       }
 
 
@@ -105,9 +105,9 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr<VerletList> verletList;
+      std::shared_ptr<VerletList> verletList;
       esutil::Array2D<Potential, esutil::enlarge> potentialArray;
-      // not needed esutil::Array2D<shared_ptr<Potential>, esutil::enlarge> potentialArrayPtr;
+      // not needed esutil::Array2D<std::shared_ptr<Potential>, esutil::enlarge> potentialArrayPtr;
     };
 
     //////////////////////////////////////////////////
@@ -127,7 +127,7 @@ namespace espressopp {
         int type1 = p1.type();
         int type2 = p2.type();
         const Potential &potential = potentialArray(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
 
         Real3D force(0.0);
         if(potential._computeForce(force, p1, p2)) {
@@ -153,7 +153,7 @@ namespace espressopp {
         int type1 = p1.type();
         int type2 = p2.type();
         const Potential &potential = getPotential(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
         e   = potential._computeEnergy(p1, p2);
         // e   = potential->_computeEnergy(p1, p2);
         es += e;
@@ -221,7 +221,7 @@ namespace espressopp {
         int type1 = p1.type();
         int type2 = p2.type();
         const Potential &potential = getPotential(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
 
         Real3D force(0.0, 0.0, 0.0);
         if(potential._computeForce(force, p1, p2)) {
@@ -250,7 +250,7 @@ namespace espressopp {
         int type1 = p1.type();
         int type2 = p2.type();
         const Potential &potential = getPotential(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
 
         Real3D force(0.0, 0.0, 0.0);
         if(potential._computeForce(force, p1, p2)) {

--- a/src/interaction/VerletListPIadressInteractionTemplate.hpp
+++ b/src/interaction/VerletListPIadressInteractionTemplate.hpp
@@ -46,7 +46,7 @@ namespace espressopp {
 
       public:
         VerletListPIadressInteractionTemplate
-        (shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList, int _ntrotter, bool _speedup)
+        (std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList, int _ntrotter, bool _speedup)
           : verletList(_verletList), fixedtupleList(_fixedtupleList), ntrotter(_ntrotter), speedup(_speedup) {
 
           potentialArrayQM = esutil::Array2D<PotentialQM, esutil::enlarge>(0, 0, PotentialQM());
@@ -55,20 +55,20 @@ namespace espressopp {
         }
 
         void
-        setVerletList(shared_ptr < VerletListAdress > _verletList) {
+        setVerletList(std::shared_ptr < VerletListAdress > _verletList) {
           verletList = _verletList;
         }
 
-        shared_ptr<VerletListAdress> getVerletList() {
+        std::shared_ptr<VerletListAdress> getVerletList() {
           return verletList;
         }
 
         void
-        setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+        setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
         }
 
-        shared_ptr < FixedTupleListAdress > getFixedTupleList() {
+        std::shared_ptr < FixedTupleListAdress > getFixedTupleList() {
           return fixedtupleList;
         }
 
@@ -139,8 +139,8 @@ namespace espressopp {
 
       protected:
         int ntypes;
-        shared_ptr<VerletListAdress> verletList;
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
+        std::shared_ptr<VerletListAdress> verletList;
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
         esutil::Array2D<PotentialQM, esutil::enlarge> potentialArrayQM;
         esutil::Array2D<PotentialCL, esutil::enlarge> potentialArrayCL;
 

--- a/src/interaction/VerletListPIadressNoDriftInteractionTemplate.hpp
+++ b/src/interaction/VerletListPIadressNoDriftInteractionTemplate.hpp
@@ -44,7 +44,7 @@ namespace espressopp {
 
       public:
         VerletListPIadressNoDriftInteractionTemplate
-        (shared_ptr<VerletListAdress> _verletList, shared_ptr<FixedTupleListAdress> _fixedtupleList, int _ntrotter, bool _speedup)
+        (std::shared_ptr<VerletListAdress> _verletList, std::shared_ptr<FixedTupleListAdress> _fixedtupleList, int _ntrotter, bool _speedup)
           : verletList(_verletList), fixedtupleList(_fixedtupleList), ntrotter(_ntrotter), speedup(_speedup) {
 
           potentialArray = esutil::Array2D<Potential, esutil::enlarge>(0, 0, Potential());
@@ -52,20 +52,20 @@ namespace espressopp {
         }
 
         void
-        setVerletList(shared_ptr < VerletListAdress > _verletList) {
+        setVerletList(std::shared_ptr < VerletListAdress > _verletList) {
           verletList = _verletList;
         }
 
-        shared_ptr<VerletListAdress> getVerletList() {
+        std::shared_ptr<VerletListAdress> getVerletList() {
           return verletList;
         }
 
         void
-        setFixedTupleList(shared_ptr<FixedTupleListAdress> _fixedtupleList) {
+        setFixedTupleList(std::shared_ptr<FixedTupleListAdress> _fixedtupleList) {
           fixedtupleList = _fixedtupleList;
         }
 
-        shared_ptr < FixedTupleListAdress > getFixedTupleList() {
+        std::shared_ptr < FixedTupleListAdress > getFixedTupleList() {
           return fixedtupleList;
         }
 
@@ -121,8 +121,8 @@ namespace espressopp {
 
       protected:
         int ntypes;
-        shared_ptr<VerletListAdress> verletList;
-        shared_ptr<FixedTupleListAdress> fixedtupleList;
+        std::shared_ptr<VerletListAdress> verletList;
+        std::shared_ptr<FixedTupleListAdress> fixedtupleList;
         esutil::Array2D<Potential, esutil::enlarge> potentialArray;
 
         int ntrotter;

--- a/src/interaction/VerletListTripleInteractionTemplate.hpp
+++ b/src/interaction/VerletListTripleInteractionTemplate.hpp
@@ -45,7 +45,7 @@ namespace espressopp {
 
     public:
       VerletListTripleInteractionTemplate
-      (shared_ptr < System > _system,shared_ptr < VerletListTriple > _verletlisttriple)
+      (std::shared_ptr < System > _system,std::shared_ptr < VerletListTriple > _verletlisttriple)
       : SystemAccess(_system), verletListTriple(_verletlisttriple)
       {
         potentialArray = esutil::Array3D<Potential, esutil::enlarge>(0, 0, 0, Potential());
@@ -53,10 +53,10 @@ namespace espressopp {
       }
 
       void
-      setVerletListTriple(shared_ptr < VerletListTriple > _verletlisttriple) {
+      setVerletListTriple(std::shared_ptr < VerletListTriple > _verletlisttriple) {
         verletListTriple = _verletlisttriple;
       }
-      shared_ptr < VerletListTriple > getVerletListTriple() {
+      std::shared_ptr < VerletListTriple > getVerletListTriple() {
         return verletListTriple;
       }
 
@@ -93,7 +93,7 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr<VerletListTriple> verletListTriple;
+      std::shared_ptr<VerletListTriple> verletListTriple;
       esutil::Array3D<Potential, esutil::enlarge> potentialArray;
     };
 

--- a/src/interaction/VerletListVSphereInteractionTemplate.hpp
+++ b/src/interaction/VerletListVSphereInteractionTemplate.hpp
@@ -48,7 +48,7 @@ namespace espressopp {
 
     public:
       VerletListVSphereInteractionTemplate
-          (shared_ptr<VerletList> _verletList)
+          (std::shared_ptr<VerletList> _verletList)
           : verletList(_verletList) {
     	  potentialArray    = esutil::Array2D<Potential, esutil::enlarge>(0, 0, Potential());
         ntypes = 0;
@@ -57,11 +57,11 @@ namespace espressopp {
       virtual ~VerletListVSphereInteractionTemplate() {};
 
       void
-      setVerletList(shared_ptr < VerletList > _verletList) {
+      setVerletList(std::shared_ptr < VerletList > _verletList) {
         verletList = _verletList;
       }
 
-      shared_ptr<VerletList> getVerletList() {
+      std::shared_ptr<VerletList> getVerletList() {
         return verletList;
       }
 
@@ -81,8 +81,8 @@ namespace espressopp {
       }
 
       // this is mainly used to access the potential from Python (e.g. to change parameters of the potential)
-      shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
-    	return  make_shared<Potential>(potentialArray.at(type1, type2));
+      std::shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
+    	return  std::make_shared<Potential>(potentialArray.at(type1, type2));
       }
 
 
@@ -103,9 +103,9 @@ namespace espressopp {
 
     protected:
       int ntypes;
-      shared_ptr<VerletList> verletList;
+      std::shared_ptr<VerletList> verletList;
       esutil::Array2D<Potential, esutil::enlarge> potentialArray;
-      esutil::Array2D<shared_ptr<Potential>, esutil::enlarge> potentialArrayPtr;
+      esutil::Array2D<std::shared_ptr<Potential>, esutil::enlarge> potentialArrayPtr;
     };
 
     //////////////////////////////////////////////////
@@ -122,7 +122,7 @@ namespace espressopp {
         int type1 = p1.type();
         int type2 = p2.type();
         const Potential &potential = getPotential(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
 
         Real3D force(0.0);
         real fsi=0.0, fsj=0.0;
@@ -149,7 +149,7 @@ namespace espressopp {
         int type1 = p1.type();
         int type2 = p2.type();
         const Potential &potential = getPotential(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
         e   = potential._computeEnergy(p1, p2);
         // e   = potential->_computeEnergy(p1, p2);
         es += e;
@@ -217,7 +217,7 @@ namespace espressopp {
         int type1 = p1.type();
         int type2 = p2.type();
         const Potential &potential = getPotential(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
 
         Real3D force(0.0, 0.0, 0.0);
         real fsi, fsj;
@@ -248,7 +248,7 @@ namespace espressopp {
         int type1 = p1.type();
         int type2 = p2.type();
         const Potential &potential = getPotential(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
 
         Real3D force(0.0, 0.0, 0.0);
         real fsi, fsj;

--- a/src/interaction/Zero.cpp
+++ b/src/interaction/Zero.cpp
@@ -57,15 +57,15 @@ namespace espressopp {
       ;
 
       class_< VerletListZero, bases< Interaction > >
-        ("interaction_VerletListZero", init< shared_ptr<VerletList> >())
+        ("interaction_VerletListZero", init< std::shared_ptr<VerletList> >())
         .def("setPotential", &VerletListZero::setPotential, return_value_policy< reference_existing_object >())
         .def("getPotential", &VerletListZero::getPotential, return_value_policy< reference_existing_object >())
       ;
 
       class_< VerletListAdressZero, bases< Interaction > >
         ("interaction_VerletListAdressZero",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setFixedTupleList", &VerletListAdressZero::setFixedTupleList)
         .def("setPotentialAT", &VerletListAdressZero::setPotentialAT)
         .def("setPotentialCG", &VerletListAdressZero::setPotentialCG);
@@ -73,21 +73,21 @@ namespace espressopp {
 
       class_< VerletListHadressZero, bases< Interaction > >
         ("interaction_VerletListHadressZero",
-           init< shared_ptr<VerletListAdress>,
-                  shared_ptr<FixedTupleListAdress> >())
+           init< std::shared_ptr<VerletListAdress>,
+                  std::shared_ptr<FixedTupleListAdress> >())
         .def("setFixedTupleList", &VerletListHadressZero::setFixedTupleList)
         .def("setPotentialAT", &VerletListHadressZero::setPotentialAT)
         .def("setPotentialCG", &VerletListHadressZero::setPotentialCG);
       ;
       
       class_< CellListZero, bases< Interaction > >
-        ("interaction_CellListZero", init< shared_ptr< storage::Storage > >())
+        ("interaction_CellListZero", init< std::shared_ptr< storage::Storage > >())
         .def("setPotential", &CellListZero::setPotential);
 	  ;
 
       class_< FixedPairListZero, bases< Interaction > >
         ("interaction_FixedPairListZero",
-          init< shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<Zero> >())
+          init< std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<Zero> >())
           .def("setPotential", &FixedPairListZero::setPotential);
       ;
     }

--- a/src/io/DumpGRO.cpp
+++ b/src/io/DumpGRO.cpp
@@ -40,7 +40,7 @@ namespace espressopp {
       
     void DumpGRO::dump(){
       
-      shared_ptr<System> system = getSystem();
+      std::shared_ptr<System> system = getSystem();
       ConfigurationsExt conf( system );
       conf.setUnfolded(unfolded);
       conf.gather();
@@ -128,8 +128,8 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<DumpGRO, bases<ParticleAccess>, boost::noncopyable >
-      ("io_DumpGRO", init< shared_ptr< System >, 
-                           shared_ptr< integrator::MDIntegrator >, 
+      ("io_DumpGRO", init< std::shared_ptr< System >,
+                           std::shared_ptr< integrator::MDIntegrator >,
                            std::string, 
                            bool,
                            real,

--- a/src/io/DumpGRO.hpp
+++ b/src/io/DumpGRO.hpp
@@ -47,8 +47,8 @@ namespace espressopp {
 
     public:
 
-      DumpGRO(shared_ptr<System> system, 
-              shared_ptr<integrator::MDIntegrator> _integrator,
+      DumpGRO(std::shared_ptr<System> system,
+              std::shared_ptr<integrator::MDIntegrator> _integrator,
               std::string _file_name,
               bool _unfolded,
               real _length_factor,
@@ -137,7 +137,7 @@ namespace espressopp {
     private:
       
       // integrator we need to know an integration step
-      shared_ptr<integrator::MDIntegrator> integrator;
+      std::shared_ptr<integrator::MDIntegrator> integrator;
       
       std::string file_name;
 

--- a/src/io/DumpGROAdress.cpp
+++ b/src/io/DumpGROAdress.cpp
@@ -41,7 +41,7 @@ namespace espressopp {
       
     void DumpGROAdress::dump(){
       
-      shared_ptr<System> system = getSystem();
+      std::shared_ptr<System> system = getSystem();
       ConfigurationsExtAdress conf( system,fixedTupleList );
       conf.setUnfolded(unfolded);
       conf.gather();
@@ -139,8 +139,8 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<DumpGROAdress, bases<ParticleAccess>, boost::noncopyable >
-      ("io_DumpGROAdress", init< shared_ptr< System >, shared_ptr<FixedTupleListAdress>,
-                           shared_ptr< integrator::MDIntegrator >, 
+      ("io_DumpGROAdress", init< std::shared_ptr< System >, std::shared_ptr<FixedTupleListAdress>,
+                           std::shared_ptr< integrator::MDIntegrator >,
                            std::string, 
                            bool,
                            real,

--- a/src/io/DumpGROAdress.hpp
+++ b/src/io/DumpGROAdress.hpp
@@ -46,8 +46,8 @@ namespace espressopp {
 
     public:
 
-      DumpGROAdress(shared_ptr<System> system, shared_ptr<FixedTupleListAdress> _fixedTupleList,
-              shared_ptr<integrator::MDIntegrator> _integrator,
+      DumpGROAdress(std::shared_ptr<System> system, std::shared_ptr<FixedTupleListAdress> _fixedTupleList,
+              std::shared_ptr<integrator::MDIntegrator> _integrator,
               std::string _file_name,
               bool _unfolded,
               real _length_factor,
@@ -132,12 +132,12 @@ namespace espressopp {
     protected:
 
       //static LOG4ESPP_DECL_LOGGER(logger);
-      shared_ptr<FixedTupleListAdress> fixedTupleList;
+      std::shared_ptr<FixedTupleListAdress> fixedTupleList;
 
     private:
       
       // integrator we need to know an integration step
-      shared_ptr<integrator::MDIntegrator> integrator;
+      std::shared_ptr<integrator::MDIntegrator> integrator;
       
       std::string file_name;
 

--- a/src/io/DumpH5MD.cpp
+++ b/src/io/DumpH5MD.cpp
@@ -72,7 +72,7 @@ namespace espressopp {
       pb->len = 0;
     }
 
-    DumpH5MD::DumpH5MD(shared_ptr<System> system, bool is_adress) :
+    DumpH5MD::DumpH5MD(std::shared_ptr<System> system, bool is_adress) :
         SystemAccess(system), is_adress_(is_adress) {
 
       store_position = true;
@@ -146,7 +146,7 @@ namespace espressopp {
 
       int i = 0;
       if (is_adress_) {
-        shared_ptr<FixedTupleListAdress> ftpl = system.storage->getFixedTuples();
+        std::shared_ptr<FixedTupleListAdress> ftpl = system.storage->getFixedTuples();
         FixedTupleListAdress::iterator it3;
         for (iterator::CellListIterator cit(realCells); !cit.isDone(); ++cit) {
           it3 = ftpl->find(&(*cit));
@@ -306,7 +306,7 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<DumpH5MD>
-        ("io_DumpH5MD", init< shared_ptr< System >, bool >())
+        ("io_DumpH5MD", init< std::shared_ptr< System >, bool >())
         .def("update", &DumpH5MD::update)
         .def("clear_buffers", &DumpH5MD::clear_buffers)
         .def("getPosition", &DumpH5MD::getPosition)

--- a/src/io/DumpH5MD.hpp
+++ b/src/io/DumpH5MD.hpp
@@ -40,7 +40,7 @@ void free_pb(Py_buffer *pb);
 /** Store particle data in Python buffers */
 class DumpH5MD : public SystemAccess {
  public:
-  DumpH5MD(shared_ptr<System> system, bool is_adress);
+  DumpH5MD(std::shared_ptr<System> system, bool is_adress);
   ~DumpH5MD();
 
   int get_NLocal() { return NLocal; }

--- a/src/io/DumpTopology.cpp
+++ b/src/io/DumpTopology.cpp
@@ -26,22 +26,22 @@
 namespace espressopp {
 namespace io {
 
-void DumpTopology::observeTuple(shared_ptr<FixedPairList> fpl) {
+void DumpTopology::observeTuple(std::shared_ptr<FixedPairList> fpl) {
   fpls_.push_back(fpl);
 }
 
-void DumpTopology::observeTriple(shared_ptr<FixedTripleList> ftl) {
+void DumpTopology::observeTriple(std::shared_ptr<FixedTripleList> ftl) {
   ftls_.push_back(ftl);
 }
 
-void DumpTopology::observeQuadruple(shared_ptr<FixedQuadrupleList> fql) {
+void DumpTopology::observeQuadruple(std::shared_ptr<FixedQuadrupleList> fql) {
   fqls_.push_back(fql);
 }
 
 void DumpTopology::saveDataToBuffer() {
   // Format: <step1><pair_idx_0><size><pid1><pid2><pid3><pid4><pair_idx_1><size><pid...><step2>..
   int idx = 0;
-  for (std::vector<shared_ptr<FixedPairList> >::iterator it = fpls_.begin(); it != fpls_.end(); ++it) {
+  for (std::vector<std::shared_ptr<FixedPairList> >::iterator it = fpls_.begin(); it != fpls_.end(); ++it) {
     std::vector<longint> pairs = (*it)->getPairList();
     fpl_buffer_.push_front(integrator_->getStep());
     fpl_buffer_.push_front(idx);
@@ -56,7 +56,7 @@ void DumpTopology::saveDataToBuffer() {
 
   // Save data from triplet.
   idx = 0;
-  for (std::vector<shared_ptr<FixedTripleList> >::iterator it = ftls_.begin(); it != ftls_.end(); ++it) {
+  for (std::vector<std::shared_ptr<FixedTripleList> >::iterator it = ftls_.begin(); it != ftls_.end(); ++it) {
     std::vector<longint> triples = (*it)->getTripleList();
     fpl_buffer_.push_front(integrator_->getStep());
     fpl_buffer_.push_front(idx);
@@ -72,7 +72,7 @@ void DumpTopology::saveDataToBuffer() {
 
   // Save data from quadruplets
   idx = 0;
-  for (std::vector<shared_ptr<FixedQuadrupleList> >::iterator it = fqls_.begin(); it != fqls_.end(); ++it) {
+  for (std::vector<std::shared_ptr<FixedQuadrupleList> >::iterator it = fqls_.begin(); it != fqls_.end(); ++it) {
     std::vector<longint> quadruples = (*it)->getQuadrupleList();
     fpl_buffer_.push_front(integrator_->getStep());
     fpl_buffer_.push_front(idx);
@@ -106,7 +106,7 @@ void DumpTopology::registerPython() {
   using namespace espressopp::python;  //NOLINT
 
   class_<DumpTopology, bases<ParticleAccess>, boost::noncopyable>
-      ("io_DumpTopology", init<shared_ptr<System>, shared_ptr<integrator::MDIntegrator> >())
+      ("io_DumpTopology", init<std::shared_ptr<System>, std::shared_ptr<integrator::MDIntegrator> >())
       .def("clear_buffer", &DumpTopology::clearBuffer)
       .def("get_data", &DumpTopology::getData)
       .def("dump", &DumpTopology::saveDataToBuffer)

--- a/src/io/DumpTopology.hpp
+++ b/src/io/DumpTopology.hpp
@@ -40,7 +40,7 @@ namespace espressopp {
 namespace io {
 class DumpTopology: public ParticleAccess {
  public:
-  DumpTopology(shared_ptr<System> system, shared_ptr<integrator::MDIntegrator> integrator)
+  DumpTopology(std::shared_ptr<System> system, std::shared_ptr<integrator::MDIntegrator> integrator)
       : ParticleAccess(system), integrator_(integrator) { }
   ~DumpTopology() {  }
 
@@ -48,9 +48,9 @@ class DumpTopology: public ParticleAccess {
     saveDataToBuffer();
   }
 
-  void observeTuple(shared_ptr<FixedPairList> fpl);
-  void observeTriple(shared_ptr<FixedTripleList> ftl);
-  void observeQuadruple(shared_ptr<FixedQuadrupleList> fql);
+  void observeTuple(std::shared_ptr<FixedPairList> fpl);
+  void observeTriple(std::shared_ptr<FixedTripleList> ftl);
+  void observeQuadruple(std::shared_ptr<FixedQuadrupleList> fql);
 
   python::list getData();
 
@@ -61,14 +61,14 @@ class DumpTopology: public ParticleAccess {
 
   void clearBuffer();
 
-  shared_ptr<integrator::MDIntegrator> integrator_;
+  std::shared_ptr<integrator::MDIntegrator> integrator_;
 
   typedef std::deque<longint> FplBuffer;
   FplBuffer fpl_buffer_;
 
-  std::vector<shared_ptr<FixedPairList> > fpls_;
-  std::vector<shared_ptr<FixedTripleList> > ftls_;
-  std::vector<shared_ptr<FixedQuadrupleList> > fqls_;
+  std::vector<std::shared_ptr<FixedPairList> > fpls_;
+  std::vector<std::shared_ptr<FixedTripleList> > ftls_;
+  std::vector<std::shared_ptr<FixedQuadrupleList> > fqls_;
 
   void saveDataToBuffer();
 };

--- a/src/io/DumpXTC.cpp
+++ b/src/io/DumpXTC.cpp
@@ -60,7 +60,7 @@ namespace espressopp {
       
     void DumpXTC::dump(){
 
-      shared_ptr<System> system = getSystem();
+      std::shared_ptr<System> system = getSystem();
       ConfigurationsExt conf( system );
       conf.setUnfolded(unfolded);
       conf.gather();
@@ -138,8 +138,8 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<DumpXTC, bases<ParticleAccess>, boost::noncopyable >
-      ("io_DumpXTC", init< shared_ptr< System >, 
-                           shared_ptr< integrator::MDIntegrator >, 
+      ("io_DumpXTC", init< std::shared_ptr< System >,
+                           std::shared_ptr< integrator::MDIntegrator >,
                            std::string, 
                            bool,
                            real,

--- a/src/io/DumpXTC.hpp
+++ b/src/io/DumpXTC.hpp
@@ -49,8 +49,8 @@ namespace espressopp {
 
     public:
 
-      DumpXTC(shared_ptr<System> system, 
-              shared_ptr<integrator::MDIntegrator> _integrator,
+      DumpXTC(std::shared_ptr<System> system,
+              std::shared_ptr<integrator::MDIntegrator> _integrator,
               std::string _file_name,
               bool _unfolded,
               real _length_factor,
@@ -93,7 +93,7 @@ namespace espressopp {
       real xtcprec;
 
       // integrator we need to know an integration step
-      shared_ptr<integrator::MDIntegrator> integrator;
+      std::shared_ptr<integrator::MDIntegrator> integrator;
       
       std::string file_name;
 

--- a/src/io/DumpXTCAdress.cpp
+++ b/src/io/DumpXTCAdress.cpp
@@ -50,7 +50,7 @@ void DumpXTCAdress::close() {
 }
 
 void DumpXTCAdress::dump() {
-  shared_ptr<System> system = getSystem();
+  std::shared_ptr<System> system = getSystem();
   analysis::ConfigurationsExtAdress conf(system, ftpl);
   conf.setUnfolded(unfolded);
   conf.gather();
@@ -120,9 +120,9 @@ void DumpXTCAdress::registerPython() {
   using namespace espressopp::python;  // NOLINT
 
   class_<DumpXTCAdress, bases<ParticleAccess>, boost::noncopyable>
-  ("io_DumpXTCAdress", init<shared_ptr<System>,
-                       shared_ptr<FixedTupleListAdress>,
-                       shared_ptr<integrator::MDIntegrator>,
+  ("io_DumpXTCAdress", init<std::shared_ptr<System>,
+                       std::shared_ptr<FixedTupleListAdress>,
+                       std::shared_ptr<integrator::MDIntegrator>,
                        std::string,
                        bool,
                        real,

--- a/src/io/DumpXTCAdress.hpp
+++ b/src/io/DumpXTCAdress.hpp
@@ -47,9 +47,9 @@ namespace espressopp {
 namespace io {
 class DumpXTCAdress : public ParticleAccess {
  public:
-  DumpXTCAdress(shared_ptr<System> system,
-    shared_ptr<FixedTupleListAdress> _ftpl,
-    shared_ptr<integrator::MDIntegrator> _integrator,
+  DumpXTCAdress(std::shared_ptr<System> system,
+    std::shared_ptr<FixedTupleListAdress> _ftpl,
+    std::shared_ptr<integrator::MDIntegrator> _integrator,
     std::string _file_name,
     bool _unfolded,
     real _length_factor,
@@ -90,8 +90,8 @@ class DumpXTCAdress : public ParticleAccess {
   real xtcprec;
 
   // integrator we need to know an integration step
-  shared_ptr<integrator::MDIntegrator> integrator;
-  shared_ptr<FixedTupleListAdress> ftpl;
+  std::shared_ptr<integrator::MDIntegrator> integrator;
+  std::shared_ptr<FixedTupleListAdress> ftpl;
 
   std::string file_name;
 

--- a/src/io/DumpXYZ.cpp
+++ b/src/io/DumpXYZ.cpp
@@ -41,7 +41,7 @@ namespace espressopp {
 
     void DumpXYZ::dump(){
 
-      shared_ptr<System> system = getSystem();
+      std::shared_ptr<System> system = getSystem();
       ConfigurationsExt conf( system );
       conf.setUnfolded(unfolded);
       conf.gather();
@@ -103,8 +103,8 @@ namespace espressopp {
       using namespace espressopp::python;
 
       class_<DumpXYZ, bases<ParticleAccess>, boost::noncopyable >
-      ("io_DumpXYZ", init< shared_ptr< System >,
-                           shared_ptr< integrator::MDIntegrator >,
+      ("io_DumpXYZ", init< std::shared_ptr< System >,
+                           std::shared_ptr< integrator::MDIntegrator >,
                            std::string,
                            bool,
                            real,

--- a/src/io/DumpXYZ.hpp
+++ b/src/io/DumpXYZ.hpp
@@ -45,8 +45,8 @@ namespace espressopp {
 
     public:
 
-      DumpXYZ(shared_ptr<System> system,
-              shared_ptr<integrator::MDIntegrator> _integrator,
+      DumpXYZ(std::shared_ptr<System> system,
+              std::shared_ptr<integrator::MDIntegrator> _integrator,
               std::string _file_name,
               bool _unfolded,
               real _length_factor,
@@ -137,7 +137,7 @@ namespace espressopp {
     private:
 
       // integrator we need to know an integration step
-      shared_ptr<integrator::MDIntegrator> integrator;
+      std::shared_ptr<integrator::MDIntegrator> integrator;
 
       std::string file_name;
 

--- a/src/main/espressopp_common.cpp
+++ b/src/main/espressopp_common.cpp
@@ -28,8 +28,7 @@
 /** the one and only instance of the MPI environment */
 static boost::mpi::environment *theEnvironment = 0;
 
-boost::shared_ptr< boost::mpi::communicator > mpiWorld 
-= boost::make_shared< boost::mpi::communicator >();
+std::shared_ptr< boost::mpi::communicator > mpiWorld = std::make_shared< boost::mpi::communicator >();
 
 /** Initialize MPI. */
 void initMPIEnv(int &argc, char **&argv) {

--- a/src/storage/DomainDecomposition.cpp
+++ b/src/storage/DomainDecomposition.cpp
@@ -68,7 +68,7 @@ namespace espressopp {
   {}
 
   DomainDecomposition::
-  DomainDecomposition(shared_ptr< System > _system,
+  DomainDecomposition(std::shared_ptr< System > _system,
           const Int3D& _nodeGrid,
           const Int3D& _cellGrid,
           int _halfCellInt)
@@ -780,7 +780,7 @@ namespace espressopp {
   void DomainDecomposition::registerPython() {
     using namespace espressopp::python;
     class_< DomainDecomposition, bases< Storage >, boost::noncopyable >
-    ("storage_DomainDecomposition", init< shared_ptr< System >, const Int3D&, const Int3D&, int >())
+    ("storage_DomainDecomposition", init< std::shared_ptr< System >, const Int3D&, const Int3D&, int >())
     .def("mapPositionToNodeClipped", &DomainDecomposition::mapPositionToNodeClipped)
     .def("getCellGrid", &DomainDecomposition::getInt3DCellGrid)
     .def("getNodeGrid", &DomainDecomposition::getInt3DNodeGrid)

--- a/src/storage/DomainDecomposition.hpp
+++ b/src/storage/DomainDecomposition.hpp
@@ -41,7 +41,7 @@ namespace espressopp {
 
     class DomainDecomposition: public Storage {
     public:
-      DomainDecomposition(shared_ptr< System > system,
+      DomainDecomposition(std::shared_ptr< System > system,
               const Int3D& _nodeGrid,
               const Int3D& _cellGrid,
               int halfCellInt

--- a/src/storage/DomainDecompositionAdress.cpp
+++ b/src/storage/DomainDecompositionAdress.cpp
@@ -66,7 +66,7 @@ namespace espressopp {
   {}
 
   DomainDecompositionAdress::
-  DomainDecompositionAdress(shared_ptr< System > _system,
+  DomainDecompositionAdress(std::shared_ptr< System > _system,
           const Int3D& _nodeGrid,
           const Int3D& _cellGrid,
           int _halfCellInt)
@@ -1170,7 +1170,7 @@ namespace espressopp {
 
   class PyDomainDecompositionAdress : public DomainDecompositionAdress {
       public:
-        PyDomainDecompositionAdress(shared_ptr< System > _system,
+        PyDomainDecompositionAdress(std::shared_ptr< System > _system,
                   const Int3D& _nodeGrid,
                   const Int3D& _cellGrid,
                   int _halfCellInt)
@@ -1188,7 +1188,7 @@ namespace espressopp {
     using namespace espressopp::python;
     class_< PyDomainDecompositionAdress, bases< Storage >, boost::noncopyable >
   ("storage_DomainDecompositionAdress",
-   init< shared_ptr< System >,
+   init< std::shared_ptr< System >,
    const Int3D&, const Int3D&, int >())
   .def("mapPositionToNodeClipped", &DomainDecompositionAdress::mapPositionToNodeClipped)
   .def("getCellGrid", &DomainDecompositionAdress::getInt3DCellGrid)

--- a/src/storage/DomainDecompositionAdress.hpp
+++ b/src/storage/DomainDecompositionAdress.hpp
@@ -41,7 +41,7 @@ namespace espressopp {
 
     class DomainDecompositionAdress: public Storage {
     public:
-      DomainDecompositionAdress(shared_ptr< System > system,
+      DomainDecompositionAdress(std::shared_ptr< System > system,
               const Int3D& _nodeGrid,
               const Int3D& _cellGrid,
               int _halfCellInt);

--- a/src/storage/DomainDecompositionNonBlocking.cpp
+++ b/src/storage/DomainDecompositionNonBlocking.cpp
@@ -45,7 +45,7 @@ namespace espressopp {
   const int DD_COMM_TAG = 0xab;
 
   DomainDecompositionNonBlocking::
-  DomainDecompositionNonBlocking(shared_ptr< System > _system,
+  DomainDecompositionNonBlocking(std::shared_ptr< System > _system,
           const Int3D& _nodeGrid,
           const Int3D& _cellGrid)
     : DomainDecomposition(_system, _nodeGrid, _cellGrid, 1 /*in DD nonblocking we do not allow halfcell at the moment*/),
@@ -411,7 +411,7 @@ namespace espressopp {
   void DomainDecompositionNonBlocking::registerPython() {
     using namespace espressopp::python;
     class_< DomainDecompositionNonBlocking, bases< DomainDecomposition >, boost::noncopyable >
-    ("storage_DomainDecompositionNonBlocking", init< shared_ptr< System >, const Int3D&, const Int3D& >())
+    ("storage_DomainDecompositionNonBlocking", init< std::shared_ptr< System >, const Int3D&, const Int3D& >())
     ;
   }
 

--- a/src/storage/DomainDecompositionNonBlocking.hpp
+++ b/src/storage/DomainDecompositionNonBlocking.hpp
@@ -30,7 +30,7 @@ namespace espressopp {
   namespace storage {
     class DomainDecompositionNonBlocking: public DomainDecomposition {
     public:
-      DomainDecompositionNonBlocking(shared_ptr< System > system,
+      DomainDecompositionNonBlocking(std::shared_ptr< System > system,
               const Int3D& _nodeGrid,
 			  const Int3D& _cellGrid);
       virtual ~DomainDecompositionNonBlocking() {}

--- a/src/storage/Storage.cpp
+++ b/src/storage/Storage.cpp
@@ -55,7 +55,7 @@ namespace espressopp {
     const int Storage::dataOfUpdateGhosts = 0;
     const int Storage::dataOfExchangeGhosts = DATA_PROPERTIES;
 
-    Storage::Storage(shared_ptr< System > system, int halfCellInt)
+    Storage::Storage(std::shared_ptr< System > system, int halfCellInt)
       : SystemAccess(system),
         halfCellInt(halfCellInt),
         inBuffer(*system->comm),

--- a/src/storage/Storage.hpp
+++ b/src/storage/Storage.hpp
@@ -49,7 +49,7 @@ namespace espressopp {
       typedef boost::unordered_map <longint, Particle*> IdParticleMap;
       typedef std::list<Particle> ParticleListAdr;
 
-      Storage(shared_ptr<class System> system, int halfCellInt);
+      Storage(std::shared_ptr<class System> system, int halfCellInt);
       virtual ~Storage();
 
       /** Scale Volume, only for Storage. It scales only the particle coord. */
@@ -253,10 +253,10 @@ namespace espressopp {
       boost::signals2::signal<void ()> onCellAdjust;
 
       // for AdResS
-      void setFixedTuplesAdress(shared_ptr<FixedTupleListAdress> _fixedtupleList){
+      void setFixedTuplesAdress(std::shared_ptr<FixedTupleListAdress> _fixedtupleList){
           fixedtupleList = _fixedtupleList;
       }
-      shared_ptr<FixedTupleListAdress> getFixedTuples() { return fixedtupleList; }
+      std::shared_ptr<FixedTupleListAdress> getFixedTuples() { return fixedtupleList; }
       ParticleList&    getAdrATParticles()  { return AdrATParticles; }
       //ParticleListAdr& getAdrATParticlesG() { return AdrATParticlesG; }
       std::list<ParticleList>& getAdrATParticlesG() { return AdrATParticlesG; }
@@ -413,7 +413,7 @@ namespace espressopp {
 
 
       // used for AdResS
-      shared_ptr<FixedTupleListAdress> fixedtupleList;
+      std::shared_ptr<FixedTupleListAdress> fixedtupleList;
       void clearAdrATParticlesG() {
           //std::cout << "size of AdrATParticlesG: " << AdrATParticlesG.size() << ", clearing... \n";
           AdrATParticlesG.clear();

--- a/src/vectorization/CellNeighborList.hpp
+++ b/src/vectorization/CellNeighborList.hpp
@@ -45,7 +45,7 @@ namespace espressopp {
       typedef typename Super::size_type size_type;
 
       CellNeighborList(){}
-      CellNeighborList(shared_ptr<storage::Storage>& storage)
+      CellNeighborList(std::shared_ptr<storage::Storage>& storage)
       {
         CellList const& localCells = storage->getLocalCells();
         CellList const& realCells  = storage->getRealCells();

--- a/src/vectorization/Vectorization.cpp
+++ b/src/vectorization/Vectorization.cpp
@@ -32,8 +32,8 @@ namespace espressopp {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     /// constructor
     Vectorization::Vectorization(
-      shared_ptr<System> system,
-      shared_ptr<MDIntegrator> mdintegrator,
+      std::shared_ptr<System> system,
+      std::shared_ptr<MDIntegrator> mdintegrator,
       Mode mode
       ): SystemAccess(system), mdintegrator(mdintegrator), mode(mode)
     {
@@ -136,9 +136,9 @@ namespace espressopp {
     {
       using namespace espressopp::python;
 
-      class_<Vectorization, shared_ptr<Vectorization> >
-        ("Vectorization", init< shared_ptr<System>, shared_ptr<MDIntegrator>, Mode >())
-        .def(init< shared_ptr<System>, shared_ptr<MDIntegrator> >())
+      class_<Vectorization, std::shared_ptr<Vectorization> >
+        ("Vectorization", init< std::shared_ptr<System>, std::shared_ptr<MDIntegrator>, Mode >())
+        .def(init< std::shared_ptr<System>, std::shared_ptr<MDIntegrator> >())
         ;
 
       enum_<Mode>("VectorizationMode")

--- a/src/vectorization/Vectorization.hpp
+++ b/src/vectorization/Vectorization.hpp
@@ -39,7 +39,7 @@ namespace espressopp {
     class Vectorization : public SystemAccess
     {
     public:
-      Vectorization(shared_ptr<System> system, shared_ptr<integrator::MDIntegrator> mdintegrator,
+      Vectorization(std::shared_ptr<System> system, std::shared_ptr<integrator::MDIntegrator> mdintegrator,
         Mode mode = ESPP_VEC_MODE_DEFAULT);
       ~Vectorization();
 
@@ -62,7 +62,7 @@ namespace espressopp {
       CellNeighborList neighborList;
       void resetCells();
 
-      shared_ptr<integrator::MDIntegrator> mdintegrator;
+      std::shared_ptr<integrator::MDIntegrator> mdintegrator;
 
       // signals that connect to integrator
       boost::signals2::connection sigBefCalcForces;
@@ -72,7 +72,7 @@ namespace espressopp {
       boost::signals2::connection sigResetParticles;
       boost::signals2::connection sigResetCells;
 
-      shared_ptr<storage::DomainDecomposition> decomp;
+      std::shared_ptr<storage::DomainDecomposition> decomp;
 
       static LOG4ESPP_DECL_LOGGER(logger);
     };

--- a/src/vectorization/VerletList.cpp
+++ b/src/vectorization/VerletList.cpp
@@ -42,7 +42,7 @@ namespace espressopp { namespace vectorization {
 /*-------------------------------------------------------------*/
 
   // cut is a cutoff (without skin)
-  VerletList::VerletList(shared_ptr<System> system, shared_ptr<Vectorization> vec,
+  VerletList::VerletList(std::shared_ptr<System> system, std::shared_ptr<Vectorization> vec,
     real _cut, bool rebuildVL)
     : SystemAccess(system), vec(vec)
   {
@@ -585,8 +585,8 @@ namespace espressopp { namespace vectorization {
           = &VerletList::exclude;
 
 
-    class_<VerletList, shared_ptr<VerletList> >
-      ("vectorization_VerletList", init< shared_ptr<System>, shared_ptr<Vectorization>, real, bool >())
+    class_<VerletList, std::shared_ptr<VerletList> >
+      ("vectorization_VerletList", init< std::shared_ptr<System>, std::shared_ptr<Vectorization>, real, bool >())
       .add_property("system", &SystemAccess::getSystem)
       .add_property("builds", &VerletList::getBuilds, &VerletList::setBuilds)
       .def("totalSize", &VerletList::totalSize)

--- a/src/vectorization/VerletList.hpp
+++ b/src/vectorization/VerletList.hpp
@@ -81,7 +81,7 @@ namespace espressopp { namespace vectorization {
 
     */
 
-    VerletList(shared_ptr<System>, shared_ptr<Vectorization>, real cut, bool rebuildVL);
+    VerletList(std::shared_ptr<System>, std::shared_ptr<Vectorization>, real cut, bool rebuildVL);
 
     ~VerletList();
 
@@ -129,7 +129,7 @@ namespace espressopp { namespace vectorization {
     static void registerPython();
 
   protected:
-    shared_ptr<Vectorization> vec;
+    std::shared_ptr<Vectorization> vec;
 
     int num_pairs = 0;
     void checkPair(Particle &pt1, Particle &pt2);

--- a/src/vectorization/interaction/LennardJones.cpp
+++ b/src/vectorization/interaction/LennardJones.cpp
@@ -48,7 +48,7 @@ namespace espressopp { namespace vectorization {
       ;
 
       class_< VerletListLennardJones, bases< Interaction > >
-        ("vectorization_interaction_VerletListLennardJones", init< shared_ptr<VerletList> >())
+        ("vectorization_interaction_VerletListLennardJones", init< std::shared_ptr<VerletList> >())
         .def("getVerletList", &VerletListLennardJones::getVerletList)
         .def("setPotential", &VerletListLennardJones::setPotential)
         .def("getPotential", &VerletListLennardJones::getPotentialPtr)

--- a/src/vectorization/interaction/VerletListLennardJones.hpp
+++ b/src/vectorization/interaction/VerletListLennardJones.hpp
@@ -63,7 +63,7 @@ namespace espressopp { namespace vectorization {
       };
 
     public:
-      VerletListLennardJones(shared_ptr<VerletList> _verletList)
+      VerletListLennardJones(std::shared_ptr<VerletList> _verletList)
         : verletList(_verletList)
       {
         potentialArray    = esutil::Array2D<Potential, esutil::enlarge>(0, 0, Potential());
@@ -75,11 +75,11 @@ namespace espressopp { namespace vectorization {
       virtual ~VerletListLennardJones() {};
 
       void
-      setVerletList(shared_ptr < VerletList > _verletList) {
+      setVerletList(std::shared_ptr < VerletList > _verletList) {
         verletList = _verletList;
       }
 
-      shared_ptr<VerletList> getVerletList() {
+      std::shared_ptr<VerletList> getVerletList() {
         return verletList;
       }
 
@@ -103,8 +103,8 @@ namespace espressopp { namespace vectorization {
       }
 
       // this is mainly used to access the potential from Python (e.g. to change parameters of the potential)
-      shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
-        return  make_shared<Potential>(potentialArray.at(type1, type2));
+      std::shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
+        return  std::make_shared<Potential>(potentialArray.at(type1, type2));
       }
 
       void rebuildPotential()
@@ -139,9 +139,9 @@ namespace espressopp { namespace vectorization {
 
     protected:
       int ntypes;
-      shared_ptr<VerletList> verletList;
+      std::shared_ptr<VerletList> verletList;
       esutil::Array2D<Potential, esutil::enlarge> potentialArray;
-      // not needed esutil::Array2D<shared_ptr<Potential>, esutil::enlarge> potentialArrayPtr;
+      // not needed esutil::Array2D<std::shared_ptr<Potential>, esutil::enlarge> potentialArrayPtr;
 
       size_t np_types, p_types;
       AlignedVector<LJCoefficients> ffs;
@@ -344,7 +344,7 @@ namespace espressopp { namespace vectorization {
         int type1 = p1.type();
         int type2 = p2.type();
         const Potential &potential = getPotential(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
         e   = potential._computeEnergy(p1, p2);
         // e   = potential->_computeEnergy(p1, p2);
         es += e;
@@ -411,7 +411,7 @@ namespace espressopp { namespace vectorization {
         int type1 = p1.type();
         int type2 = p2.type();
         const Potential &potential = getPotential(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
 
         Real3D force(0.0, 0.0, 0.0);
         if(potential._computeForce(force, p1, p2)) {
@@ -440,7 +440,7 @@ namespace espressopp { namespace vectorization {
         int type1 = p1.type();
         int type2 = p2.type();
         const Potential &potential = getPotential(type1, type2);
-        // shared_ptr<Potential> potential = getPotential(type1, type2);
+        // std::shared_ptr<Potential> potential = getPotential(type1, type2);
 
         Real3D force(0.0, 0.0, 0.0);
         if(potential._computeForce(force, p1, p2)) {

--- a/testsuite/analysis/PTestTemperature.cpp
+++ b/testsuite/analysis/PTestTemperature.cpp
@@ -62,8 +62,8 @@ static int halfCellInt = 1;
 BOOST_GLOBAL_FIXTURE(LoggingFixture);
 
 struct Fixture {
-  shared_ptr<DomainDecomposition> domdec;
-  shared_ptr<System> system;
+  std::shared_ptr<DomainDecomposition> domdec;
+  std::shared_ptr<System> system;
 
   Fixture() {
 
@@ -96,11 +96,11 @@ struct Fixture {
     BOOST_TEST_MESSAGE("ncells in each dim / proc: " << cellGrid[0] << " x " <<
                                  cellGrid[1] << " x " << cellGrid[2]);
 
-    system = make_shared< System >();
-    system->rng = make_shared< RNG >();
-    system->bc = make_shared< OrthorhombicBC >(system->rng, boxLRef);
+    system = std::make_shared< System >();
+    system->rng = std::make_shared< RNG >();
+    system->bc = std::make_shared< OrthorhombicBC >(system->rng, boxLRef);
     system->setSkin(skin);
-    domdec = make_shared< DomainDecomposition >(system,
+    domdec = std::make_shared< DomainDecomposition >(system,
                                                 nodeGrid,
                                                 cellGrid,
                                                 halfCellInt);
@@ -141,8 +141,8 @@ struct Fixture {
 
 struct DomainFixture {
 
-  shared_ptr<DomainDecomposition> domdec;
-  shared_ptr<System> system;
+  std::shared_ptr<DomainDecomposition> domdec;
+  std::shared_ptr<System> system;
 
   real SIZE;
 
@@ -179,11 +179,11 @@ struct DomainFixture {
     BOOST_TEST_MESSAGE("ncells in each dim / proc: " << cellGrid[0] << " x " <<
                                  cellGrid[1] << " x " << cellGrid[2]);
 
-    system = make_shared< System >();
-    system->rng = make_shared< RNG >();
-    system->bc = make_shared< OrthorhombicBC >(system->rng, boxL);
+    system = std::make_shared< System >();
+    system->rng = std::make_shared< RNG >();
+    system->bc = std::make_shared< OrthorhombicBC >(system->rng, boxL);
     system->setSkin(skin);
-    domdec = make_shared< DomainDecomposition >(system,
+    domdec = std::make_shared< DomainDecomposition >(system,
                                                 nodeGrid,
                                                 cellGrid,
                                                 halfCellInt);

--- a/testsuite/bc/TestOrthorhombicBC.cpp
+++ b/testsuite/bc/TestOrthorhombicBC.cpp
@@ -44,13 +44,13 @@ struct LoggingFixture {
 BOOST_GLOBAL_FIXTURE(LoggingFixture);
 
 struct Fixture {
-  shared_ptr< bc::BC > bc;
+  std::shared_ptr< bc::BC > bc;
 
   Fixture() {
     Real3D L(10.0, 10.0, 10.0);
-    shared_ptr< esutil::RNG > rng 
-      = make_shared< esutil::RNG >();
-    bc = make_shared< bc::OrthorhombicBC >(rng, L);
+    std::shared_ptr< esutil::RNG > rng
+      = std::make_shared< esutil::RNG >();
+    bc = std::make_shared< bc::OrthorhombicBC >(rng, L);
   }
 };
 

--- a/testsuite/integrator/PTestVelocityVerlet.cpp
+++ b/testsuite/integrator/PTestVelocityVerlet.cpp
@@ -52,8 +52,8 @@ static int N = 3;
 static real nSize = N;
 static int halfCellInt = 1;
 
-shared_ptr<DomainDecomposition> domdec;
-shared_ptr<System> esppSystem;
+std::shared_ptr<DomainDecomposition> domdec;
+std::shared_ptr<System> esppSystem;
 
 
 struct Fixture {
@@ -86,11 +86,11 @@ struct Fixture {
 
     BOOST_TEST_MESSAGE("ncells in each dim / proc: " << cellGrid);
 
-    esppSystem = make_shared< System >();
-    esppSystem->rng = make_shared< RNG >();
-    esppSystem->bc = make_shared< OrthorhombicBC >(esppSystem->rng, boxL);
+    esppSystem = std::make_shared< System >();
+    esppSystem->rng = std::make_shared< RNG >();
+    esppSystem->bc = std::make_shared< OrthorhombicBC >(esppSystem->rng, boxL);
     esppSystem->setSkin(skin);
-    domdec = make_shared< DomainDecomposition >(esppSystem,
+    domdec = std::make_shared< DomainDecomposition >(esppSystem,
                                                 nodeGrid,
                                                 cellGrid,
                                                 halfCellInt);
@@ -165,11 +165,11 @@ struct DomainFixture {
 
     BOOST_TEST_MESSAGE("ncells in each dim / proc: " << cellGrid);
 
-    esppSystem = make_shared< System >();
-    esppSystem->rng = make_shared< RNG >();
-    esppSystem->bc = make_shared< OrthorhombicBC >(esppSystem->rng, boxL);
+    esppSystem = std::make_shared< System >();
+    esppSystem->rng = std::make_shared< RNG >();
+    esppSystem->bc = std::make_shared< OrthorhombicBC >(esppSystem->rng, boxL);
     esppSystem->setSkin(skin);
-    domdec = make_shared< DomainDecomposition >(esppSystem,
+    domdec = std::make_shared< DomainDecomposition >(esppSystem,
                                                 nodeGrid,
                                                 cellGrid,
                                                 halfCellInt);
@@ -227,8 +227,8 @@ BOOST_FIXTURE_TEST_CASE(moveParticles, LatticeFixture)
 
   BOOST_TEST_MESSAGE("starting to build verlet lists");
 
-  shared_ptr<MDIntegrator> integrator = 
-     make_shared<VelocityVerlet>(esppSystem);
+  std::shared_ptr<MDIntegrator> integrator =
+     std::make_shared<VelocityVerlet>(esppSystem);
 
   integrator->setTimeStep(0.01);
 

--- a/testsuite/storage/PTestDomainDecomposition.cpp
+++ b/testsuite/storage/PTestDomainDecomposition.cpp
@@ -53,8 +53,8 @@ struct LoggingFixture {
 BOOST_GLOBAL_FIXTURE(LoggingFixture);
 
 struct Fixture {
-  shared_ptr< DomainDecomposition > domdec;
-  shared_ptr< System > system;
+  std::shared_ptr< DomainDecomposition > domdec;
+  std::shared_ptr< System > system;
 
   Fixture() {
     Real3D boxL(1.0, 2.0, 3.0);
@@ -72,10 +72,10 @@ struct Fixture {
       }
     }
     Int3D cellGrid(1, 2, 3);
-    system = make_shared< System >();
-    system->rng = make_shared< esutil::RNG >();
-    system->bc = make_shared< bc::OrthorhombicBC >(system->rng, boxL);
-    domdec = make_shared< DomainDecomposition >(system,
+    system = std::make_shared< System >();
+    system->rng = std::make_shared< esutil::RNG >();
+    system->bc = std::make_shared< bc::OrthorhombicBC >(system->rng, boxL);
+    domdec = std::make_shared< DomainDecomposition >(system,
     						nodeGrid,
     						cellGrid,
                             halfCellInt);
@@ -83,17 +83,17 @@ struct Fixture {
 };
 
 BOOST_AUTO_TEST_CASE(addAndLookup) {
-  shared_ptr< DomainDecomposition > domdec;
-  shared_ptr< System > system;
+  std::shared_ptr< DomainDecomposition > domdec;
+  std::shared_ptr< System > system;
 
   Real3D boxL(1.0);
   Int3D nodeGrid(mpiWorld->size(), 1, 1);
   Int3D cellGrid(1);
 
-  system = make_shared< System >();
-  system->rng = make_shared< esutil::RNG >();
-  system->bc = make_shared< bc::OrthorhombicBC >(system->rng, boxL);
-  domdec = make_shared< DomainDecomposition >(system,
+  system = std::make_shared< System >();
+  system->rng = std::make_shared< esutil::RNG >();
+  system->bc = std::make_shared< bc::OrthorhombicBC >(system->rng, boxL);
+  domdec = std::make_shared< DomainDecomposition >(system,
 					      nodeGrid,
 					      cellGrid,
                           halfCellInt);
@@ -110,10 +110,10 @@ BOOST_AUTO_TEST_CASE(addAndLookup) {
 BOOST_AUTO_TEST_CASE(constructDomainDecomposition) 
 {
   Real3D boxL(1.0, 2.0, 3.0);
-  shared_ptr< System > system;
-  system = make_shared< System >();
-  system->rng = make_shared< esutil::RNG >();
-  system->bc = make_shared< bc::OrthorhombicBC >(system->rng, boxL);
+  std::shared_ptr< System > system;
+  system = std::make_shared< System >();
+  system->rng = std::make_shared< esutil::RNG >();
+  system->bc = std::make_shared< bc::OrthorhombicBC >(system->rng, boxL);
 
  for(int i = 0; i < 3; ++i) {
     Int3D nodeGrid(1);
@@ -448,8 +448,8 @@ BOOST_AUTO_TEST_CASE(migrateParticle)
 {
   // check whether a particle is migrated from one node to the other
   // and whether it takes all data with it
-  shared_ptr< DomainDecomposition > domdec;
-  shared_ptr< System > system;
+  std::shared_ptr< DomainDecomposition > domdec;
+  std::shared_ptr< System > system;
 
   int nodes = mpiWorld->size();
   int lastnode = nodes-1;
@@ -457,11 +457,11 @@ BOOST_AUTO_TEST_CASE(migrateParticle)
   Int3D nodeGrid(nodes, 1, 1);
   Int3D cellGrid(1);
 
-  system = make_shared< System >();
+  system = std::make_shared< System >();
   system->setSkin(0.0);
-  system->rng = make_shared< esutil::RNG >();
-  system->bc = make_shared< bc::OrthorhombicBC >(system->rng, boxL);
-  domdec = make_shared< DomainDecomposition >(system,
+  system->rng = std::make_shared< esutil::RNG >();
+  system->bc = std::make_shared< bc::OrthorhombicBC >(system->rng, boxL);
+  domdec = std::make_shared< DomainDecomposition >(system,
 					      nodeGrid,
 					      cellGrid,
                           halfCellInt);

--- a/testsuite/unittest/PTestVerletList.cpp
+++ b/testsuite/unittest/PTestVerletList.cpp
@@ -59,8 +59,8 @@ static int halfCellInt = 1;
 
 struct DomainFixture {
 
-  shared_ptr<DomainDecomposition> domdec;
-  shared_ptr<System> system;
+  std::shared_ptr<DomainDecomposition> domdec;
+  std::shared_ptr<System> system;
 
   real SIZE;
 
@@ -97,13 +97,13 @@ struct DomainFixture {
     BOOST_TEST_MESSAGE("ncells in each dim / proc: " << cellGrid[0] << " x " <<
                                  cellGrid[1] << " x " << cellGrid[2]);
 
-    system = make_shared< System >();
-    system->rng = make_shared< esutil::RNG >();
-    system->bc = make_shared< OrthorhombicBC >(system->rng, boxL);
+    system = std::make_shared< System >();
+    system->rng = std::make_shared< esutil::RNG >();
+    system->bc = std::make_shared< OrthorhombicBC >(system->rng, boxL);
     system->setSkin(skin);
-    domdec = make_shared< DomainDecomposition >(system, nodeGrid, cellGrid, halfCellInt);
+    domdec = std::make_shared< DomainDecomposition >(system, nodeGrid, cellGrid, halfCellInt);
     system->storage = domdec;
-    system->rng = make_shared< esutil::RNG >();
+    system->rng = std::make_shared< esutil::RNG >();
   }
 };
 
@@ -153,7 +153,7 @@ BOOST_FIXTURE_TEST_CASE(RandomTest, RandomFixture)
 
   BOOST_TEST_MESSAGE("RandomTest: build verlet lists, cutoff = " << cutoff);
 
-  shared_ptr< VerletList > vl = make_shared< VerletList >(system, cutoff, true);
+  std::shared_ptr< VerletList > vl = std::make_shared< VerletList >(system, cutoff, true);
 
   PairList pairs = vl->getPairs();
 


### PR DESCRIPTION
Getting rid of a lot of deprecated warnings coming from boost.