### PR TITLE
Improve dump_xtc_* test

### DIFF
--- a/testsuite/FileIOTests/dump_xtc/test_dump_xtc.py
+++ b/testsuite/FileIOTests/dump_xtc/test_dump_xtc.py
@@ -62,8 +62,8 @@ class TestDumpXTC(unittest.TestCase):
         dump_xtc = espressopp.io.DumpXTC(self.system, self.integrator, filename=file_xtc_10atoms, unfolded = False, length_factor = 1.0, append = False)
         dump_xtc.dump()
 
-#        self.assertTrue(filecmp.cmp(file_xtc_9atoms, expected_files[0], shallow = False), "!!! Error! Files are not equal!! They should be equal!")
-#        self.assertTrue(filecmp.cmp(file_xtc_10atoms, expected_files[1], shallow = False), "!!! Error! Files are not equal!! They should be equal!")
+        self.assertTrue(filecmp.cmp(file_xtc_9atoms, expected_files[0], shallow = False), "!!! Error! Files are not equal!! They should be equal!")
+        self.assertTrue(filecmp.cmp(file_xtc_10atoms, expected_files[1], shallow = False), "!!! Error! Files are not equal!! They should be equal!")
 
 
     def tearDown(self):

--- a/testsuite/FileIOTests/dump_xtc_adress/test_dump_xtc_adress.py
+++ b/testsuite/FileIOTests/dump_xtc_adress/test_dump_xtc_adress.py
@@ -60,9 +60,9 @@ class TestDumpXTCAdress(unittest.TestCase):
             length_factor=1.0,
             append=False)
         dump_xtc.dump()
-#        self.assertTrue(
-#            filecmp.cmp(file_xtc_9atoms, expected_files[0], shallow = False),
-#            "!!! Error! Files are not equal!! They should be equal!")
+        self.assertTrue(
+            filecmp.cmp(file_xtc_9atoms, expected_files[0], shallow = False),
+            "!!! Error! Files are not equal!! They should be equal!")
 
     def tearDown(self):
         os.remove("test.xtc")


### PR DESCRIPTION
This reverts commit 792d3ada97e42f15480374a4c070c6b4d4b6937e.

We need to find a better way to compare the output than just binary compares.