### PR TITLE
removing mpi4py dependency from the C++ code

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,6 @@ target_link_libraries(_espressopp PUBLIC Boost::mpi Boost::serialization Boost::
 target_link_libraries(_espressopp PUBLIC Python3::Python)
 target_link_libraries(_espressopp PUBLIC MPI::MPI_CXX)
 target_link_libraries(_espressopp PRIVATE FFTW3::fftw3)
-target_link_libraries(_espressopp PRIVATE MPI4PY::include)
 
 if(WITH_XTC)
     target_add_definitions(_espressopp PRIVATE -DHAS_GROMACS)

--- a/src/System.hpp
+++ b/src/System.hpp
@@ -44,7 +44,7 @@ private:
 
 public:
     System();
-    System(python::object _pyobj);
+    explicit System(int fComm);
 
     std::shared_ptr<mpi::communicator> comm;
 

--- a/src/System.py
+++ b/src/System.py
@@ -113,11 +113,11 @@ class SystemLocal(_espressopp.System):
 
         if pmi._PMIComm and pmi._PMIComm.isActive():
             if pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-                cxxinit(self, _espressopp.System, pmi._PMIComm.getMPIsubcomm())
+                cxxinit(self, _espressopp.System, pmi._PMIComm.getMPIsubcomm().py2f())
             else :
                 pass
         else :
-            cxxinit(self, _espressopp.System, pmi._MPIcomm)
+            cxxinit(self, _espressopp.System, pmi._MPIcomm.py2f())
 
         self._integrator = None
         self._interaction2id = {}


### PR DESCRIPTION
Since MPI_Comm is a complicated struct not directly exposed by mpi4py the coupling is done
via the Fortran communicator that is a plain int.