### PR TITLE
replace boost:bind with std::bind

### DIFF
--- a/src/FixedListComm.cpp
+++ b/src/FixedListComm.cpp
@@ -21,7 +21,7 @@
 */
 
 #include "storage/Storage.hpp"
-#include <boost/bind.hpp>
+#include <functional>
 #include "Buffer.hpp"
 #include "FixedListComm.hpp"
 
@@ -38,11 +38,11 @@ namespace espressopp {
 
         LOG4ESPP_INFO(theLogger, "construct FixedPairList");
         con1 = storage->beforeSendParticles.connect
-          (boost::bind(&FixedListComm::beforeSendParticles, this, _1, _2));
+          (std::bind(&FixedListComm::beforeSendParticles, this, std::placeholders::_1, std::placeholders::_2));
         con2 = storage->afterRecvParticles.connect
-          (boost::bind(&FixedListComm::afterRecvParticles, this, _1, _2));
+          (std::bind(&FixedListComm::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
         con3 = storage->onParticlesChanged.connect
-          (boost::bind(&FixedListComm::onParticlesChanged, this));
+          (std::bind(&FixedListComm::onParticlesChanged, this));
     }
 
     FixedListComm::~FixedListComm() {

--- a/src/FixedLocalTupleList.cpp
+++ b/src/FixedLocalTupleList.cpp
@@ -22,7 +22,7 @@
 #include <sstream>
 #include "FixedLocalTupleList.hpp"
 
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "Buffer.hpp"
 
@@ -39,11 +39,11 @@ namespace espressopp {
 	LOG4ESPP_INFO(theLogger, "construct FixedLocalTupleList");
 	
 	con1 = storage->beforeSendParticles.connect
-	    (boost::bind(&FixedLocalTupleList::beforeSendParticles, this, _1, _2));
+	    (std::bind(&FixedLocalTupleList::beforeSendParticles, this, std::placeholders::_1, std::placeholders::_2));
 	con2 = storage->afterRecvParticles.connect
-	    (boost::bind(&FixedLocalTupleList::afterRecvParticles, this, _1, _2));
+	    (std::bind(&FixedLocalTupleList::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
 	con3 = storage->onParticlesChanged.connect
-	    (boost::bind(&FixedLocalTupleList::onParticlesChanged, this));
+	    (std::bind(&FixedLocalTupleList::onParticlesChanged, this));
     }
 
     FixedLocalTupleList::~FixedLocalTupleList() {

--- a/src/FixedPairDistList.cpp
+++ b/src/FixedPairDistList.cpp
@@ -22,7 +22,7 @@
 
 #include "python.hpp"
 #include "FixedPairDistList.hpp"
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "Buffer.hpp"
 #include "bc/BC.hpp"
@@ -39,11 +39,11 @@ namespace espressopp {
     LOG4ESPP_INFO(theLogger, "construct FixedPairDistList");
 
     con1 = storage->beforeSendParticles.connect
-      (boost::bind(&FixedPairDistList::beforeSendParticles, this, _1, _2));
+      (std::bind(&FixedPairDistList::beforeSendParticles, this, std::placeholders::_1, std::placeholders::_2));
     con2 = storage->afterRecvParticles.connect
-      (boost::bind(&FixedPairDistList::afterRecvParticles, this, _1, _2));
+      (std::bind(&FixedPairDistList::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
     con3 = storage->onParticlesChanged.connect
-      (boost::bind(&FixedPairDistList::onParticlesChanged, this));
+      (std::bind(&FixedPairDistList::onParticlesChanged, this));
   }
 
   FixedPairDistList::~FixedPairDistList() {

--- a/src/FixedPairList.cpp
+++ b/src/FixedPairList.cpp
@@ -27,7 +27,7 @@
 #include "FixedPairList.hpp"
 //#include <utility>
 //#include <algorithm>
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "boost/serialization/vector.hpp"
 #include "Buffer.hpp"
@@ -57,11 +57,11 @@ namespace espressopp {
     LOG4ESPP_INFO(theLogger, "construct FixedPairList");
 
     sigBeforeSend = storage->beforeSendParticles.connect
-      (boost::bind(&FixedPairList::beforeSendParticles, this, _1, _2));
+      (std::bind(&FixedPairList::beforeSendParticles, this, std::placeholders::_1, std::placeholders::_2));
     sigAfterRecv = storage->afterRecvParticles.connect
-      (boost::bind(&FixedPairList::afterRecvParticles, this, _1, _2));
+      (std::bind(&FixedPairList::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
     sigOnParticlesChanged = storage->onParticlesChanged.connect
-      (boost::bind(&FixedPairList::onParticlesChanged, this));
+      (std::bind(&FixedPairList::onParticlesChanged, this));
   }
 
   FixedPairList::~FixedPairList() {

--- a/src/FixedPairListAdress.cpp
+++ b/src/FixedPairListAdress.cpp
@@ -21,7 +21,7 @@
 */
 
 #include "storage/Storage.hpp"
-#include <boost/bind.hpp>
+#include <functional>
 #include "FixedPairListAdress.hpp"
 #include "Buffer.hpp"
 #include "esutil/Error.hpp"
@@ -40,10 +40,10 @@ namespace espressopp {
     LOG4ESPP_INFO(theLogger, "construct FixedPairListAdress");
     
     sigBeforeSendAT = fixedtupleList->beforeSendATParticles.connect
-          (boost::bind(&FixedPairListAdress::beforeSendATParticles, this, _1, _2));
+          (std::bind(&FixedPairListAdress::beforeSendATParticles, this, std::placeholders::_1, std::placeholders::_2));
 
     sigAfterRecvAT = fixedtupleList->afterRecvATParticles.connect
-      (boost::bind(&FixedPairListAdress::afterRecvParticles, this, _1, _2));
+      (std::bind(&FixedPairListAdress::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
 
     // We do not need those signals here.
     sigBeforeSend.disconnect();

--- a/src/FixedQuadrupleAngleList.cpp
+++ b/src/FixedQuadrupleAngleList.cpp
@@ -23,7 +23,7 @@
 #include "python.hpp"
 #include <sstream>
 #include "FixedQuadrupleAngleList.hpp"
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "bc/BC.hpp"
 #include "Buffer.hpp"
@@ -50,11 +50,11 @@ namespace espressopp {
     LOG4ESPP_INFO(theLogger, "construct FixedQuadrupleAngleList");
 
     con1 = storage->beforeSendParticles.connect
-      (boost::bind(&FixedQuadrupleAngleList::beforeSendParticles, this, _1, _2));
+      (std::bind(&FixedQuadrupleAngleList::beforeSendParticles, this, std::placeholders::_1, std::placeholders::_2));
     con2 = storage->afterRecvParticles.connect
-      (boost::bind(&FixedQuadrupleAngleList::afterRecvParticles, this, _1, _2));
+      (std::bind(&FixedQuadrupleAngleList::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
     con3 = storage->onParticlesChanged.connect
-      (boost::bind(&FixedQuadrupleAngleList::onParticlesChanged, this));
+      (std::bind(&FixedQuadrupleAngleList::onParticlesChanged, this));
   }
 
   FixedQuadrupleAngleList::~FixedQuadrupleAngleList() {

--- a/src/FixedQuadrupleList.cpp
+++ b/src/FixedQuadrupleList.cpp
@@ -26,7 +26,7 @@
 #include <sstream>
 #include "FixedQuadrupleList.hpp"
 
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "Buffer.hpp"
 
@@ -50,11 +50,11 @@ namespace espressopp {
     LOG4ESPP_INFO(theLogger, "construct FixedQuadrupleList");
 
     sigBeforeSend = storage->beforeSendParticles.connect
-      (boost::bind(&FixedQuadrupleList::beforeSendParticles, this, _1, _2));
+      (std::bind(&FixedQuadrupleList::beforeSendParticles, this, std::placeholders::_1, std::placeholders::_2));
     sigAfterRecv = storage->afterRecvParticles.connect
-      (boost::bind(&FixedQuadrupleList::afterRecvParticles, this, _1, _2));
+      (std::bind(&FixedQuadrupleList::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
     sigOnParticlesChanged = storage->onParticlesChanged.connect
-      (boost::bind(&FixedQuadrupleList::onParticlesChanged, this));
+      (std::bind(&FixedQuadrupleList::onParticlesChanged, this));
   }
 
   FixedQuadrupleList::~FixedQuadrupleList() {

--- a/src/FixedQuadrupleListAdress.cpp
+++ b/src/FixedQuadrupleListAdress.cpp
@@ -26,7 +26,7 @@
 #include <sstream>
 #include "FixedQuadrupleListAdress.hpp"
 
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "Buffer.hpp"
 
@@ -42,10 +42,10 @@ FixedQuadrupleListAdress::FixedQuadrupleListAdress(
   LOG4ESPP_INFO(theLogger, "construct FixedQuadrupleListAdress");
 
   sigBeforeSendAT = fixedtupleList->beforeSendATParticles.connect(
-    boost::bind(&FixedQuadrupleListAdress::beforeSendATParticles, this, _1, _2));
+    std::bind(&FixedQuadrupleListAdress::beforeSendATParticles, this, std::placeholders::_1, std::placeholders::_2));
 
   sigAfterRecvAT = fixedtupleList->afterRecvATParticles.connect
-    (boost::bind(&FixedQuadrupleListAdress::afterRecvParticles, this, _1, _2));
+    (std::bind(&FixedQuadrupleListAdress::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
 
   // We do not need those signals.
   sigBeforeSend.disconnect();

--- a/src/FixedSingleList.cpp
+++ b/src/FixedSingleList.cpp
@@ -23,7 +23,7 @@
 #include "python.hpp"
 #include <sstream>
 #include "FixedSingleList.hpp"
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "Buffer.hpp"
 
@@ -42,11 +42,11 @@ namespace espressopp {
     LOG4ESPP_INFO(theLogger, "construct FixedSingleList");
 
     con1 = storage->beforeSendParticles.connect
-      (boost::bind(&FixedSingleList::beforeSendParticles, this, _1, _2));
+      (std::bind(&FixedSingleList::beforeSendParticles, this, std::placeholders::_1, std::placeholders::_2));
     con2 = storage->afterRecvParticles.connect
-      (boost::bind(&FixedSingleList::afterRecvParticles, this, _1, _2));
+      (std::bind(&FixedSingleList::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
     con3 = storage->onParticlesChanged.connect
-      (boost::bind(&FixedSingleList::onParticlesChanged, this));
+      (std::bind(&FixedSingleList::onParticlesChanged, this));
   }
 
   FixedSingleList::~FixedSingleList() {

--- a/src/FixedTripleAngleList.cpp
+++ b/src/FixedTripleAngleList.cpp
@@ -23,7 +23,7 @@
 #include "python.hpp"
 #include <sstream>
 #include "FixedTripleAngleList.hpp"
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "Buffer.hpp"
 #include "bc/BC.hpp"
@@ -41,11 +41,11 @@ namespace espressopp {
     LOG4ESPP_INFO(theLogger, "construct FixedTripleAngleList");
     
     con1 = storage->beforeSendParticles.connect
-      (boost::bind(&FixedTripleAngleList::beforeSendParticles, this, _1, _2));
+      (std::bind(&FixedTripleAngleList::beforeSendParticles, this, std::placeholders::_1, std::placeholders::_2));
     con2 = storage->afterRecvParticles.connect
-      (boost::bind(&FixedTripleAngleList::afterRecvParticles, this, _1, _2));
+      (std::bind(&FixedTripleAngleList::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
     con3 = storage->onParticlesChanged.connect
-      (boost::bind(&FixedTripleAngleList::onParticlesChanged, this));
+      (std::bind(&FixedTripleAngleList::onParticlesChanged, this));
   }
 
   FixedTripleAngleList::~FixedTripleAngleList() {

--- a/src/FixedTripleList.cpp
+++ b/src/FixedTripleList.cpp
@@ -26,7 +26,7 @@
 #include <sstream>
 #include "FixedTripleList.hpp"
 
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "Buffer.hpp"
 
@@ -49,11 +49,11 @@ namespace espressopp {
     LOG4ESPP_INFO(theLogger, "construct FixedTripleList");
 
     sigBeforeSend = storage->beforeSendParticles.connect
-      (boost::bind(&FixedTripleList::beforeSendParticles, this, _1, _2));
+      (std::bind(&FixedTripleList::beforeSendParticles, this, std::placeholders::_1, std::placeholders::_2));
     sigAfterRecv = storage->afterRecvParticles.connect
-      (boost::bind(&FixedTripleList::afterRecvParticles, this, _1, _2));
+      (std::bind(&FixedTripleList::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
     sigOnParticleChanged = storage->onParticlesChanged.connect
-      (boost::bind(&FixedTripleList::onParticlesChanged, this));
+      (std::bind(&FixedTripleList::onParticlesChanged, this));
   }
 
   FixedTripleList::~FixedTripleList() {

--- a/src/FixedTripleListAdress.cpp
+++ b/src/FixedTripleListAdress.cpp
@@ -27,7 +27,7 @@
 //#include <vector>
 //#include <utility>
 //#include <algorithm>
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "Buffer.hpp"
 
@@ -45,10 +45,10 @@ FixedTripleListAdress::FixedTripleListAdress(std::shared_ptr< storage::Storage >
   LOG4ESPP_INFO(theLogger, "construct FixedTripleListAdress");
 
   sigBeforeSendAT = fixedtupleList->beforeSendATParticles.connect
-        (boost::bind(&FixedTripleListAdress::beforeSendATParticles, this, _1, _2));
+        (std::bind(&FixedTripleListAdress::beforeSendATParticles, this, std::placeholders::_1, std::placeholders::_2));
 
   sigAfterRecvAT = fixedtupleList->afterRecvATParticles.connect
-    (boost::bind(&FixedTripleListAdress::afterRecvParticles, this, _1, _2));
+    (std::bind(&FixedTripleListAdress::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
 
   // We do not need those signals.
   sigBeforeSend.disconnect();

--- a/src/FixedTupleList.cpp
+++ b/src/FixedTupleList.cpp
@@ -27,7 +27,7 @@
 //#include <vector>
 //#include <utility>
 //#include <algorithm>
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "Buffer.hpp"
 
@@ -44,11 +44,11 @@ namespace espressopp {
     LOG4ESPP_INFO(theLogger, "construct FixedTupleList");
 
     con1 = storage->beforeSendParticles.connect
-      (boost::bind(&FixedTupleList::beforeSendParticles, this, _1, _2));
+      (std::bind(&FixedTupleList::beforeSendParticles, this, std::placeholders::_1, std::placeholders::_2));
     con2 = storage->afterRecvParticles.connect
-      (boost::bind(&FixedTupleList::afterRecvParticles, this, _1, _2));
+      (std::bind(&FixedTupleList::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
     con3 = storage->onParticlesChanged.connect
-      (boost::bind(&FixedTupleList::onParticlesChanged, this));
+      (std::bind(&FixedTupleList::onParticlesChanged, this));
   }
 
   FixedTupleList::~FixedTupleList() {

--- a/src/FixedTupleListAdress.cpp
+++ b/src/FixedTupleListAdress.cpp
@@ -27,7 +27,7 @@
 //#include <vector>
 //#include <utility>
 //#include <algorithm>
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "Buffer.hpp"
 
@@ -47,11 +47,11 @@ namespace espressopp {
         LOG4ESPP_INFO(theLogger, "construct FixedTupleListAdress");
 
         sigBeforeSend = storage->beforeSendParticles.connect
-           (boost::bind(&FixedTupleListAdress::beforeSendParticles, this, _1, _2));
+           (std::bind(&FixedTupleListAdress::beforeSendParticles, this, std::placeholders::_1, std::placeholders::_2));
         sigAfterRecv = storage->afterRecvParticles.connect
-           (boost::bind(&FixedTupleListAdress::afterRecvParticles, this, _1, _2));
+           (std::bind(&FixedTupleListAdress::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
         sigOnTupleChanged = storage->onTuplesChanged.connect
-           (boost::bind(&FixedTupleListAdress::onParticlesChanged, this));
+           (std::bind(&FixedTupleListAdress::onParticlesChanged, this));
     }
 
     FixedTupleListAdress::~FixedTupleListAdress() {

--- a/src/ParticleGroup.cpp
+++ b/src/ParticleGroup.cpp
@@ -30,11 +30,11 @@ namespace espressopp {
     ParticleGroup::ParticleGroup(std::shared_ptr <storage::Storage> _storage)
     : storage(_storage) {
         con_send = storage->beforeSendParticles.connect
-                (boost::bind(&ParticleGroup::beforeSendParticles, this, _1, _2));
+                (std::bind(&ParticleGroup::beforeSendParticles, this, std::placeholders::_1, std::placeholders::_2));
         con_recv = storage->afterRecvParticles.connect
-                (boost::bind(&ParticleGroup::afterRecvParticles, this, _1, _2));
+                (std::bind(&ParticleGroup::afterRecvParticles, this, std::placeholders::_1, std::placeholders::_2));
         con_changed = storage->onParticlesChanged.connect
-                (boost::bind(&ParticleGroup::onParticlesChanged, this));
+                (std::bind(&ParticleGroup::onParticlesChanged, this));
     }
 
 

--- a/src/VerletList.cpp
+++ b/src/VerletList.cpp
@@ -62,7 +62,7 @@ namespace espressopp {
   
     // make a connection to System to invoke rebuild on resort
     connectionResort = system->storage->onParticlesChanged.connect(
-        boost::bind(&VerletList::rebuild, this));
+        std::bind(&VerletList::rebuild, this));
   }
   
   real VerletList::getVerletCutoff(){
@@ -74,7 +74,7 @@ namespace espressopp {
 
   // make a connection to System to invoke rebuild on resort
   connectionResort = getSystem()->storage->onParticlesChanged.connect(
-      boost::bind(&VerletList::rebuild, this));
+      std::bind(&VerletList::rebuild, this));
   }
 
   void VerletList::disconnect()

--- a/src/VerletListAdress.cpp
+++ b/src/VerletListAdress.cpp
@@ -64,7 +64,7 @@ namespace espressopp {
 
       // make a connection to System to invoke rebuild on resort
       connectionResort = system->storage->onParticlesChanged.connect(
-          boost::bind(&VerletListAdress::rebuild, this));
+          std::bind(&VerletListAdress::rebuild, this));
     }
 
     /*-------------------------------------------------------------*/

--- a/src/VerletListTriple.cpp
+++ b/src/VerletListTriple.cpp
@@ -53,7 +53,7 @@ namespace espressopp {
 
     // make a connection to System to invoke rebuild on resort
     connectionResort = system->storage->onParticlesChanged.connect(
-        boost::bind(&VerletListTriple::rebuild, this));
+        std::bind(&VerletListTriple::rebuild, this));
   }
   
   real VerletListTriple::getVerletCutoff(){
@@ -63,7 +63,7 @@ namespace espressopp {
   void VerletListTriple::connect(){
     // make a connection to System to invoke rebuild on resort
     connectionResort = getSystem()->storage->onParticlesChanged.connect( 
-            boost::bind(&VerletListTriple::rebuild, this));
+            std::bind(&VerletListTriple::rebuild, this));
   }
 
   void VerletListTriple::disconnect(){

--- a/src/analysis/RDFatomistic.cpp
+++ b/src/analysis/RDFatomistic.cpp
@@ -160,7 +160,7 @@ namespace espressopp {
                   num_pairs += 1;
 
                   if( resolutionP2 == 1.0 ) {
-                    Real3D distVector = (0.0, 0.0, 0.0);
+                    Real3D distVector(0.0, 0.0, 0.0);
                     system.bc->getMinimumImageVector(distVector, coordP1, coordP2);
 
                     int bin = (int)( distVector.abs() / dr );

--- a/src/integrator/Adress.cpp
+++ b/src/integrator/Adress.cpp
@@ -81,45 +81,45 @@ namespace espressopp {
 
         // connection to after runInit()
         _SetPosVel = integrator->runInit.connect(
-                boost::bind(&Adress::SetPosVel, this), boost::signals2::at_front);
+                std::bind(&Adress::SetPosVel, this), boost::signals2::at_front);
 
         // connection to after initForces()
         _initForces = integrator->aftInitF.connect(
-                boost::bind(&Adress::initForces, this), boost::signals2::at_front);
+                std::bind(&Adress::initForces, this), boost::signals2::at_front);
 
         // connection to inside of integrate1()
         _integrate1 = integrator->inIntP.connect(
-                boost::bind(&Adress::integrate1, this, _1), boost::signals2::at_front);
+                std::bind(&Adress::integrate1, this, std::placeholders::_1), boost::signals2::at_front);
 
         // // connection to inside of integrate1()
         // _inIntP = integrator->inIntP.connect(
-        //         boost::bind(&Adress::communicateAdrPositions, this), boost::signals2::at_front);
+        //         std::bind(&Adress::communicateAdrPositions, this), boost::signals2::at_front);
 
         // connection to after integrate2()
         _integrate2 = integrator->aftIntV.connect(
-                boost::bind(&Adress::integrate2, this), boost::signals2::at_front);
+                std::bind(&Adress::integrate2, this), boost::signals2::at_front);
 
         // connection to after integrate2()
         _integrateSlow = integrator->aftIntSlow.connect(
-                boost::bind(&Adress::integrateSlow, this), boost::signals2::at_front);
+                std::bind(&Adress::integrateSlow, this), boost::signals2::at_front);
 
         // Note: Both this extension as well as Langevin Thermostat access singal aftCalcF. This might lead to undefined behavior.
         // Therefore, we use other signals here, to make sure the Thermostat would be always called first, before force distributions take place.
         // connection to after _aftCalcF()
         //_aftCalcF = integrator->aftCalcF.connect(
-        //        boost::bind(&Adress::aftCalcF, this));
+        //        std::bind(&Adress::aftCalcF, this));
 
         // connection to after aftCalcSlow
         _aftCalcSlow = integrator->aftCalcSlow.connect(
-                boost::bind(&Adress::aftCalcF, this), boost::signals2::at_back);
+                std::bind(&Adress::aftCalcF, this), boost::signals2::at_back);
 
         // connection to after _recalc2()
         _recalc2 = integrator->recalc2.connect(
-                boost::bind(&Adress::aftCalcF, this), boost::signals2::at_front);
+                std::bind(&Adress::aftCalcF, this), boost::signals2::at_front);
 
         // connection to after _befIntV()
         _befIntV = integrator->befIntV.connect(
-                boost::bind(&Adress::aftCalcF, this), boost::signals2::at_front);
+                std::bind(&Adress::aftCalcF, this), boost::signals2::at_front);
     }
 
 

--- a/src/integrator/AssociationReaction.cpp
+++ b/src/integrator/AssociationReaction.cpp
@@ -167,10 +167,10 @@ namespace espressopp {
 
       // connect to initialization inside run()
       _initialize = integrator->runInit.connect(
-						boost::bind(&AssociationReaction::initialize, this));
+						std::bind(&AssociationReaction::initialize, this));
 
       _react = integrator->aftIntV.connect(
-					   boost::bind(&AssociationReaction::react, this));
+					   std::bind(&AssociationReaction::react, this));
     }
 
     /** Performs all steps of the reactive scheme.

--- a/src/integrator/BerendsenBarostat.cpp
+++ b/src/integrator/BerendsenBarostat.cpp
@@ -60,10 +60,10 @@ namespace espressopp {
 
     void BerendsenBarostat::connect(){
       // connection to initialisation
-      _runInit = integrator->runInit.connect( boost::bind(&BerendsenBarostat::initialize, this));
+      _runInit = integrator->runInit.connect( std::bind(&BerendsenBarostat::initialize, this));
 
       // connection to the signal at the end of the run
-      _aftIntV = integrator->aftIntV.connect( boost::bind(&BerendsenBarostat::barostat, this));
+      _aftIntV = integrator->aftIntV.connect( std::bind(&BerendsenBarostat::barostat, this));
     }
 
     // set and get time constant for Berendsen barostat

--- a/src/integrator/BerendsenBarostatAnisotropic.cpp
+++ b/src/integrator/BerendsenBarostatAnisotropic.cpp
@@ -59,10 +59,10 @@ namespace espressopp {
 
     void BerendsenBarostatAnisotropic::connect(){
       // connection to initialisation
-      _runInit = integrator->runInit.connect( boost::bind(&BerendsenBarostatAnisotropic::initialize, this));
+      _runInit = integrator->runInit.connect( std::bind(&BerendsenBarostatAnisotropic::initialize, this));
 
       // connection to the signal at the end of the run
-      _aftIntV = integrator->aftIntV.connect( boost::bind(&BerendsenBarostatAnisotropic::barostat, this));
+      _aftIntV = integrator->aftIntV.connect( std::bind(&BerendsenBarostatAnisotropic::barostat, this));
     }
 
     // set and get time constant for Berendsen barostat

--- a/src/integrator/BerendsenThermostat.cpp
+++ b/src/integrator/BerendsenThermostat.cpp
@@ -58,10 +58,10 @@ namespace espressopp {
 
     void BerendsenThermostat::connect(){
       // connection to initialisation
-      _runInit = integrator->runInit.connect( boost::bind(&BerendsenThermostat::initialize, this));
+      _runInit = integrator->runInit.connect( std::bind(&BerendsenThermostat::initialize, this));
 
       // connection to the signal at the end of the run
-      _aftIntV = integrator->aftIntV.connect( boost::bind(&BerendsenThermostat::thermostat, this));
+      _aftIntV = integrator->aftIntV.connect( std::bind(&BerendsenThermostat::thermostat, this));
     }
     
 

--- a/src/integrator/CapForce.cpp
+++ b/src/integrator/CapForce.cpp
@@ -79,9 +79,9 @@ namespace espressopp {
     void CapForce::connect(){
       // connection to initialisation
       if (!allParticles) {
-        _aftCalcF  = integrator->aftCalcF.connect( boost::bind(&CapForce::applyForceCappingToGroup, this), boost::signals2::at_back);
+        _aftCalcF  = integrator->aftCalcF.connect( std::bind(&CapForce::applyForceCappingToGroup, this), boost::signals2::at_back);
       } else {
-    	_aftCalcF  = integrator->aftCalcF.connect( boost::bind(&CapForce::applyForceCappingToAll, this), boost::signals2::at_back);
+    	_aftCalcF  = integrator->aftCalcF.connect( std::bind(&CapForce::applyForceCappingToAll, this), boost::signals2::at_back);
       }
     }
 

--- a/src/integrator/DPDThermostat.cpp
+++ b/src/integrator/DPDThermostat.cpp
@@ -105,16 +105,16 @@ namespace espressopp {
 
         // connect to initialization inside run()
         _initialize = integrator->runInit.connect(
-                boost::bind(&DPDThermostat::initialize, this));
+                std::bind(&DPDThermostat::initialize, this));
 
         _heatUp = integrator->recalc1.connect(
-                boost::bind(&DPDThermostat::heatUp, this));
+                std::bind(&DPDThermostat::heatUp, this));
 
         _coolDown = integrator->recalc2.connect(
-                boost::bind(&DPDThermostat::coolDown, this));
+                std::bind(&DPDThermostat::coolDown, this));
 
         _thermalize = integrator->aftInitF.connect(
-                boost::bind(&DPDThermostat::thermalize, this));
+                std::bind(&DPDThermostat::thermalize, this));
     }
 
 

--- a/src/integrator/EmptyExtension.cpp
+++ b/src/integrator/EmptyExtension.cpp
@@ -47,7 +47,7 @@ namespace espressopp {
 
     void EmptyExtension::connect(){
       // connection to initialisation
-  	  //_aftInitF  = integrator->aftInitF.connect( boost::bind(&EmptyExtension::applyForceToAll, this));
+  	  //_aftInitF  = integrator->aftInitF.connect( std::bind(&EmptyExtension::applyForceToAll, this));
     }
 
     void EmptyExtension::emptyFunction() {

--- a/src/integrator/ExtAnalyze.cpp
+++ b/src/integrator/ExtAnalyze.cpp
@@ -47,7 +47,7 @@ namespace espressopp {
 
     void ExtAnalyze::connect(){
       // connection to end of integrator
-      _aftIntV  = integrator->aftIntV.connect( boost::bind(&ExtAnalyze::perform_action, this));
+      _aftIntV  = integrator->aftIntV.connect( std::bind(&ExtAnalyze::perform_action, this));
       counter = 0;
     }
 

--- a/src/integrator/ExtForce.cpp
+++ b/src/integrator/ExtForce.cpp
@@ -57,9 +57,9 @@ namespace espressopp {
     void ExtForce::connect(){
       // connection to initialisation
       if (!allParticles) {
-        _aftInitF  = integrator->aftInitF.connect( boost::bind(&ExtForce::applyForceToGroup, this));
+        _aftInitF  = integrator->aftInitF.connect( std::bind(&ExtForce::applyForceToGroup, this));
       } else {
-    	_aftInitF  = integrator->aftInitF.connect( boost::bind(&ExtForce::applyForceToAll, this));
+    	_aftInitF  = integrator->aftInitF.connect( std::bind(&ExtForce::applyForceToAll, this));
       }
     }
 

--- a/src/integrator/FixPositions.cpp
+++ b/src/integrator/FixPositions.cpp
@@ -49,8 +49,8 @@ namespace espressopp {
 
     void FixPositions::connect(){
       // connection to initialisation
-      _befIntP  = integrator->befIntP.connect( boost::bind(&FixPositions::savePositions, this));
-      _aftIntP  = integrator->aftIntP.connect( boost::bind(&FixPositions::restorePositions, this));
+      _befIntP  = integrator->befIntP.connect( std::bind(&FixPositions::savePositions, this));
+      _aftIntP  = integrator->aftIntP.connect( std::bind(&FixPositions::restorePositions, this));
     }
 
     void FixPositions::setParticleGroup(std::shared_ptr< ParticleGroup > _particleGroup) {

--- a/src/integrator/FreeEnergyCompensation.cpp
+++ b/src/integrator/FreeEnergyCompensation.cpp
@@ -53,11 +53,11 @@ namespace espressopp {
     void FreeEnergyCompensation::connect(){
       if(slow){
         _applyForce = integrator->aftCalcSlow.connect(
-            boost::bind(&FreeEnergyCompensation::applyForce, this));
+            std::bind(&FreeEnergyCompensation::applyForce, this));
       }
       else{
         _applyForce = integrator->aftCalcF.connect(
-            boost::bind(&FreeEnergyCompensation::applyForce, this));
+            std::bind(&FreeEnergyCompensation::applyForce, this));
       }
     }
 

--- a/src/integrator/GeneralizedLangevinThermostat.cpp
+++ b/src/integrator/GeneralizedLangevinThermostat.cpp
@@ -62,10 +62,10 @@ namespace espressopp {
     void GeneralizedLangevinThermostat::connect() {
 
         _integrate = integrator->aftIntP.connect(
-                boost::bind(&GeneralizedLangevinThermostat::integrate, this));
+                std::bind(&GeneralizedLangevinThermostat::integrate, this));
 
         _friction = integrator->aftCalcF.connect(
-                boost::bind(&GeneralizedLangevinThermostat::friction, this));
+                std::bind(&GeneralizedLangevinThermostat::friction, this));
     }
 
     void GeneralizedLangevinThermostat::addCoeffs(int itype, const char* _filename, int type) {

--- a/src/integrator/Isokinetic.cpp
+++ b/src/integrator/Isokinetic.cpp
@@ -63,7 +63,7 @@ namespace espressopp {
 
     void Isokinetic::connect(){
       // connection to the signal at the end of the run
-      _aftIntV = integrator->aftIntV.connect( boost::bind(&Isokinetic::rescaleVelocities, this));
+      _aftIntV = integrator->aftIntV.connect( std::bind(&Isokinetic::rescaleVelocities, this));
     }
     
     void Isokinetic::setTemperature(real _temperature)

--- a/src/integrator/LangevinBarostat.cpp
+++ b/src/integrator/LangevinBarostat.cpp
@@ -83,15 +83,15 @@ namespace espressopp {
 
     void LangevinBarostat::connect(){
       // connection to initialisation
-      _runInit = integrator->runInit.connect( boost::bind(&LangevinBarostat::initialize, this));
+      _runInit = integrator->runInit.connect( std::bind(&LangevinBarostat::initialize, this));
       
-      _befIntP = integrator->befIntP.connect( boost::bind(&LangevinBarostat::upd_Vp, this));
+      _befIntP = integrator->befIntP.connect( std::bind(&LangevinBarostat::upd_Vp, this));
               
-      _inIntP = integrator->inIntP.connect( boost::bind(&LangevinBarostat::updDisplacement, this, _1));
+      _inIntP = integrator->inIntP.connect( std::bind(&LangevinBarostat::updDisplacement, this, std::placeholders::_1));
               
-      _aftIntV = integrator->aftIntV.connect( boost::bind(&LangevinBarostat::upd_pV, this));
+      _aftIntV = integrator->aftIntV.connect( std::bind(&LangevinBarostat::upd_pV, this));
               
-      _aftCalcF = integrator->aftCalcF.connect( boost::bind(&LangevinBarostat::updForces, this));
+      _aftCalcF = integrator->aftCalcF.connect( std::bind(&LangevinBarostat::updForces, this));
     }
     
     void LangevinBarostat::setGammaP(real _gammaP){

--- a/src/integrator/LangevinThermostat.cpp
+++ b/src/integrator/LangevinThermostat.cpp
@@ -105,21 +105,21 @@ namespace espressopp {
 
         // connect to initialization inside run()
         _initialize = integrator->runInit.connect(
-                boost::bind(&LangevinThermostat::initialize, this));
+                std::bind(&LangevinThermostat::initialize, this));
 
         _heatUp = integrator->recalc1.connect(
-                boost::bind(&LangevinThermostat::heatUp, this));
+                std::bind(&LangevinThermostat::heatUp, this));
 
         _coolDown = integrator->recalc2.connect(
-                boost::bind(&LangevinThermostat::coolDown, this));
+                std::bind(&LangevinThermostat::coolDown, this));
 
         if (adress) {
             _thermalizeAdr = integrator->aftCalcF.connect(
-                boost::bind(&LangevinThermostat::thermalizeAdr, this));
+                std::bind(&LangevinThermostat::thermalizeAdr, this));
         }
         else {
             _thermalize = integrator->aftCalcF.connect(
-                boost::bind(&LangevinThermostat::thermalize, this));
+                std::bind(&LangevinThermostat::thermalize, this));
         }
     }
 

--- a/src/integrator/LangevinThermostat1D.cpp
+++ b/src/integrator/LangevinThermostat1D.cpp
@@ -113,21 +113,21 @@ namespace espressopp {
 
         // connect to initialization inside run()
         _initialize = integrator->runInit.connect(
-                boost::bind(&LangevinThermostat1D::initialize, this));
+                std::bind(&LangevinThermostat1D::initialize, this));
 
         _heatUp = integrator->recalc1.connect(
-                boost::bind(&LangevinThermostat1D::heatUp, this));
+                std::bind(&LangevinThermostat1D::heatUp, this));
 
         _coolDown = integrator->recalc2.connect(
-                boost::bind(&LangevinThermostat1D::coolDown, this));
+                std::bind(&LangevinThermostat1D::coolDown, this));
 
         if (adress) {
             _thermalizeAdr = integrator->aftCalcF.connect(
-                boost::bind(&LangevinThermostat1D::thermalizeAdr, this));
+                std::bind(&LangevinThermostat1D::thermalizeAdr, this));
         }
         else {
             _thermalize = integrator->aftCalcF.connect(
-                boost::bind(&LangevinThermostat1D::thermalize, this));
+                std::bind(&LangevinThermostat1D::thermalize, this));
         }
     }
 

--- a/src/integrator/LangevinThermostatHybrid.cpp
+++ b/src/integrator/LangevinThermostatHybrid.cpp
@@ -115,16 +115,16 @@ namespace espressopp {
 
         // connect to initialization inside run()
         _initialize = integrator->runInit.connect(
-                boost::bind(&LangevinThermostatHybrid::initialize, this));
+                std::bind(&LangevinThermostatHybrid::initialize, this));
 
         _heatUp = integrator->recalc1.connect(
-                boost::bind(&LangevinThermostatHybrid::heatUp, this));
+                std::bind(&LangevinThermostatHybrid::heatUp, this));
 
         _coolDown = integrator->recalc2.connect(
-                boost::bind(&LangevinThermostatHybrid::coolDown, this));
+                std::bind(&LangevinThermostatHybrid::coolDown, this));
 
         _thermalizeAdr = integrator->aftCalcF.connect(
-                boost::bind(&LangevinThermostatHybrid::thermalizeAdr, this));
+                std::bind(&LangevinThermostatHybrid::thermalizeAdr, this));
     }
 
     void LangevinThermostatHybrid::thermalizeAdr()

--- a/src/integrator/LangevinThermostatOnGroup.cpp
+++ b/src/integrator/LangevinThermostatOnGroup.cpp
@@ -79,16 +79,16 @@ void LangevinThermostatOnGroup::disconnect() {
 void LangevinThermostatOnGroup::connect() {
   // connect to initialization inside run()
   _initialize = integrator->runInit.connect(
-      boost::bind(&LangevinThermostatOnGroup::initialize, this));
+      std::bind(&LangevinThermostatOnGroup::initialize, this));
 
   _heatUp = integrator->recalc1.connect(
-      boost::bind(&LangevinThermostatOnGroup::heatUp, this));
+      std::bind(&LangevinThermostatOnGroup::heatUp, this));
 
   _coolDown = integrator->recalc2.connect(
-      boost::bind(&LangevinThermostatOnGroup::coolDown, this));
+      std::bind(&LangevinThermostatOnGroup::coolDown, this));
 
   _thermalize = integrator->aftCalcF.connect(
-      boost::bind(&LangevinThermostatOnGroup::thermalize, this));
+      std::bind(&LangevinThermostatOnGroup::thermalize, this));
 }
 
 

--- a/src/integrator/LangevinThermostatOnRadius.cpp
+++ b/src/integrator/LangevinThermostatOnRadius.cpp
@@ -92,16 +92,16 @@ namespace espressopp {
 	    
 	    // connect to initialization inside run()
 	    _initialize = integrator->runInit.connect(
-                boost::bind(&LangevinThermostatOnRadius::initialize, this));
+                std::bind(&LangevinThermostatOnRadius::initialize, this));
 	    
 	    _heatUp = integrator->recalc1.connect(
-                boost::bind(&LangevinThermostatOnRadius::heatUp, this));
+                std::bind(&LangevinThermostatOnRadius::heatUp, this));
 	    
 	    _coolDown = integrator->recalc2.connect(
-                boost::bind(&LangevinThermostatOnRadius::coolDown, this));
+                std::bind(&LangevinThermostatOnRadius::coolDown, this));
 	    
 	    _thermalize = integrator->aftCalcF.connect(
-                boost::bind(&LangevinThermostatOnRadius::thermalize, this));
+                std::bind(&LangevinThermostatOnRadius::thermalize, this));
 	}
 	
 	

--- a/src/integrator/LatticeBoltzmann.cpp
+++ b/src/integrator/LatticeBoltzmann.cpp
@@ -135,8 +135,8 @@ namespace espressopp {
       }
 
       void LatticeBoltzmann::connect() {
-         _recalc2 = integrator->recalc2.connect ( boost::bind(&LatticeBoltzmann::zeroMDCMVel, this));
-         _befIntV = integrator->befIntV.connect ( boost::bind(&LatticeBoltzmann::makeLBStep, this));
+         _recalc2 = integrator->recalc2.connect ( std::bind(&LatticeBoltzmann::zeroMDCMVel, this));
+         _befIntV = integrator->befIntV.connect ( std::bind(&LatticeBoltzmann::makeLBStep, this));
       }
 
 /*******************************************************************************************/

--- a/src/integrator/OnTheFlyFEC.cpp
+++ b/src/integrator/OnTheFlyFEC.cpp
@@ -63,7 +63,7 @@ namespace espressopp {
     // Connect & Disconnect
     void OnTheFlyFEC::connect(){
         _gatherStats = integrator->aftIntV.connect(
-            boost::bind(&OnTheFlyFEC::gatherStats, this));
+            std::bind(&OnTheFlyFEC::gatherStats, this));
     }
 
     void OnTheFlyFEC::disconnect(){

--- a/src/integrator/Rattle.cpp
+++ b/src/integrator/Rattle.cpp
@@ -22,7 +22,7 @@
 
 #include "Rattle.hpp"
 
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "iterator/CellListIterator.hpp"
 #include "System.hpp"
@@ -59,9 +59,9 @@ namespace espressopp {
     }
 
     void Rattle::connect(){
-      _befIntP  = integrator->befIntP.connect( boost::bind(&Rattle::saveOldPos, this));
-      _aftIntP  = integrator->aftIntP.connect( boost::bind(&Rattle::applyPositionConstraints, this));
-      _aftIntV  = integrator->aftIntV.connect( boost::bind(&Rattle::applyVelocityConstraints, this));
+      _befIntP  = integrator->befIntP.connect( std::bind(&Rattle::saveOldPos, this));
+      _aftIntP  = integrator->aftIntP.connect( std::bind(&Rattle::applyPositionConstraints, this));
+      _aftIntV  = integrator->aftIntV.connect( std::bind(&Rattle::applyVelocityConstraints, this));
     }
 
     void Rattle::addBond(int pid1, int pid2, real constraintDist, real mass1, real mass2) {

--- a/src/integrator/Settle.cpp
+++ b/src/integrator/Settle.cpp
@@ -24,7 +24,7 @@
 
 #include "Settle.hpp"
 
-#include <boost/bind.hpp>
+#include <functional>
 #include "storage/Storage.hpp"
 #include "iterator/CellListIterator.hpp"
 #include "System.hpp"
@@ -46,9 +46,9 @@ namespace espressopp {
 
         /*
         con1 = integrator->saveOldPos.connect
-          (boost::bind(&Settle::saveOldPos, this));
+          (std::bind(&Settle::saveOldPos, this));
         con2 = integrator->applyConstraints.connect
-          (boost::bind(&Settle::applyConstraints, this));
+          (std::bind(&Settle::applyConstraints, this));
         */
 
         // initialize settlep variables
@@ -89,10 +89,10 @@ namespace espressopp {
 
     void Settle::connect(){
       // connection to initialisation
-      _befIntP  = integrator->befIntP.connect( boost::bind(&Settle::saveOldPos, this));
-      _aftIntP  = integrator->aftIntP.connect( boost::bind(&Settle::applyConstraints, this));
-      _aftIntV  = integrator->aftIntV.connect( boost::bind(&Settle::correctVelocities, this));   // OUT AGAIN?
-      _aftIntSlow  = integrator->aftIntSlow.connect( boost::bind(&Settle::correctVelocities, this));
+      _befIntP  = integrator->befIntP.connect( std::bind(&Settle::saveOldPos, this));
+      _aftIntP  = integrator->aftIntP.connect( std::bind(&Settle::applyConstraints, this));
+      _aftIntV  = integrator->aftIntV.connect( std::bind(&Settle::correctVelocities, this));   // OUT AGAIN?
+      _aftIntSlow  = integrator->aftIntSlow.connect( std::bind(&Settle::correctVelocities, this));
     }
 
     void Settle::saveOldPos() {

--- a/src/integrator/StochasticVelocityRescaling.cpp
+++ b/src/integrator/StochasticVelocityRescaling.cpp
@@ -74,9 +74,9 @@ void StochasticVelocityRescaling::disconnect(){
 
 void StochasticVelocityRescaling::connect(){
   // connection to initialization
-  _runInit = integrator->runInit.connect( boost::bind(&StochasticVelocityRescaling::initialize, this));
+  _runInit = integrator->runInit.connect( std::bind(&StochasticVelocityRescaling::initialize, this));
   // connection to the signal at the end of the run
-  _aftIntV = integrator->aftIntV.connect( boost::bind(&StochasticVelocityRescaling::rescaleVelocities, this));
+  _aftIntV = integrator->aftIntV.connect( std::bind(&StochasticVelocityRescaling::rescaleVelocities, this));
 }
 
 void StochasticVelocityRescaling::setTemperature(real _temperature) {

--- a/src/integrator/TDforce.cpp
+++ b/src/integrator/TDforce.cpp
@@ -69,11 +69,11 @@ namespace espressopp {
     void TDforce::connect(){
       if(slow){
         _applyForce = integrator->aftCalcSlow.connect(
-            boost::bind(&TDforce::applyForce, this), boost::signals2::at_front);
+            std::bind(&TDforce::applyForce, this), boost::signals2::at_front);
       }
       else{
         _applyForce = integrator->aftCalcF.connect(
-            boost::bind(&TDforce::applyForce, this));
+            std::bind(&TDforce::applyForce, this));
       }
     }
 

--- a/src/integrator/VelocityVerletOnRadius.cpp
+++ b/src/integrator/VelocityVerletOnRadius.cpp
@@ -50,9 +50,9 @@ namespace espressopp {
 
     void VelocityVerletOnRadius::connect(){
       // connection to initialisation
-      _aftIntP  = integrator->aftIntP.connect( boost::bind(&VelocityVerletOnRadius::integrate1, this));
-      _aftIntV  = integrator->aftIntV.connect( boost::bind(&VelocityVerletOnRadius::integrate2, this));
-      _aftInitF  = integrator->aftInitF.connect( boost::bind(&VelocityVerletOnRadius::initForces, this));
+      _aftIntP  = integrator->aftIntP.connect( std::bind(&VelocityVerletOnRadius::integrate1, this));
+      _aftIntV  = integrator->aftIntV.connect( std::bind(&VelocityVerletOnRadius::integrate2, this));
+      _aftInitF  = integrator->aftInitF.connect( std::bind(&VelocityVerletOnRadius::initForces, this));
     }
 
     void VelocityVerletOnRadius::integrate1() {

--- a/src/interaction/CoulombKSpaceEwald.cpp
+++ b/src/interaction/CoulombKSpaceEwald.cpp
@@ -48,9 +48,9 @@ namespace espressopp {
       count_charges(system->storage->getRealCells()); 
 
       // make a connection to boundary conditions to invoke recalculation of KVec if box dimensions change
-      connectionRecalcKVec = system->bc->onBoxDimensionsChanged.connect(boost::bind(&CoulombKSpaceEwald::preset, this));
+      connectionRecalcKVec = system->bc->onBoxDimensionsChanged.connect(std::bind(&CoulombKSpaceEwald::preset, this));
       // make a connection to storage to get number of particles
-      connectionGetParticleNumber = system->storage->onParticlesChanged.connect(boost::bind(&CoulombKSpaceEwald::getParticleNumber, this));
+      connectionGetParticleNumber = system->storage->onParticlesChanged.connect(std::bind(&CoulombKSpaceEwald::getParticleNumber, this));
     }
     
     CoulombKSpaceEwald::~CoulombKSpaceEwald(){

--- a/src/interaction/CoulombKSpaceP3M.cpp
+++ b/src/interaction/CoulombKSpaceP3M.cpp
@@ -205,10 +205,10 @@ namespace espressopp {
          dimensions change
       */
       connectionRecalcKVec = system->bc->onBoxDimensionsChanged.
-              connect(boost::bind(&CoulombKSpaceP3M::preset, this));
+              connect(std::bind(&CoulombKSpaceP3M::preset, this));
       // make a connection to storage in order to get number of particles
       connectionGetParticleNumber = system->storage->onParticlesChanged.
-              connect(boost::bind(&CoulombKSpaceP3M::getParticleNumber, this));
+              connect(std::bind(&CoulombKSpaceP3M::getParticleNumber, this));
       
       // sign a signal in order not to recalculate common part twice
       //recalcCommonPart = system.

--- a/src/interaction/CoulombKSpaceP3M.hpp
+++ b/src/interaction/CoulombKSpaceP3M.hpp
@@ -478,7 +478,7 @@ namespace espressopp {
             d1[i] = ppos[i] * M[i] / sysL[i] + modadd1;
           }
           Gi  = Int3D(d1 + modadd2) + assignshift;
-          arg = Int3D( (d1 - dround(d1) + 0.5)*_2interp );
+          arg = Int3D( (d1 - dround(d1) + 0.5)* _2interp );
 
           // specific for force !!!!!!!!
           g_ca[p.id()] = Gi;

--- a/src/vectorization/Vectorization.cpp
+++ b/src/vectorization/Vectorization.cpp
@@ -56,16 +56,16 @@ namespace espressopp {
     {
       sigResetParticles     = getSystem()->storage->onParticlesChanged.connect(
                                 boost::signals2::at_front, // call first due to reordering
-                                boost::bind(&Vectorization::resetParticles, this));
+                                std::bind(&Vectorization::resetParticles, this));
       sigResetCells         = getSystem()->storage->onCellAdjust.connect(
                                 boost::signals2::at_back,
-                                boost::bind(&Vectorization::resetCells, this));
+                                std::bind(&Vectorization::resetCells, this));
       sigBefCalcForces      = mdintegrator->aftInitF.connect(
                                 boost::signals2::at_back,
-                                boost::bind(&Vectorization::befCalcForces,this));
+                                std::bind(&Vectorization::befCalcForces,this));
       sigUpdateForces       = mdintegrator->aftCalcFLocal.connect(
                                 boost::signals2::at_front,
-                                boost::bind(&Vectorization::updateForces,this));
+                                std::bind(&Vectorization::updateForces,this));
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/vectorization/VerletList.cpp
+++ b/src/vectorization/VerletList.cpp
@@ -63,7 +63,7 @@ namespace espressopp { namespace vectorization {
 
     // make a connection to System to invoke rebuild on resort
     connectionResort = system->storage->onParticlesChanged.connect(
-        boost::bind(&VerletList::rebuild, this));
+        std::bind(&VerletList::rebuild, this));
   }
 
   real VerletList::getVerletCutoff(){
@@ -75,7 +75,7 @@ namespace espressopp { namespace vectorization {
 
   // make a connection to System to invoke rebuild on resort
   connectionResort = getSystem()->storage->onParticlesChanged.connect(
-      boost::bind(&VerletList::rebuild, this));
+      std::bind(&VerletList::rebuild, this));
   }
 
   void VerletList::disconnect()


### PR DESCRIPTION
Getting rid of more deprecated warnings. We are getting closer to a warning free master.