### PR TITLE
enable c compiler

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,14 +26,17 @@ jobs:
       matrix:
         BUILD_TYPE: [Release, Debug]
         DISTRO: ['fedora']
-        CXX: ['g++', 'clang++']
+        CMAKE_COMPILER: [
+            '-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++', 
+            '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
+        ]
         include:
           - BUILD_TYPE: 'Debug'
             DISTRO: 'fedora_intel'
-            CXX: 'icpc'
+            CMAKE_COMPILER: '-DCMAKE_C_COMPILER=icc -DCMAKE_CXX_COMPILER=icpc'
           - BUILD_TYPE: 'Debug'
             DISTRO: 'fedora_intel'
-            CXX: 'icpx'
+            CMAKE_COMPILER: '-DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx'
 
     runs-on: ubuntu-latest
     container: espressopp/buildenv:${{ matrix.distro }}
@@ -41,8 +44,8 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.ccache
-          key: ${{ matrix.DISTRO }}-${{ matrix.CXX }}-${{ matrix.BUILD_TYPE }}-${{ github.run_id }}
-          restore-keys: ${{ matrix.DISTRO }}-${{ matrix.CXX }}-${{ matrix.BUILD_TYPE }}
+          key: ${{ matrix.DISTRO }}-${{ matrix.CMAKE_COMPILER }}-${{ matrix.BUILD_TYPE }}-${{ github.run_id }}
+          restore-keys: ${{ matrix.DISTRO }}-${{ matrix.CMAKE_COMPILER }}-${{ matrix.BUILD_TYPE }}
 
       - uses: actions/checkout@v2
 
@@ -50,7 +53,7 @@ jobs:
         run: pip3 install -r requirements.txt
 
       - name: Configure
-        run: cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$HOME/espressopp -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_CXX_COMPILER=${{ matrix.CXX }} -DUSE_CCACHE=ON -DESPP_WERROR=ON
+        run: cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$HOME/espressopp -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} ${{ matrix.CMAKE_COMPILER }} -DUSE_CCACHE=ON -DESPP_WERROR=ON
 
       - name: Build
         run: cmake --build build --verbose --target all -j 2

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -11,14 +11,17 @@ jobs:
       matrix:
         BUILD_TYPE: [Release, Debug]
         DISTRO: ['fedora', 'fedora_rawhide', 'fedora_mpich', 'opensuse', 'ubuntu', 'ubuntu_devel', 'ubuntu_rolling', 'ubuntu_mpich']
-        CXX: ['g++', 'clang++']
+        CMAKE_COMPILER: [
+            '-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++', 
+            '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'
+        ]
         include:
           - BUILD_TYPE: 'Debug'
             DISTRO: 'fedora_intel'
-            CXX: 'icpc'
+            CMAKE_COMPILER: '-DCMAKE_C_COMPILER=icc -DCMAKE_CXX_COMPILER=icpc'
           - BUILD_TYPE: 'Debug'
             DISTRO: 'fedora_intel'
-            CXX: 'icpx'
+            CMAKE_COMPILER: '-DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx'
 
     runs-on: ubuntu-latest
     container: espressopp/buildenv:${{ matrix.distro }}
@@ -26,8 +29,8 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.ccache
-          key: ${{ matrix.DISTRO }}-${{ matrix.CXX }}-${{ matrix.BUILD_TYPE }}-${{ github.run_id }}
-          restore-keys: ${{ matrix.DISTRO }}-${{ matrix.CXX }}-${{ matrix.BUILD_TYPE }}
+          key: ${{ matrix.DISTRO }}-${{ matrix.CMAKE_COMPILER }}-${{ matrix.BUILD_TYPE }}-${{ github.run_id }}
+          restore-keys: ${{ matrix.DISTRO }}-${{ matrix.CMAKE_COMPILER }}-${{ matrix.BUILD_TYPE }}
 
       - uses: actions/checkout@v2
 
@@ -35,7 +38,7 @@ jobs:
         run: pip3 install -r requirements.txt
 
       - name: Configure
-        run: cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$HOME/espressopp -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_CXX_COMPILER=${{ matrix.CXX }} -DESPP_WERROR=ON
+        run: cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$HOME/espressopp -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} ${{ matrix.CMAKE_COMPILER }} -DESPP_WERROR=ON
 
       - name: Build
         run: cmake --build build --verbose --target all -j 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(espressopp LANGUAGES CXX)
+project(espressopp LANGUAGES C CXX)
 
 # Cmake modules/macros are in a subdirectory to keep this file cleaner
 set(ESPP_CMAKE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
We will need C language bindings for HDF5. CMake needs the C language to be enabled to correctly extract compiler flags.
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4534
This is needed by #356 

This MR introduces the C language and updates the CI accordingly.
