### PR TITLE
fix: more precision in SmoothSquareWell potential test

### DIFF
--- a/testsuite/interaction_potentials/smooth_square_well/TestSmoothSquareWell.cpp
+++ b/testsuite/interaction_potentials/smooth_square_well/TestSmoothSquareWell.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(SSW_force)
     Real3D dist(0.85, 0.5, 0.4);
     Real3D f = ssw.computeForce(dist);
 
-    BOOST_CHECK_CLOSE(f[0], -0.0005493, 0.01);
-    BOOST_CHECK_CLOSE(f[1], -0.0003231, 0.01);
-    BOOST_CHECK_CLOSE(f[2], -0.0002585, 0.01);
+    BOOST_CHECK_CLOSE(f[0], -0.00054933, 0.01);
+    BOOST_CHECK_CLOSE(f[1], -0.00032314, 0.01);
+    BOOST_CHECK_CLOSE(f[2], -0.00025851, 0.01);
 }


### PR DESCRIPTION
Hello, 

Based on the comments here: https://github.com/espressopp/espressopp/pull/372, I added more precision to the values to the test of smooth square well potential. I ran the test, and it passed on my machine. I did NOT remove ignore file in this pull request.

Thank you,
Bin 