### PR TITLE
cmake: fix mpi4py include path

### DIFF
--- a/contrib/mpi4py/CMakeLists.txt
+++ b/contrib/mpi4py/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT ${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
 add_library(MPI4PY_include INTERFACE)
-target_include_directories(MPI4PY_include INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${MPI4PY_DIR}/src/mpi4py/include>)
+target_include_directories(MPI4PY_include SYSTEM INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${MPI4PY_DIR}/src/mpi4py/include>)
 
 add_library(MPI4PY::mpi4py ALIAS MPI)
 add_library(MPI4PY::include ALIAS MPI4PY_include)

--- a/contrib/mpi4py/CMakeLists.txt
+++ b/contrib/mpi4py/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT ${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
 add_library(MPI4PY_include INTERFACE)
-target_include_directories(MPI4PY_include INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${MPI4PY_DIR}/src/include>)
+target_include_directories(MPI4PY_include INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${MPI4PY_DIR}/src/mpi4py/include>)
 
 add_library(MPI4PY::mpi4py ALIAS MPI)
 add_library(MPI4PY::include ALIAS MPI4PY_include)


### PR DESCRIPTION
Next attempt to fix `weekly` build.

The docker build in the CI doesn't fail because we are using the mpi4py system header even with `EXTERNAL_MPI4PY=ON` (on Ubuntu). On Fedora the headers are in a non-standard location hence the failure.