### PR TITLE
Reverse mapping

### DIFF
--- a/src/FixedVSList.cpp
+++ b/src/FixedVSList.cpp
@@ -1,0 +1,76 @@
+/*
+  Copyright (C) 2014-2017
+      Jakub Krajniak (jkrajniak at gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "python.hpp"
+#include "FixedVSList.hpp"
+
+#include <boost/bind.hpp>
+#include "storage/Storage.hpp"
+#include "Buffer.hpp"
+
+#include "System.hpp"
+#include "bc/BC.hpp"
+
+#include "esutil/Error.hpp"
+
+namespace espressopp
+{
+LOG4ESPP_LOGGER(FixedVSList::theLogger, "FixedVSList");
+
+FixedVSList::FixedVSList(shared_ptr<storage::Storage> _storage) : storage(_storage), globalTuples()
+{
+    LOG4ESPP_INFO(theLogger, "construct FixedVSList");
+}
+
+FixedVSList::~FixedVSList() { LOG4ESPP_INFO(theLogger, "~FixedVSList"); }
+
+bool FixedVSList::addT(tuple pids)
+{
+    bool returnVal = true;
+
+    tuple::iterator it = pids.begin();
+    longint pid_cg = *it;
+    std::vector<longint> pidstmp;
+
+    for (++it; it != pids.end(); ++it)
+    {
+        pidstmp.push_back(*it);
+    }
+    globalTuples.insert(make_pair(pid_cg, pidstmp));
+
+    return returnVal;
+}
+
+/****************************************************
+** REGISTRATION WITH PYTHON
+****************************************************/
+void FixedVSList::registerPython()
+{
+    using namespace espressopp::python;
+
+    void (FixedVSList::*pyAdd)(longint pid) = &FixedVSList::add;
+
+    class_<FixedVSList, shared_ptr<FixedVSList>, boost::noncopyable>(
+        "FixedVSList", init<shared_ptr<storage::Storage> >())
+        .def("add", pyAdd)
+        .def("addTs", &FixedVSList::addTs);
+}
+
+}  // namespace espressopp

--- a/src/FixedVSList.hpp
+++ b/src/FixedVSList.hpp
@@ -1,0 +1,65 @@
+/*
+  Copyright (C) 2014-2017
+      Jakub Krajniak (jkrajniak at gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// ESPP_CLASS
+#ifndef _FixedVSList_HPP
+#define _FixedVSList_HPP
+
+#include "log4espp.hpp"
+
+#include "Particle.hpp"
+#include "esutil/ESPPIterator.hpp"
+#include <boost/unordered_map.hpp>
+#include <boost/signals2.hpp>
+
+namespace espressopp
+{
+class FixedVSList
+{
+protected:
+    shared_ptr<storage::Storage> storage;
+
+public:
+    typedef std::vector<longint> tuple;
+    typedef boost::unordered_map<longint, tuple> GlobalTuples;
+    GlobalTuples globalTuples;
+
+    FixedVSList(shared_ptr<storage::Storage> _storage);
+    ~FixedVSList();
+
+    void add(longint pid) { tmppids.push_back(pid); }
+    void addTs()
+    {
+        addT(tmppids);
+        tmppids.clear();
+    }
+
+    tuple& getATParticleIds(longint pidK) { return globalTuples[pidK]; }
+
+    static void registerPython();
+
+private:
+    tuple tmppids;
+    bool addT(tuple pids);  // add tuple
+    static LOG4ESPP_DECL_LOGGER(theLogger);
+};
+}  // namespace espressopp
+
+#endif

--- a/src/FixedVSList.py
+++ b/src/FixedVSList.py
@@ -1,20 +1,20 @@
 #  Copyright (C) 2016,2021
 #      Jakub Krajniak (jkrajniak at gmail.com)
-#  
+#
 #  This file is part of ESPResSo++.
-#  
+#
 #  ESPResSo++ is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
-#  
+#
 #  ESPResSo++ is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  
+#
 #  You should have received a copy of the GNU General Public License
-#  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 r"""
@@ -65,7 +65,7 @@ class FixedVSListLocal(_espressopp.FixedVSList):
             for tuple in tuplelist:
                 for pid in tuple:
                     self.cxxclass.add(self, pid)
-                self.cxxclass.addTs(self);
+                self.cxxclass.addTs(self)
 
 
 if pmi.isController:

--- a/src/FixedVSList.py
+++ b/src/FixedVSList.py
@@ -1,0 +1,76 @@
+#  Copyright (C) 2016,2021
+#      Jakub Krajniak (jkrajniak at gmail.com)
+#  
+#  This file is part of ESPResSo++.
+#  
+#  ESPResSo++ is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  
+#  ESPResSo++ is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+
+
+r"""
+**************************************
+**FixedVSList** - Object
+**************************************
+
+The FixedVSList keeps the connection between the coarse-grained and underlaying atomistic
+particles.
+
+Example - creating the FixedVSList:
+
+>>> tuples = [(1, 2, 3), (4, 5, 6), (7, 8, 9)]
+>>> ftpl = espressopp.FixedVSList(system.storage)
+>>> ftpl.addTuples(tuples)
+
+
+
+.. function:: espressopp.FixedVSList(storage)
+		:param storage:
+		:type storage: 
+
+.. function:: espressopp.FixedVSList.addTuples(tuplelist)
+
+		:param tuplelist: 
+		:type tuplelist: 
+		:rtype: 
+"""
+
+from espressopp import pmi
+import _espressopp
+import espressopp
+from espressopp.esutil import cxxinit
+
+
+class FixedVSListLocal(_espressopp.FixedVSList):
+    def __init__(self, storage):
+        if pmi.workerIsActive():
+            cxxinit(self, _espressopp.FixedVSList, storage)
+
+    def addTuples(self, tuplelist):
+        """
+        Each processor takes the broadcasted tuplelist and
+        adds those tuples whose virtual particle is owned by
+        this processor.
+        """
+        if pmi.workerIsActive():
+            for tuple in tuplelist:
+                for pid in tuple:
+                    self.cxxclass.add(self, pid)
+                self.cxxclass.addTs(self);
+
+
+if pmi.isController:
+    class FixedVSList(metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+            cls='espressopp.FixedVSListLocal',
+            pmicall=["addTuples"]
+        )

--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -53,6 +53,7 @@ void Particle::registerPython()
         .add_property("state", &Particle::getState, &Particle::setState)
         .add_property("res_id", &Particle::getResId, &Particle::setResId)
         .add_property("extVar", &Particle::getExtVar, &Particle::setExtVar)
-        .add_property("drift_f", &Particle::getDrift, &Particle::setDrift);
+        .add_property("drift_f", &Particle::getDrift, &Particle::setDrift)
+	.add_property("isVP", &Particle::getVP, &Particle::setVP);
 }
 }  // namespace espressopp

--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -54,6 +54,6 @@ void Particle::registerPython()
         .add_property("res_id", &Particle::getResId, &Particle::setResId)
         .add_property("extVar", &Particle::getExtVar, &Particle::setExtVar)
         .add_property("drift_f", &Particle::getDrift, &Particle::setDrift)
-	.add_property("isVP", &Particle::getVP, &Particle::setVP);
+        .add_property("isVP", &Particle::getVP, &Particle::setVP);
 }
 }  // namespace espressopp

--- a/src/Particle.hpp
+++ b/src/Particle.hpp
@@ -55,6 +55,7 @@ struct ParticleProperties
     Real3D fm;
     int state;
     longint res_id;
+    bool vp;
 
 private:
     friend class boost::serialization::access;
@@ -227,6 +228,7 @@ struct Particle
         p.state = 0;
         p.pib = 0;
         p.res_id = 0;
+        p.vp = false;
     }
 
     // getter and setter used for export in Python
@@ -374,6 +376,12 @@ struct Particle
     int getResId() const { return p.res_id; }
     void setResId(const int& _res_id) { p.res_id = _res_id; }
 
+    // virtual-particle
+    bool& vp() { return p.vp; }
+    const bool& vp() const { return p.vp; }
+    bool getVP() const { return p.vp; }
+    void setVP(const bool& _vp) { p.vp = _vp; }
+
     static void registerPython();
 
     void copyAsGhost(const Particle& src, int extradata, const Real3D& shift)
@@ -392,6 +400,22 @@ struct Particle
             l = src.l;
         }
         ghost() = 1;
+        lambda() = src.lambda();
+    }
+
+    bool operator<(Particle other) const { return p.id < other.id(); }
+
+    bool operator<(const Particle& other) { return p.id < other.id(); }
+
+    bool operator<(Particle* other) { return p.id < other->id(); }
+
+    friend std::ostream& operator<<(std::ostream& output, const Particle& p)
+    {
+        output << "P.id=" << p.id() << " type=" << p.type() << " pos=" << p.position()
+               << " v=" << p.velocity() << " f=" << p.force() << " mass=" << p.mass()
+               << " img=" << p.image() << " ghost=" << p.ghost() << " lmb=" << p.lambda()
+               << " state=" << p.state() << " resid=" << p.res_id() << " vp=" << p.vp();
+        return output;
     }
 
 private:

--- a/src/Particle.py
+++ b/src/Particle.py
@@ -262,6 +262,11 @@ class ParticleLocal(object):
     def isGhost(self, val): self.__getTmp().isGhost = val
 
     @property
+    def isVP(self): return self.__getTmp().isVP
+    @isVP.setter
+    def isVP(self, val): self.__getTmp().isVP = val
+    
+    @property
     def lambda_adr(self): return self.__getTmp().lambda_adr
     @lambda_adr.setter
     def lambda_adr(self, val): self.__getTmp().lambda_adr = val
@@ -301,6 +306,7 @@ class ParticleLocal(object):
     def locateParticle(self):
         tmp = self.storage.lookupRealParticle(self.pid)
         return (tmp is not None)
+
 
 if pmi.isController:
     class Particle(metaclass=pmi.Proxy):

--- a/src/Particle.py
+++ b/src/Particle.py
@@ -165,6 +165,7 @@ class ParticleLocal(object):
     * when a ghost particle is to be written
     * when data is to be read from a ghost that is not available
     """
+
     def __init__(self, pid, storage):
         self.pid = pid
         self.storage = storage
@@ -265,7 +266,7 @@ class ParticleLocal(object):
     def isVP(self): return self.__getTmp().isVP
     @isVP.setter
     def isVP(self, val): self.__getTmp().isVP = val
-    
+
     @property
     def lambda_adr(self): return self.__getTmp().lambda_adr
     @lambda_adr.setter
@@ -311,9 +312,9 @@ class ParticleLocal(object):
 if pmi.isController:
     class Particle(metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls = 'espressopp.ParticleLocal',
-            pmiproperty = ["id", "storage"]
-            )
+            cls='espressopp.ParticleLocal',
+            pmiproperty=["id", "storage"]
+        )
 
         @property
         def node(self):
@@ -321,9 +322,11 @@ if pmi.isController:
             return node
 
         def __getattr__(self, key):
-            value = list(filter(lambda v: v is not None, pmi.invoke(self, 'getLocalData', key)))
+            value = list(filter(lambda v: v is not None,
+                         pmi.invoke(self, 'getLocalData', key)))
             if len(value) == 0:
                 return None
             if len(value) > 1:
-                raise RuntimeError('The requested particle is on more than one CPU - should not happen')
+                raise RuntimeError(
+                    'The requested particle is on more than one CPU - should not happen')
             return value[0]

--- a/src/Real3D.hpp
+++ b/src/Real3D.hpp
@@ -24,6 +24,7 @@
 #ifndef _REAL3D_HPP
 #define _REAL3D_HPP
 
+#include <math.h>
 #include "types.hpp"
 
 namespace espressopp
@@ -62,6 +63,11 @@ public:
 
     void setItem(int i, real v);
     real getItem(int i) const;
+
+    // error checking
+    bool isNaN() const;
+    bool isInf() const;
+    bool isNaNInf() const;
 
     // unary operators
     Real3D& operator+=(const Real3D& v);
@@ -156,6 +162,19 @@ inline const real& Real3D::at(int i) const
 inline void Real3D::setItem(int i, real v) { this->at(i) = v; }
 
 inline real Real3D::getItem(int i) const { return this->at(i); }
+
+// error check
+inline bool Real3D::isNaN() const
+{
+    return (data[0] != data[0] || data[1] != data[1] || data[2] != data[2]);
+}
+
+inline bool Real3D::isInf() const
+{
+    return (std::isinf(data[0]) || std::isinf(data[1]) || std::isinf(data[2]));
+}
+
+inline bool Real3D::isNaNInf() const { return (this->isNaN() || this->isInf()); }
 
 // unary operators
 inline Real3D& Real3D::operator+=(const Real3D& v)

--- a/src/VerletListHybrid.cpp
+++ b/src/VerletListHybrid.cpp
@@ -1,0 +1,133 @@
+/*
+  Copyright (C) 2016
+      Jakub Krajniak <jkrajniak at gmail.com>
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "python.hpp"
+#include "VerletListHybrid.hpp"
+#include "Real3D.hpp"
+#include "Particle.hpp"
+#include "Cell.hpp"
+#include "System.hpp"
+#include "storage/Storage.hpp"
+#include "bc/BC.hpp"
+#include "iterator/CellListAllPairsIterator.hpp"
+
+namespace espressopp
+{
+using namespace espressopp::iterator;
+
+/** Implementation of VerletListHybrid **/
+LOG4ESPP_LOGGER(VerletListHybridAT::theLogger, "VerletListHybridAT");
+LOG4ESPP_LOGGER(VerletListHybridCG::theLogger, "VerletListHybridCG");
+
+void VerletListHybridAT::checkPair(Particle &pt1, Particle &pt2)
+{
+    if (pt1.vp() || pt2.vp())
+    {  // only AT pairs
+        LOG4ESPP_DEBUG(theLogger, " at skip pair " << pt1.id() << "-" << pt2.id()
+                                                   << " vp1=" << pt1.vp() << " vp2=" << pt2.vp());
+        return;
+    }
+
+    Real3D d = pt1.position() - pt2.position();
+    real distsq = d.sqr();
+
+    LOG4ESPP_TRACE(theLogger, "p1: " << pt1.id() << " @ " << pt1.position() << " - p2: " << pt2.id()
+                                     << " @ " << pt2.position() << " -> distsq = " << distsq
+                                     << " cutsq=" << cutsq);
+
+    if (distsq > cutsq) return;
+
+    // see if it's in the exclusion list (both directions)
+    if (exList.count(std::make_pair(pt1.id(), pt2.id())) == 1) return;
+    if (exList.count(std::make_pair(pt2.id(), pt1.id())) == 1) return;
+
+    vlPairs.add(pt1, pt2);  // add pair to Verlet List
+}
+
+void VerletListHybridCG::checkPair(Particle &pt1, Particle &pt2)
+{
+    if ((!pt1.vp()) || (!pt2.vp()))
+    {  // only CG pairs
+        LOG4ESPP_DEBUG(theLogger, "cg skip pair " << pt1.id() << "-" << pt2.id()
+                                                  << " vp1=" << pt1.vp() << " vp2=" << pt2.vp());
+        return;
+    }
+
+    Real3D d = pt1.position() - pt2.position();
+    real distsq = d.sqr();
+
+    LOG4ESPP_TRACE(theLogger, "p1: " << pt1.id() << " @ " << pt1.position() << " - p2: " << pt2.id()
+                                     << " @ " << pt2.position() << " -> distsq = " << distsq);
+
+    if (distsq > cutsq) return;
+
+    // see if it's in the exclusion list (both directions)
+    if (exList.count(std::make_pair(pt1.id(), pt2.id())) == 1) return;
+    if (exList.count(std::make_pair(pt2.id(), pt1.id())) == 1) return;
+
+    vlPairs.add(pt1, pt2);  // add pair to Verlet List
+}
+
+/****************************************************
+** REGISTRATION WITH PYTHON
+****************************************************/
+void VerletListHybridAT::registerPython()
+{
+    using namespace espressopp::python;
+
+    bool (VerletListHybridAT::*pyExclude)(longint pid1, longint pid2) =
+        &VerletListHybridAT::exclude;
+
+    class_<VerletListHybridAT, shared_ptr<VerletListHybridAT>, bases<VerletList> >(
+        "VerletListHybridAT", init<shared_ptr<System>, real, bool>())
+        .add_property("system", &SystemAccess::getSystem)
+        .add_property("builds", &VerletListHybridAT::getBuilds, &VerletListHybridAT::setBuilds)
+        .def("totalSize", &VerletListHybridAT::totalSize)
+        .def("localSize", &VerletListHybridAT::localSize)
+        .def("getPair", &VerletListHybridAT::getPair)
+        .def("exclude", pyExclude)
+        .def("rebuild", &VerletListHybridAT::rebuild)
+        .def("connect", &VerletListHybridAT::connect)
+        .def("disconnect", &VerletListHybridAT::disconnect)
+        .def("getVerletCutoff", &VerletListHybridAT::getVerletCutoff);
+}
+
+void VerletListHybridCG::registerPython()
+{
+    using namespace espressopp::python;
+
+    bool (VerletListHybridCG::*pyExclude)(longint pid1, longint pid2) =
+        &VerletListHybridCG::exclude;
+
+    class_<VerletListHybridCG, shared_ptr<VerletListHybridCG>, bases<VerletList> >(
+        "VerletListHybridCG", init<shared_ptr<System>, real, bool>())
+        .add_property("system", &SystemAccess::getSystem)
+        .add_property("builds", &VerletListHybridCG::getBuilds, &VerletListHybridCG::setBuilds)
+        .def("totalSize", &VerletListHybridCG::totalSize)
+        .def("localSize", &VerletListHybridCG::localSize)
+        .def("getPair", &VerletListHybridCG::getPair)
+        .def("exclude", pyExclude)
+        .def("rebuild", &VerletListHybridCG::rebuild)
+        .def("connect", &VerletListHybridCG::connect)
+        .def("disconnect", &VerletListHybridCG::disconnect)
+        .def("getVerletCutoff", &VerletListHybridCG::getVerletCutoff);
+}
+
+}  // namespace espressopp

--- a/src/VerletListHybrid.hpp
+++ b/src/VerletListHybrid.hpp
@@ -1,0 +1,73 @@
+/*
+  Copyright (C) 2016
+      Jakub Krajniak <jkrajniak at gmail.com>
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// ESPP_CLASS
+#ifndef _VERLETLISTHYBRID_HPP
+#define _VERLETLISTHYBRID_HPP
+
+#include "log4espp.hpp"
+#include "types.hpp"
+#include "python.hpp"
+#include "Particle.hpp"
+#include "SystemAccess.hpp"
+#include "integrator/MDIntegrator.hpp"
+#include "boost/signals2.hpp"
+#include "boost/unordered_set.hpp"
+#include "VerletList.hpp"
+
+namespace espressopp
+{
+class VerletListHybridAT : public VerletList
+{
+public:
+    VerletListHybridAT(std::shared_ptr<System> system, real cut, bool rebuildVL)
+        : VerletList(system, cut, rebuildVL)
+    {
+    }
+
+    /** Register this class so it can be used from Python. */
+    static void registerPython();
+
+protected:
+    void checkPair(Particle &pt1, Particle &pt2);
+
+    static LOG4ESPP_DECL_LOGGER(theLogger);
+};
+
+class VerletListHybridCG : public VerletList
+{
+public:
+    VerletListHybridCG(std::shared_ptr<System> system, real cut, bool rebuildVL)
+        : VerletList(system, cut, rebuildVL)
+    {
+    }
+
+    /** Register this class so it can be used from Python. */
+    static void registerPython();
+
+protected:
+    void checkPair(Particle &pt1, Particle &pt2);
+
+    static LOG4ESPP_DECL_LOGGER(theLogger);
+};
+
+}  // namespace espressopp
+
+#endif

--- a/src/VerletListHybrid.py
+++ b/src/VerletListHybrid.py
@@ -1,0 +1,145 @@
+#  Copyright (C) 2016
+#      Jakub Krajniak <jkrajniak at gmail.com>
+#
+#  This file is part of ESPResSo++.
+#
+#  ESPResSo++ is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ESPResSo++ is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+r"""
+*******************************
+**espressopp.VerletListHybrid**
+*******************************
+"""
+from espressopp import pmi
+import _espressopp
+from espressopp.esutil import cxxinit
+
+
+class VerletListHybridATLocal(_espressopp.VerletListHybridAT):
+    def __init__(self, system, cutoff, exclusionlist=None):
+
+        if pmi.workerIsActive():
+            if exclusionlist is None:
+                # rebuild list in constructor
+                cxxinit(self, _espressopp.VerletListHybridAT,
+                        system, cutoff, True)
+            else:
+                # do not rebuild list in constructor
+                cxxinit(self, _espressopp.VerletListHybridAT,
+                        system, cutoff, False)
+                # add exclusions
+                for pair in exclusionlist:
+                    pid1, pid2 = pair
+                    self.cxxclass.exclude(self, pid1, pid2)
+                # now rebuild list with exclusions
+                self.cxxclass.rebuild(self)
+
+    def totalSize(self):
+        if pmi.workerIsActive():
+            return self.cxxclass.totalSize(self)
+
+    def localSize(self):
+        if pmi.workerIsActive():
+            return self.cxxclass.localSize(self)
+
+    def exclude(self, exclusionlist):
+        """
+        Each processor takes the broadcasted exclusion list
+        and adds it to its list.
+        """
+        if pmi.workerIsActive():
+            for pair in exclusionlist:
+                pid1, pid2 = pair
+                self.cxxclass.exclude(self, pid1, pid2)
+            # rebuild list with exclusions
+            self.cxxclass.rebuild(self)
+
+    def getAllPairs(self):
+        if pmi.workerIsActive():
+            pairs = []
+            npairs = self.localSize()
+            for i in range(npairs):
+                pair = self.cxxclass.getPair(self, i+1)
+                pairs.append(pair)
+            return pairs
+
+
+class VerletListHybridCGLocal(_espressopp.VerletListHybridCG):
+    def __init__(self, system, cutoff, exclusionlist=None):
+
+        if pmi.workerIsActive():
+            if exclusionlist is None:
+                # rebuild list in constructor
+                cxxinit(self, _espressopp.VerletListHybridCG,
+                        system, cutoff, True)
+            else:
+                # do not rebuild list in constructor
+                cxxinit(self, _espressopp.VerletListHybridCG,
+                        system, cutoff, False)
+                # add exclusions
+                for pair in exclusionlist:
+                    pid1, pid2 = pair
+                    self.cxxclass.exclude(self, pid1, pid2)
+                # now rebuild list with exclusions
+                self.cxxclass.rebuild(self)
+
+    def totalSize(self):
+        if pmi.workerIsActive():
+            return self.cxxclass.totalSize(self)
+
+    def localSize(self):
+        if pmi.workerIsActive():
+            return self.cxxclass.localSize(self)
+
+    def exclude(self, exclusionlist):
+        """
+        Each processor takes the broadcasted exclusion list
+        and adds it to its list.
+        """
+        if pmi.workerIsActive():
+            for pair in exclusionlist:
+                pid1, pid2 = pair
+                self.cxxclass.exclude(self, pid1, pid2)
+            # rebuild list with exclusions
+            self.cxxclass.rebuild(self)
+
+    def getAllPairs(self):
+        if pmi.workerIsActive():
+            pairs = []
+            npairs = self.localSize()
+            for i in range(npairs):
+                pair = self.cxxclass.getPair(self, i+1)
+                pairs.append(pair)
+            return pairs
+
+
+if pmi.isController:
+    class VerletListHybridAT(object, metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+            cls='espressopp.VerletListHybridATLocal',
+            pmiproperty=['builds'],
+            pmicall=['totalSize', 'exclude', 'connect',
+                     'disconnect', 'getVerletCutoff'],
+            pmiinvoke=['getAllPairs']
+        )
+
+    class VerletListHybridCG(object, metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+            cls='espressopp.VerletListHybridCGLocal',
+            pmiproperty=['builds'],
+            pmicall=['totalSize', 'exclude', 'connect',
+                     'disconnect', 'getVerletCutoff'],
+            pmiinvoke=['getAllPairs']
+        )

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -39,6 +39,7 @@ from espressopp.System import *
 from espressopp.VerletList import *
 from espressopp.VerletListTriple import *
 from espressopp.VerletListAdress import *
+from espressopp.VerletListHybrid import *
 from espressopp.FixedSingleList import *
 from espressopp.FixedPairList import *
 from espressopp.FixedPairDistList import *

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -56,6 +56,7 @@ from espressopp.MultiSystem import *
 from espressopp.ParallelTempering import *
 from espressopp.Version import *
 from espressopp.PLogger import *
+from espressopp.FixedVSList import *
 
 
 infinity=float("inf")

--- a/src/analysis/Resolution.cpp
+++ b/src/analysis/Resolution.cpp
@@ -1,0 +1,62 @@
+/*
+  Copyright (C) 2015
+    Jakub Krajniak (jkrajniak at gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "python.hpp"
+#include "Resolution.hpp"
+
+using namespace espressopp;  // NOLINT
+using namespace iterator;    // NOLINT
+
+namespace espressopp
+{
+namespace analysis
+{
+real Resolution::compute_real() const
+{
+    System& system = getSystemRef();
+    CellList realCells = system.storage->getRealCells();
+
+    real res = 0.0;
+    longint NPart = 0;
+
+    for (CellListIterator cit(realCells); !cit.isDone(); ++cit)
+    {
+        const Particle& p = *cit;
+        res += p.lambda();
+        NPart++;
+    }
+
+    longint systemN = 0;
+    real sumRes = 0.0;
+
+    mpi::all_reduce(*getSystem()->comm, res, sumRes, std::plus<real>());
+    mpi::all_reduce(*getSystem()->comm, NPart, systemN, std::plus<longint>());
+
+    return sumRes / systemN;
+}
+
+void Resolution::registerPython()
+{
+    using namespace espressopp::python;  // NOLINT
+    class_<Resolution, bases<Observable> >("analysis_Resolution", init<shared_ptr<System> >())
+        .add_property("value", &Resolution::compute_real);
+}
+}  // end namespace analysis
+}  // end namespace espressopp

--- a/src/analysis/Resolution.hpp
+++ b/src/analysis/Resolution.hpp
@@ -1,0 +1,46 @@
+/*
+  Copyright (C) 2015
+      Jakub Krajniak (jkrajniak at gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// ESPP_CLASS
+#ifndef _ANALYSIS_RESOLUTION_HPP
+#define _ANALYSIS_RESOLUTION_HPP
+
+#include "types.hpp"
+#include "Observable.hpp"
+#include "iterator/CellListIterator.hpp"
+#include "storage/DomainDecomposition.hpp"
+
+namespace espressopp
+{
+namespace analysis
+{
+class Resolution : public Observable
+{
+public:
+    Resolution(shared_ptr<System> system) : Observable(system) { result_type = real_scalar; }
+    virtual ~Resolution() {}
+    virtual real compute_real() const;
+
+    static void registerPython();
+};
+}  // end namespace analysis
+}  // namespace espressopp
+
+#endif

--- a/src/analysis/Resolution.py
+++ b/src/analysis/Resolution.py
@@ -1,0 +1,46 @@
+#  Copyright (C) 2016
+#      Jakub Krajniak (jkrajniak at gmail.com)
+#
+#  This file is part of ESPResSo++.
+#
+#  ESPResSo++ is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ESPResSo++ is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""
+**********************************
+**espressopp.analysis.Resolution**
+**********************************
+
+"""
+from espressopp.esutil import cxxinit
+from espressopp import pmi
+
+from espressopp.analysis.Observable import *
+from _espressopp import analysis_Resolution
+
+
+class ResolutionLocal(ObservableLocal, analysis_Resolution):
+    'The (local) compute of the number of particles of the system.'
+
+    def __init__(self, system):
+        if pmi.workerIsActive():
+            cxxinit(self, analysis_Resolution, system)
+
+
+if pmi.isController:
+    class Resolution(Observable, metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+            cls='espressopp.analysis.ResolutionLocal',
+            pmiproperty=['value']
+        )

--- a/src/analysis/SystemMonitor.py
+++ b/src/analysis/SystemMonitor.py
@@ -78,7 +78,7 @@ Example
 from espressopp.esutil import cxxinit
 from espressopp import pmi
 
-from espressopp.analysis.AnalysisBase import *  #NOQA
+from espressopp.analysis.AnalysisBase import *  # NOQA
 from _espressopp import analysis_SystemMonitor
 from _espressopp import analysis_SystemMonitorOutput
 from _espressopp import analysis_SystemMonitorOutputCSV
@@ -114,16 +114,19 @@ class SystemMonitorLocal(analysis_SystemMonitor):
         if pmi.workerIsActive():
             self.cxxclass.dump(self)
 
+
 if pmi.isController:
     class SystemMonitorDummy(metaclass=pmi.Proxy):
-        pmiproxydefs = dict(cls='espressopp.analysis.SystemMonitorOutputDummyLocal')
+        pmiproxydefs = dict(
+            cls='espressopp.analysis.SystemMonitorOutputDummyLocal')
 
     class SystemMonitorOutputCSV(metaclass=pmi.Proxy):
-        pmiproxydefs = dict(cls='espressopp.analysis.SystemMonitorOutputCSVLocal')
+        pmiproxydefs = dict(
+            cls='espressopp.analysis.SystemMonitorOutputCSVLocal')
 
     class SystemMonitor(metaclass=pmi.Proxy):
         pmiproxydefs = dict(
             cls='espressopp.analysis.SystemMonitorLocal',
             pmicall=['add_observable', 'info', 'dump'],
             pmiproperty=('total_energy', 'potential_energy')
-            )
+        )

--- a/src/analysis/SystemMonitor.py
+++ b/src/analysis/SystemMonitor.py
@@ -115,15 +115,13 @@ class SystemMonitorLocal(analysis_SystemMonitor):
             self.cxxclass.dump(self)
 
 if pmi.isController:
-    class SystemMonitorDummy:
-        __metaclass__ = pmi.Proxy
+    class SystemMonitorDummy(metaclass=pmi.Proxy):
         pmiproxydefs = dict(cls='espressopp.analysis.SystemMonitorOutputDummyLocal')
-    class SystemMonitorOutputCSV:
-        __metaclass__ = pmi.Proxy
+
+    class SystemMonitorOutputCSV(metaclass=pmi.Proxy):
         pmiproxydefs = dict(cls='espressopp.analysis.SystemMonitorOutputCSVLocal')
 
-    class SystemMonitor:
-        __metaclass__ = pmi.Proxy
+    class SystemMonitor(metaclass=pmi.Proxy):
         pmiproxydefs = dict(
             cls='espressopp.analysis.SystemMonitorLocal',
             pmicall=['add_observable', 'info', 'dump'],

--- a/src/analysis/TemperatureOnGroup.cpp
+++ b/src/analysis/TemperatureOnGroup.cpp
@@ -29,7 +29,8 @@ void TemperatureOnGroup::registerPython()
 {
     using namespace espressopp::python;
     class_<TemperatureOnGroup, bases<Observable> >(
-        "analysis_TemperatureOnGroup", init<std::shared_ptr<System>, std::shared_ptr<ParticleGroup> >());
+        "analysis_TemperatureOnGroup",
+        init<std::shared_ptr<System>, std::shared_ptr<ParticleGroup> >());
 }
 
 }  // end namespace analysis

--- a/src/analysis/TemperatureOnGroup.cpp
+++ b/src/analysis/TemperatureOnGroup.cpp
@@ -1,0 +1,36 @@
+/*
+  Copyright (C) 2016
+      Jakub Krajniak (jkrajniak at gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "python.hpp"
+#include "TemperatureOnGroup.hpp"
+
+namespace espressopp
+{
+namespace analysis
+{
+void TemperatureOnGroup::registerPython()
+{
+    using namespace espressopp::python;
+    class_<TemperatureOnGroup, bases<Observable> >(
+        "analysis_TemperatureOnGroup", init<std::shared_ptr<System>, std::shared_ptr<ParticleGroup> >());
+}
+
+}  // end namespace analysis
+}  // end namespace espressopp

--- a/src/analysis/TemperatureOnGroup.hpp
+++ b/src/analysis/TemperatureOnGroup.hpp
@@ -1,0 +1,80 @@
+/*
+  Copyright (C) 2016
+      Jakub Krajniak (jkrajniak at gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// ESPP_CLASS
+#ifndef _ANALYSIS_TemperatureOnGroup_HPP
+#define _ANALYSIS_TemperatureOnGroup_HPP
+
+#include "types.hpp"
+#include "Observable.hpp"
+#include "storage/Storage.hpp"
+#include "ParticleGroup.hpp"
+
+namespace espressopp
+{
+namespace analysis
+{
+/** Class to compute the Temperature in ParticleGroup. */
+class TemperatureOnGroup : public Observable
+{
+public:
+    static void registerPython();
+
+    TemperatureOnGroup(std::shared_ptr<System> system, std::shared_ptr<ParticleGroup> pg)
+        : Observable(system), eKin_(0.0), particle_group_(pg)
+    {
+        result_type = real_scalar;
+    }
+
+    virtual ~TemperatureOnGroup() {}
+
+    real compute_real() const
+    {
+        int myN, systemN;
+        real sumT = 0.0;
+        real v2sum = 0.0;
+        myN = 0;
+        systemN = 0;
+
+        for (ParticleGroup::iterator it = particle_group_->begin(); it != particle_group_->end();
+             it++)
+        {
+            Real3D vel = it->velocity();
+            v2sum += it->mass() * (vel * vel);
+            myN += 1;
+        }
+
+        mpi::all_reduce(*getSystem()->comm, v2sum, sumT, std::plus<real>());
+        mpi::all_reduce(*getSystem()->comm, myN, systemN, std::plus<int>());
+
+        eKin_ = 0.5 * sumT;
+        return sumT / (3.0 * systemN);
+    }
+
+    real getEkin() const { return eKin_; }
+
+private:
+    std::shared_ptr<ParticleGroup> particle_group_;
+    mutable real eKin_;
+};
+
+}  // end namespace analysis
+}  // end namespace espressopp
+#endif

--- a/src/analysis/TemperatureOnGroup.py
+++ b/src/analysis/TemperatureOnGroup.py
@@ -1,0 +1,50 @@
+#  Copyright (C) 2016
+#      Jakub Krajniak (jkrajniak at gmail.com)
+#  
+#  This file is part of ESPResSo++.
+#  
+#  ESPResSo++ is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  
+#  ESPResSo++ is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+
+
+r"""
+******************************************
+**espressopp.analysis.TemperatureOnGroup**
+******************************************
+
+
+.. function:: espressopp.analysis.TemperatureOnGroup(system, particle_group)
+
+		:param system: The System object.
+		:type system: espressopp.System
+		:param particle_group: The ParticleGroup.
+		:type particle_group: espressopp.ParticleGroup
+"""
+
+from espressopp.esutil import cxxinit
+from espressopp import pmi
+
+from espressopp.analysis.Observable import *
+from _espressopp import analysis_TemperatureOnGroup
+
+class TemperatureOnGroupLocal(ObservableLocal, analysis_TemperatureOnGroup):
+    def __init__(self, system, particle_group):
+        if pmi.workerIsActive():
+            cxxinit(self, analysis_TemperatureOnGroup, system, particle_group)
+
+if pmi.isController :
+    class TemperatureOnGroup(Observable):
+        __metaclass__ = pmi.Proxy
+        pmiproxydefs = dict(
+            cls =  'espressopp.analysis.TemperatureOnGroupLocal',
+            )

--- a/src/analysis/TemperatureOnGroup.py
+++ b/src/analysis/TemperatureOnGroup.py
@@ -1,20 +1,20 @@
 #  Copyright (C) 2016
 #      Jakub Krajniak (jkrajniak at gmail.com)
-#  
+#
 #  This file is part of ESPResSo++.
-#  
+#
 #  ESPResSo++ is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
-#  
+#
 #  ESPResSo++ is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  
+#
 #  You should have received a copy of the GNU General Public License
-#  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 r"""
@@ -37,14 +37,16 @@ from espressopp import pmi
 from espressopp.analysis.Observable import *
 from _espressopp import analysis_TemperatureOnGroup
 
+
 class TemperatureOnGroupLocal(ObservableLocal, analysis_TemperatureOnGroup):
     def __init__(self, system, particle_group):
         if pmi.workerIsActive():
             cxxinit(self, analysis_TemperatureOnGroup, system, particle_group)
 
-if pmi.isController :
+
+if pmi.isController:
     class TemperatureOnGroup(Observable):
         __metaclass__ = pmi.Proxy
         pmiproxydefs = dict(
-            cls =  'espressopp.analysis.TemperatureOnGroupLocal',
-            )
+            cls='espressopp.analysis.TemperatureOnGroupLocal',
+        )

--- a/src/analysis/__init__.py
+++ b/src/analysis/__init__.py
@@ -69,3 +69,4 @@ from espressopp.analysis.ParticleRadiusDistribution import *
 from espressopp.analysis.SystemMonitor import *
 from espressopp.analysis.PotentialEnergy import *
 from espressopp.analysis.KineticEnergy import *
+from espressopp.analysis.Resolution import *

--- a/src/analysis/__init__.py
+++ b/src/analysis/__init__.py
@@ -70,3 +70,4 @@ from espressopp.analysis.SystemMonitor import *
 from espressopp.analysis.PotentialEnergy import *
 from espressopp.analysis.KineticEnergy import *
 from espressopp.analysis.Resolution import *
+from espressopp.analysis.TemperatureOnGroup import *

--- a/src/analysis/bindings.cpp
+++ b/src/analysis/bindings.cpp
@@ -72,6 +72,7 @@
 #include "SystemMonitor.hpp"
 #include "PotentialEnergy.hpp"
 #include "KineticEnergy.hpp"
+#include "Resolution.hpp"
 
 namespace espressopp
 {
@@ -131,6 +132,7 @@ void registerPython()
     SystemMonitor::registerPython();
     PotentialEnergy::registerPython();
     KineticEnergy::registerPython();
+    Resolution::registerPython();
 
     RadGyrXProfilePI::registerPython();
 }

--- a/src/analysis/bindings.cpp
+++ b/src/analysis/bindings.cpp
@@ -73,6 +73,7 @@
 #include "PotentialEnergy.hpp"
 #include "KineticEnergy.hpp"
 #include "Resolution.hpp"
+#include "TemperatureOnGroup.hpp"
 
 namespace espressopp
 {
@@ -133,6 +134,7 @@ void registerPython()
     PotentialEnergy::registerPython();
     KineticEnergy::registerPython();
     Resolution::registerPython();
+    TemperatureOnGroup::registerPython();
 
     RadGyrXProfilePI::registerPython();
 }

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -31,6 +31,7 @@
 #include <VerletList.hpp>
 #include <VerletListAdress.hpp>
 #include <VerletListTriple.hpp>
+#include <VerletListHybrid.hpp>
 #include <FixedSingleList.hpp>
 #include <FixedPairList.hpp>
 #include <FixedPairDistList.hpp>
@@ -72,6 +73,8 @@ void espressopp::registerPython()
     espressopp::VerletList::registerPython();
     espressopp::VerletListAdress::registerPython();
     espressopp::VerletListTriple::registerPython();
+    espressopp::VerletListHybridAT::registerPython();
+    espressopp::VerletListHybridCG::registerPython();
     espressopp::FixedSingleList::registerPython();
     espressopp::FixedPairList::registerPython();
     espressopp::FixedPairDistList::registerPython();

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -51,6 +51,7 @@
 #include <Version.hpp>
 #include <ParticleAccess.hpp>
 #include <RealND.hpp>
+#include <FixedVSList.hpp>
 
 #include <esutil/PyLogger.hpp>
 #include <esutil/bindings.hpp>
@@ -92,6 +93,7 @@ void espressopp::registerPython()
     espressopp::Version::registerPython();
     espressopp::ParticleAccess::registerPython();
     espressopp::RealNDs::registerPython();
+    espressopp::FixedVSList::registerPython();
 
     espressopp::esutil::registerPython();
     espressopp::bc::registerPython();

--- a/src/esutil/Timer.hpp
+++ b/src/esutil/Timer.hpp
@@ -51,13 +51,12 @@ public:
     void reset() { currentTime = getCurrentTime(); }
     /// get the time that elapsed since the last reset
     float getElapsedTime() const { return getCurrentTime() - currentTime; }
-    void startMeasure() {
-      time0 = getElapsedTime();
-    }
-    float stopMeasure() {
-      float result = getElapsedTime() - time0;
-      time0 = 0.0;
-      return result;
+    void startMeasure() { time0 = getElapsedTime(); }
+    float stopMeasure()
+    {
+        float result = getElapsedTime() - time0;
+        time0 = 0.0;
+        return result;
     }
 };
 

--- a/src/esutil/Timer.hpp
+++ b/src/esutil/Timer.hpp
@@ -42,6 +42,7 @@ class Timer
 {
 protected:
     float currentTime;
+    float time0;
     virtual float getCurrentTime() const = 0;
 
 public:
@@ -50,6 +51,14 @@ public:
     void reset() { currentTime = getCurrentTime(); }
     /// get the time that elapsed since the last reset
     float getElapsedTime() const { return getCurrentTime() - currentTime; }
+    void startMeasure() {
+      time0 = getElapsedTime();
+    }
+    float stopMeasure() {
+      float result = getElapsedTime() - time0;
+      time0 = 0.0;
+      return result;
+    }
 };
 
 /// when printing give the current elapsed time

--- a/src/include/esconfig.hpp
+++ b/src/include/esconfig.hpp
@@ -40,6 +40,9 @@ typedef double real;
 static const real infinity = std::numeric_limits<real>::infinity();
 static const real ROUND_ERROR_PREC = std::numeric_limits<real>::epsilon();
 
+static const real ALMOST_ZERO = std::numeric_limits<real>::epsilon();
+static const real ALMOST_ONE = 1.0 - std::numeric_limits<real>::epsilon();
+
 // define this to "long long" if you need longer integers
 typedef int longint;
 
@@ -47,6 +50,9 @@ typedef int longint;
 typedef boost::lagged_fibonacci607 RNGType;
 // If you REALLY need speed use the line below instead
 // typedef boost::rand48 RNGType;
+
+inline bool isAlmostZero(real value1) { return (std::abs(value1 - ALMOST_ZERO) < 10e-16); }
+
 }  // namespace espressopp
 
 #endif

--- a/src/integrator/DynamicResolution.cpp
+++ b/src/integrator/DynamicResolution.cpp
@@ -1,0 +1,130 @@
+/*
+  Copyright (C) 2015-2016,2021
+      Jakub Krajniak (jkrajniak at gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "DynamicResolution.hpp"
+#include <algorithm>
+#include <vector>
+#include <iomanip>
+#include <sstream>
+#include "python.hpp"
+#include "Real3D.hpp"
+#include "Particle.hpp"
+#include "Cell.hpp"
+#include "System.hpp"
+#include "storage/Storage.hpp"
+#include "bc/BC.hpp"
+#include "iterator/CellListAllPairsIterator.hpp"
+#include "iterator/CellListIterator.hpp"
+
+namespace espressopp
+{
+namespace integrator
+{
+using namespace espressopp::iterator;  // NOLINT
+
+LOG4ESPP_LOGGER(DynamicResolution::theLogger, "DynamicResolution");
+
+DynamicResolution::DynamicResolution(shared_ptr<System> _system,
+                                     shared_ptr<FixedVSList> _vslist,
+                                     real _rate)
+    : Extension(_system), vs_list(_vslist), rate_(_rate)
+{
+    LOG4ESPP_INFO(theLogger, "construct DynamicResolution");
+    type = Extension::Adress;
+}
+
+DynamicResolution::~DynamicResolution()
+{
+    LOG4ESPP_INFO(theLogger, "~DynamicResolution");
+    disconnect();
+}
+
+void DynamicResolution::connect()
+{
+    LOG4ESPP_INFO(theLogger, "connect");
+    _aftIntV = integrator->aftIntV.connect(boost::bind(&DynamicResolution::updateWeights, this),
+                                           boost::signals2::at_back);
+}
+
+void DynamicResolution::disconnect()
+{
+    LOG4ESPP_INFO(theLogger, "disconnect");
+    _aftIntV.disconnect();
+}
+
+void DynamicResolution::set_active(bool active) { active_ = active; }
+
+void DynamicResolution::updateWeights()
+{
+    LOG4ESPP_INFO(theLogger, "updateWeights");
+    if (!active_) return;
+
+    System &system = getSystemRef();
+
+    // Update weights of the particles.
+    FixedVSList::GlobalTuples vs = vs_list->globalTuples;
+    FixedVSList::GlobalTuples::iterator it = vs.begin();
+    for (; it != vs.end(); ++it)
+    {
+        Particle *vp = system.storage->lookupLocalParticle(it->first);
+        if (vp)
+        {
+            real res = vp->lambda() + rate_;
+            if (res > (1.0 + rate_)) continue;
+            if (res > 1.0) res = 1.0;
+            vp->lambda() = res;
+
+            // Update weights for all underlying particles.
+            for (FixedVSList::tuple::iterator itp = it->second.begin(); itp != it->second.end();
+                 ++itp)
+            {
+                Particle *at = system.storage->lookupLocalParticle(*itp);
+                if (at)
+                {
+                    at->lambda() = res;
+                }
+                else
+                {
+                    std::cout << " AT particle (" << *itp << ") of VP " << vp->id() << "-"
+                              << vp->ghost() << " not found in tuples ";
+                    std::cout << " (" << vp->position() << ")" << std::endl;
+                    exit(1);
+                }
+            }
+        }
+    }
+}
+
+/****************************************************
+** REGISTRATION WITH PYTHON
+****************************************************/
+void DynamicResolution::registerPython()
+{
+    using namespace espressopp::python;  // NOLINT
+    class_<DynamicResolution, shared_ptr<DynamicResolution>, bases<Extension> >(
+        "integrator_DynamicResolution", init<shared_ptr<System>, shared_ptr<FixedVSList>, real>())
+        .add_property("active", &DynamicResolution::active, &DynamicResolution::set_active)
+        .add_property("rate", &DynamicResolution::rate, &DynamicResolution::set_rate)
+        .def("update_weights", &DynamicResolution::updateWeights)
+        .def("connect", &DynamicResolution::connect)
+        .def("disconnect", &DynamicResolution::disconnect);
+}
+}  // end namespace integrator
+}  // end namespace espressopp

--- a/src/integrator/DynamicResolution.hpp
+++ b/src/integrator/DynamicResolution.hpp
@@ -1,0 +1,75 @@
+/*
+  Copyright (c) 2015-2016,2021
+      Jakub Krajniak (jkrajniak at gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// ESPP_CLASS
+#ifndef _INTEGRATOR_DYNAMICRESOLUTION_HPP
+#define _INTEGRATOR_DYNAMICRESOLUTION_HPP
+
+#include "log4espp.hpp"
+#include "types.hpp"
+#include "Particle.hpp"
+#include "SystemAccess.hpp"
+#include "FixedVSList.hpp"
+#include "Extension.hpp"
+
+#include "boost/signals2.hpp"
+
+namespace espressopp
+{
+namespace integrator
+{
+/*
+ * This module implement dynamic resolution extension.
+ */
+class DynamicResolution : public Extension
+{
+public:
+    DynamicResolution(shared_ptr<System> _system, shared_ptr<FixedVSList> _vslist, real _rate);
+
+    ~DynamicResolution();
+
+    real rate() { return rate_; }
+    void set_rate(real rate) { rate_ = rate; }
+
+    bool active() { return active_; }
+    void set_active(bool active);
+
+    /** Register this class so it can be used from Python. */
+    static void registerPython();
+
+private:
+    void updateWeights();
+
+    real rate_;
+    bool active_;
+
+    void connect();
+    void disconnect();
+
+    shared_ptr<FixedVSList> vs_list;
+
+    // Signals
+    boost::signals2::connection _aftIntV, _runInit;
+
+    static LOG4ESPP_DECL_LOGGER(theLogger);
+};
+}  // namespace integrator
+}  // namespace espressopp
+#endif

--- a/src/integrator/DynamicResolution.py
+++ b/src/integrator/DynamicResolution.py
@@ -77,16 +77,18 @@ class DynamicResolutionLocal(ExtensionLocal, integrator_DynamicResolution):
     def __init__(self, _system, _vs_list, _rate):
         'Local construction of a verlet list for AdResS'
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, integrator_DynamicResolution, _system, _vs_list, _rate)
+            cxxinit(self, integrator_DynamicResolution,
+                    _system, _vs_list, _rate)
 
     def update_weights(self):
         if pmi.workerIsActive():
             self.cxxclass.update_weights(self)
 
+
 if pmi.isController:
     class DynamicResolution(Extension, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls = 'espressopp.integrator.DynamicResolutionLocal',
-            pmiproperty = ['rate', 'active'],
-            pmicall = ['update_weights']
-            )
+            cls='espressopp.integrator.DynamicResolutionLocal',
+            pmiproperty=['rate', 'active'],
+            pmicall=['update_weights']
+        )

--- a/src/integrator/DynamicResolution.py
+++ b/src/integrator/DynamicResolution.py
@@ -1,0 +1,92 @@
+#  Copyright (c) 2015-2016,2021
+#      Jakub Krajniak (jkrajniak at gmail.com)
+#
+#  This file is part of ESPResSo++.
+#
+#  ESPResSo++ is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ESPResSo++ is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+*******************************************
+**espressopp.integrator.DynamicResolution**
+*******************************************
+
+*DynamicResolution* extension allows changing the *lambda* parameter of particles, namely
+the so called resolution. The module can be used to perform backmapping.
+
+The resolution is changed by
+
+.. math::
+
+   \lambda(t) = \lambda_0 + at
+
+
+where :math:`\lambda` is the current resolution of the particles, :math:`a` is
+the rate by which the resolution is changed during the simulation and :math:`\lambda_0`
+is an initial resolution.
+
+.. class:: espressopp.integrator.DynamicResolution
+
+      The main class for DynamicResolution method.
+
+      .. data:: resolution
+
+         The initial resolution (:math:`\lambda_0`).
+
+      .. data:: rate
+
+         The rate of resolution update.
+
+      .. data:: active
+
+         If set to True then resolution change is active.
+
+      .. method:: DynamicResolution(system, vs_list, rate)
+
+         :param system: The system object.
+         :type system: espressopp.System
+         :param vs_list: The MD integrator.
+         :type vs_list: espressopp.FixedVSList
+         :param rate: The rate.
+         :type output: float
+
+      .. method:: update_weights
+
+         Manual update the resolutions of the particles.
+
+"""
+
+from espressopp.esutil import cxxinit
+from espressopp import pmi
+
+from espressopp.integrator.Extension import Extension, ExtensionLocal
+from _espressopp import integrator_DynamicResolution
+
+
+class DynamicResolutionLocal(ExtensionLocal, integrator_DynamicResolution):
+    def __init__(self, _system, _vs_list, _rate):
+        'Local construction of a verlet list for AdResS'
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            cxxinit(self, integrator_DynamicResolution, _system, _vs_list, _rate)
+
+    def update_weights(self):
+        if pmi.workerIsActive():
+            self.cxxclass.update_weights(self)
+
+if pmi.isController:
+    class DynamicResolution(Extension, metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+            cls = 'espressopp.integrator.DynamicResolutionLocal',
+            pmiproperty = ['rate', 'active'],
+            pmicall = ['update_weights']
+            )

--- a/src/integrator/VelocityVerletHybrid.cpp
+++ b/src/integrator/VelocityVerletHybrid.cpp
@@ -1,0 +1,583 @@
+/*
+  Copyright (C) 2016
+      Jakub Krajniak (jkrajniak at gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "python.hpp"
+#include "VelocityVerletHybrid.hpp"
+#include <iomanip>
+#include "iterator/CellListIterator.hpp"
+#include "interaction/Potential.hpp"
+#include "storage/Storage.hpp"
+#include "bc/BC.hpp"
+
+namespace espressopp
+{
+using namespace std;
+namespace integrator
+{
+using namespace interaction;
+using namespace iterator;
+using namespace esutil;
+
+LOG4ESPP_LOGGER(VelocityVerletHybrid::theLogger, "VelocityVerletHybrid");
+
+VelocityVerletHybrid::VelocityVerletHybrid(shared_ptr<System> system,
+                                           shared_ptr<FixedVSList> vs_list)
+    : MDIntegrator(system), vs_list_(vs_list)
+{
+    LOG4ESPP_INFO(theLogger, "construct VelocityVerletHybrid");
+    resortFlag = true;
+    maxDist = 0.0;
+    timeIntegrate.reset();
+    resetTimers();
+}
+
+VelocityVerletHybrid::~VelocityVerletHybrid()
+{
+    LOG4ESPP_INFO(theLogger, "free VelocityVerletHybrid");
+}
+
+real VelocityVerletHybrid::updateVS()
+{
+    LOG4ESPP_INFO(theLogger, "update position and velocity of VS");
+
+    System &system = getSystemRef();
+    storage::Storage &storage = *system.storage;
+    const bc::BC &bc = *getSystemRef().bc;
+
+    real maxSqDist = 0.0;
+
+    FixedVSList::GlobalTuples vs = vs_list_->globalTuples;
+    FixedVSList::GlobalTuples::iterator it = vs.begin();
+    for (; it != vs.end(); ++it)
+    {
+        Particle *vp = storage.lookupLocalParticle(it->first);  // update local ghost particle.
+        if (vp)
+        {
+            if (vp->id() != it->first) throw std::runtime_error("something is really wrong!");
+            Real3D cmp(0.0, 0.0, 0.0);
+            // Real3D cmv(0.0, 0.0, 0.0);
+            for (FixedVSList::tuple::iterator itp = it->second.begin(); itp != it->second.end();
+                 ++itp)
+            {
+                Particle *atp =
+                    storage.lookupLocalParticle(*itp);  // based on real or ghost position.
+                if (atp)
+                {
+                    if (atp->id() != *itp) throw std::runtime_error("something is really wrong!");
+                    const Real3D &pos = atp->position();
+                    real m = atp->mass();
+                    LOG4ESPP_DEBUG(theLogger, "vp-" << vp->id() << " atp:" << atp->id() << " "
+                                                    << atp->position());
+                    Real3D vec12;
+                    bc.getMinimumImageVectorBox(vec12, pos, vp->position());
+                    cmp[0] += m * vec12[0];
+                    cmp[1] += m * vec12[1];
+                    cmp[2] += m * vec12[2];
+                }
+                else
+                {
+                    std::cout << " AT particle (" << *itp << ") of VP " << vp->id() << "-"
+                              << vp->ghost() << " not found in tuples ";
+                    std::cout << " (" << vp->position() << ")" << std::endl;
+                    exit(1);
+                }
+            }
+            cmp /= vp->mass();
+            // cmv /= vp->mass();
+            LOG4ESPP_DEBUG(theLogger, "vp-" << vp->id() << " cmp=" << cmp);
+            Real3D old_p = vp->position();
+            vp->position() += cmp;
+            // vp->velocity() = cmv;
+            //  Check how fare we move new cg position.
+            Real3D d_p = old_p - vp->position();
+            maxSqDist = std::max(maxSqDist, d_p.sqr());
+        }
+    }
+
+    real maxAllSqDist;
+    mpi::all_reduce(*system.comm, maxSqDist, maxAllSqDist, boost::mpi::maximum<real>());
+
+    LOG4ESPP_INFO(theLogger, " particles in updateVS"
+                                 << ", max move local = " << sqrt(maxSqDist)
+                                 << ", global = " << sqrt(maxAllSqDist));
+
+    return sqrt(maxAllSqDist);
+}
+
+void VelocityVerletHybrid::updateVS_vel()
+{
+    LOG4ESPP_INFO(theLogger, "update velocity of VS");
+
+    FixedVSList::GlobalTuples vs = vs_list_->globalTuples;
+    FixedVSList::GlobalTuples::iterator it = vs.begin();
+
+    System &system = getSystemRef();
+    storage::Storage &storage = *system.storage;
+
+    for (; it != vs.end(); ++it)
+    {
+        Particle *vp = storage.lookupRealParticle(it->first);
+        if (vp)
+        {
+            Real3D cmv(0.0, 0.0, 0.0);
+            for (FixedVSList::tuple::iterator itp = it->second.begin(); itp != it->second.end();
+                 ++itp)
+            {
+                Particle *at = storage.lookupLocalParticle(*itp);
+                if (at)
+                {
+                    cmv += at->mass() * at->velocity();
+                }
+                else
+                {
+                    std::cout << " AT particle (" << *itp << ") of VP " << vp->id() << "-"
+                              << vp->ghost() << " not found in tuples ";
+                    std::cout << " (" << vp->position() << ")" << std::endl;
+                    exit(1);
+                }
+            }
+            // Updates velocity.
+            cmv /= vp->mass();
+            vp->velocity() = cmv;
+        }
+    }
+}
+
+void VelocityVerletHybrid::run(int nsteps)
+{
+    int nResorts = 0;
+    real time;
+    timeIntegrate.reset();
+    System &system = getSystemRef();
+    storage::Storage &storage = *system.storage;
+    skinHalf = 0.5 * system.getSkin();
+
+    // Prepare the force comp timers if the size is not valid.
+    const InteractionList &srIL = system.shortRangeInteractions;
+    if (timeForceComp.size() < srIL.size())
+    {
+        LOG4ESPP_DEBUG(theLogger, "Prepare timeForceComp");
+        timeForceComp.clear();
+        for (size_t i = 0; i < srIL.size(); i++)
+        {
+            timeForceComp.push_back(0.0);
+        }
+    }
+
+    time = timeIntegrate.getElapsedTime();
+    // signal
+    runInit();
+    timeRunInitS += timeIntegrate.getElapsedTime() - time;
+
+    // Before start make sure that particles are on the right processor
+    if (resortFlag)
+    {
+        LOG4ESPP_INFO(theLogger, "resort particles");
+        storage.decompose();
+        maxDist = 0.0;
+        resortFlag = false;
+    }
+
+    bool recalcForces = true;  // TODO: more intelligent
+
+    if (recalcForces)
+    {
+        LOG4ESPP_INFO(theLogger, "recalc forces before starting main integration loop");
+
+        time = timeIntegrate.getElapsedTime();
+        // signal
+        recalc1();
+        timeRecalc1S += timeIntegrate.getElapsedTime() - time;
+
+        updateForces();
+
+        time = timeIntegrate.getElapsedTime();
+        // signal
+        recalc2();
+        timeRecalc2S += timeIntegrate.getElapsedTime() - time;
+    }
+
+    LOG4ESPP_INFO(theLogger, "starting main integration loop (nsteps=" << nsteps << ")");
+
+    for (int i = 0; i < nsteps; i++)
+    {
+        LOG4ESPP_INFO(theLogger, "Next step " << i << " of " << nsteps << " starts");
+
+        time = timeIntegrate.getElapsedTime();
+        // signal
+        befIntP();
+        timeBefIntPS += timeIntegrate.getElapsedTime() - time;
+
+        LOG4ESPP_INFO(theLogger, "updating positions and velocities")
+        maxDist += integrate1();
+        timeInt1 += timeIntegrate.getElapsedTime() - time;
+
+        time = timeIntegrate.getElapsedTime();
+        // signal
+        aftIntP();
+        timeAftIntPS += timeIntegrate.getElapsedTime() - time;
+
+        LOG4ESPP_INFO(theLogger, "maxDist = " << maxDist << ", skin/2 = " << skinHalf);
+
+        if (maxDist > skinHalf) resortFlag = true;
+
+        if (resortFlag)
+        {
+            time = timeIntegrate.getElapsedTime();
+            LOG4ESPP_INFO(theLogger, "step " << i << ": resort particles");
+            storage.decompose();
+            maxDist = 0.0;
+            resortFlag = false;
+            nResorts++;
+            timeResort += timeIntegrate.getElapsedTime() - time;
+        }
+
+        LOG4ESPP_INFO(theLogger, "updating forces")
+        updateForces();
+
+        timeIntegrate.startMeasure();
+        // signal
+        befIntV();
+        timeBefIntVS += timeIntegrate.stopMeasure();
+
+        time = timeIntegrate.getElapsedTime();
+        integrate2();
+        timeInt2 += timeIntegrate.getElapsedTime() - time;
+
+        timeIntegrate.startMeasure();
+        // signal
+        aftIntV();
+        timeAftIntVS += timeIntegrate.stopMeasure();
+    }
+
+    timeRun = timeIntegrate.getElapsedTime();
+
+    LOG4ESPP_INFO(theLogger, "finished run");
+}
+
+void VelocityVerletHybrid::resetTimers()
+{
+    timeForce = 0.0;
+
+    timeComm1 = 0.0;
+    timeComm2 = 0.0;
+    timeInt1 = 0.0;
+    timeInt2 = 0.0;
+    timeResort = 0.0;
+
+    // Reset signal timers.
+    timeRunInitS = 0.0;
+    timeRecalc1S = 0.0;
+    timeRecalc2S = 0.0;
+    timeBefIntPS = 0.0;
+    timeAftIntPS = 0.0;
+    timeAftInitFS = 0.0;
+    timeAftCalcFS = 0.0;
+    timeBefIntVS = 0.0;
+    timeAftIntVS = 0.0;
+
+    timeVS = 0.0;
+    timeVSvel = 0.0;
+    timeVSdistrF = 0.0;
+}
+
+void VelocityVerletHybrid::loadTimers(std::vector<real> &return_vector,
+                                      std::vector<std::string> &return_labels)
+{
+    return_vector.push_back(timeRun);
+    return_labels.push_back("timeRun");
+    for (int i = 0; i < timeForceComp.size(); i++)
+    {
+        return_vector.push_back(timeForceComp[i]);
+        std::stringstream ss;
+        ss << "f" << i;
+        return_labels.push_back(ss.str());
+    }
+
+    // signal timers.
+    return_vector.push_back(timeRunInitS);
+    return_vector.push_back(timeRecalc1S);
+    return_vector.push_back(timeRecalc2S);
+    return_vector.push_back(timeBefIntPS);
+    return_vector.push_back(timeAftIntPS);
+    return_vector.push_back(timeAftCalcFS);
+    return_vector.push_back(timeBefIntVS);
+    return_vector.push_back(timeAftIntVS);
+
+    return_vector.push_back(timeVS);
+    return_vector.push_back(timeVSdistrF);
+    return_vector.push_back(timeVSvel);
+    return_vector.push_back(timeComm1);
+    return_vector.push_back(timeComm2);
+    return_vector.push_back(timeInt1);
+    return_vector.push_back(timeInt2);
+    return_vector.push_back(timeResort);
+
+    return_labels.push_back("timeRunInitS");
+    return_labels.push_back("timeRecalc1S");
+    return_labels.push_back("timeRecalc2S");
+    return_labels.push_back("timeBefIntPS");
+    return_labels.push_back("timeAftIntPS");
+    return_labels.push_back("timeAftCalcFS");
+    return_labels.push_back("timeBefIntVS");
+    return_labels.push_back("timeAftIntVS");
+    return_labels.push_back("timeVS");
+    return_labels.push_back("timeVSdistrF");
+    return_labels.push_back("timeVSvel");
+    return_labels.push_back("timeComm1");
+    return_labels.push_back("timeComm2");
+    return_labels.push_back("timeInt1");
+    return_labels.push_back("timeInt2");
+    return_labels.push_back("timeResort");
+}
+
+real VelocityVerletHybrid::integrate1()
+{
+    System &system = getSystemRef();
+    CellList realCells = system.storage->getRealCells();
+
+    // loop over all particles of the local cells
+    int count = 0;
+    real maxSqDist = 0.0;  // maximal square distance a particle moves
+    for (CellListIterator cit(realCells); !cit.isDone(); ++cit)
+    {
+        if (cit->vp())  // propagate only real particles, skip virtual sites.
+            continue;
+        real sqDist = 0.0;
+        LOG4ESPP_INFO(theLogger,
+                      "updating first half step of velocities and full step of positions")
+        LOG4ESPP_DEBUG(theLogger, "Particle " << cit->id() << ", pos = " << cit->position()
+                                              << ", v = " << cit->velocity()
+                                              << ", f = " << cit->force());
+
+        real dtfm = 0.5 * dt / cit->mass();
+
+        // Propagate velocities: v(t+0.5*dt) = v(t) + 0.5*dt * f(t)
+        cit->velocity() += dtfm * cit->force();
+
+        // Propagate positions (only NVT): p(t + dt) = p(t) + dt * v(t+0.5*dt)
+        Real3D deltaP = cit->velocity();
+
+        deltaP *= dt;
+        cit->position() += deltaP;
+        sqDist += deltaP * deltaP;
+
+        count++;
+
+        maxSqDist = std::max(maxSqDist, sqDist);
+    }
+
+    // signal
+    inIntP(maxSqDist);
+
+    real maxAllSqDist;
+    mpi::all_reduce(*system.comm, maxSqDist, maxAllSqDist, boost::mpi::maximum<real>());
+
+    LOG4ESPP_INFO(theLogger, "moved " << count << " particles in integrate1"
+                                      << ", max move local = " << sqrt(maxSqDist)
+                                      << ", global = " << sqrt(maxAllSqDist));
+
+    return sqrt(maxAllSqDist);
+}
+
+void VelocityVerletHybrid::integrate2()
+{
+    LOG4ESPP_INFO(theLogger, "updating second half step of velocities")
+    System &system = getSystemRef();
+    CellList realCells = system.storage->getRealCells();
+
+    // loop over all particles of the local cells
+    real half_dt = 0.5 * dt;
+    for (CellListIterator cit(realCells); !cit.isDone(); ++cit)
+    {
+        if (cit->vp()) continue;
+        real dtfm = half_dt / cit->mass();
+        /* Propagate velocities: v(t+0.5*dt) = v(t) + 0.5*dt * f(t) */
+        cit->velocity() += dtfm * cit->force();
+    }
+
+    // Update velocity of VS based on the AT velocities.
+    timeIntegrate.startMeasure();
+    // updateVS_vel();
+    timeVSvel += timeIntegrate.stopMeasure();
+
+    step++;
+}
+
+void VelocityVerletHybrid::calcForces()
+{
+    LOG4ESPP_INFO(theLogger, "calculate forces");
+
+    initForces();
+
+    timeIntegrate.startMeasure();
+    // signal
+    aftInitF();
+    timeAftInitFS += timeIntegrate.stopMeasure();
+
+    System &sys = getSystemRef();
+    const InteractionList &srIL = sys.shortRangeInteractions;
+    real time;
+    for (size_t i = 0; i < srIL.size(); i++)
+    {
+        LOG4ESPP_INFO(theLogger, "compute forces for srIL " << i << " of " << srIL.size());
+        time = timeIntegrate.getElapsedTime();
+        srIL[i]->addForces();
+        timeForceComp[i] += timeIntegrate.getElapsedTime() - time;
+    }
+}
+
+void VelocityVerletHybrid::updateForces()
+{
+    LOG4ESPP_INFO(theLogger, "update ghosts, calculate forces and collect ghost forces")
+    real time;
+    storage::Storage &storage = *getSystemRef().storage;
+
+    // Make sure that positions and velocity of VS sites is correct with respect to the atoms.
+    timeIntegrate.startMeasure();
+    real maxDist = updateVS();
+    timeVS += timeIntegrate.stopMeasure();
+
+    if (maxDist > skinHalf)
+    {
+        LOG4ESPP_TRACE(theLogger,
+                       "maxDist=" << maxDist << " >" << skinHalf << " storage.decompose()");
+        time = timeIntegrate.getElapsedTime();
+        storage.decompose();
+        timeComm1 += timeIntegrate.getElapsedTime() - time;
+    }
+    else
+    {
+        time = timeIntegrate.getElapsedTime();
+        storage.updateGhosts();
+        timeComm1 += timeIntegrate.getElapsedTime() - time;
+    }
+
+    time = timeIntegrate.getElapsedTime();
+    calcForces();
+    timeForce += timeIntegrate.getElapsedTime() - time;
+
+    time = timeIntegrate.getElapsedTime();
+    storage.collectGhostForces();
+    timeComm2 += timeIntegrate.getElapsedTime() - time;
+
+    // Distribute forces from VS to AT.
+    timeIntegrate.startMeasure();
+    distributeVSforces();
+    timeVSdistrF += timeIntegrate.stopMeasure();
+
+    timeIntegrate.startMeasure();
+    // signal
+    aftCalcF();
+    timeAftCalcFS += timeIntegrate.stopMeasure();
+}
+
+void VelocityVerletHybrid::initForces()
+{
+    // forces are initialized for real + ghost particles
+
+    System &system = getSystemRef();
+    CellList localCells = system.storage->getLocalCells();
+
+    LOG4ESPP_INFO(theLogger, "init forces for real + ghost particles");
+
+    for (CellListIterator cit(localCells); !cit.isDone(); ++cit)
+    {
+        cit->force() = 0.0;
+        cit->drift() = 0.0;  // Can in principle be commented, when drift is not used.
+    }
+}
+
+void VelocityVerletHybrid::distributeVSforces()
+{
+    // Zeros forces on ghost particles.
+    System &system = getSystemRef();
+    storage::Storage &storage = *system.storage;
+    CellList ghostCells = storage.getGhostCells();
+    LOG4ESPP_INFO(theLogger, "zeros forces on ghost particles");
+
+    for (CellListIterator cit(ghostCells); !cit.isDone(); ++cit)
+    {
+        cit->force() = 0.0;
+        cit->drift() = 0.0;
+    }
+
+    // Distribute forces to AT particles from VS.
+    FixedVSList::GlobalTuples vs = vs_list_->globalTuples;
+    FixedVSList::GlobalTuples::iterator it = vs.begin();
+
+    for (; it != vs.end(); ++it)
+    {
+        Particle *vp = storage.lookupRealParticle(it->first);
+        if (vp)
+        {
+            for (FixedVSList::tuple::iterator itp = it->second.begin(); itp != it->second.end();
+                 ++itp)
+            {
+                Particle *at = storage.lookupLocalParticle(*itp);
+                if (at)
+                {
+                    at->force() += (at->mass() / vp->mass()) * vp->force();
+                }
+                else
+                {
+                    std::cout << " AT particle (" << *itp << ") of VP " << vp->id() << "-"
+                              << vp->ghost() << " not found in tuples ";
+                    std::cout << " (" << vp->position() << ")" << std::endl;
+                    exit(1);
+                }
+            }
+        }
+    }
+    real time = timeIntegrate.getElapsedTime();
+    storage.collectGhostForces();
+    timeComm2 += timeIntegrate.getElapsedTime() - time;
+}
+
+static boost::python::object wrapGetTimers(class VelocityVerletHybrid *obj)
+{
+    std::vector<real> timers;
+    std::vector<std::string> labels;
+    obj->loadTimers(timers, labels);
+
+    boost::python::list return_list;
+    for (int i = 0; i < timers.size(); i++)
+    {
+        return_list.append(boost::python::make_tuple(labels[i], timers[i]));
+    }
+    return return_list;
+}
+
+/****************************************************
+** REGISTRATION WITH PYTHON
+****************************************************/
+
+void VelocityVerletHybrid::registerPython()
+{
+    using namespace espressopp::python;
+
+    // Note: use noncopyable and no_init for abstract classes
+    class_<VelocityVerletHybrid, bases<MDIntegrator>, boost::noncopyable>(
+        "integrator_VelocityVerletHybrid", init<shared_ptr<System>, shared_ptr<FixedVSList> >())
+        .def("getTimers", &wrapGetTimers)
+        .def("resetTimers", &VelocityVerletHybrid::resetTimers);
+}
+}  // namespace integrator
+}  // namespace espressopp

--- a/src/integrator/VelocityVerletHybrid.hpp
+++ b/src/integrator/VelocityVerletHybrid.hpp
@@ -1,0 +1,113 @@
+/*
+  Copyright (C) 2016
+      Jakub Krajniak (jkrajniak at gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// ESPP_CLASS
+#ifndef _INTEGRATOR_VelocityVerletHybrid_HPP
+#define _INTEGRATOR_VelocityVerletHybrid_HPP
+
+#include "types.hpp"
+#include "MDIntegrator.hpp"
+#include "esutil/Timer.hpp"
+#include "FixedVSList.hpp"
+#include <boost/signals2.hpp>
+
+namespace espressopp
+{
+namespace integrator
+{
+/** Velocity Verlet Integrator */
+class VelocityVerletHybrid : public MDIntegrator
+{
+public:
+    VelocityVerletHybrid(shared_ptr<class espressopp::System> system,
+                         shared_ptr<FixedVSList> vs_list);
+
+    virtual ~VelocityVerletHybrid();
+
+    void run(int nsteps);
+
+    /** Load timings in array to export to Python as a tuple. */
+    void loadTimers(std::vector<real> &return_vector, std::vector<std::string> &return_labels);
+
+    /** Clean up all timers.*/
+    void resetTimers();
+
+    /** Register this class so it can be used from Python. */
+    static void registerPython();
+
+protected:
+    bool resortFlag;  //!< true implies need for resort of particles
+    real maxDist;
+
+    real maxCut;
+
+    real integrate1();
+
+    void integrate2();
+
+    void initForces();
+
+    void updateForces();
+
+    void calcForces();
+
+    esutil::WallTimer timeIntegrate;  //!< used for timing
+
+    // variables that keep time information about different phases
+    real timeRun;
+    real timeLost;
+    real timeForce;
+    std::vector<real> timeForceComp;
+    real timeComm1;
+    real timeComm2;
+    real timeInt1;
+    real timeInt2;
+    real timeResort;
+
+    // Signal timers
+    real timeRunInitS;
+    real timeRecalc1S;
+    real timeRecalc2S;
+    real timeBefIntPS;
+    real timeAftIntPS;
+    real timeAftInitFS;
+    real timeAftCalcFS;
+    real timeBefIntVS;
+    real timeAftIntVS;
+
+    real timeVS;
+    real timeVSvel;
+    real timeVSdistrF;
+
+    static LOG4ESPP_DECL_LOGGER(theLogger);
+
+private:
+    void distributeVSforces();
+    real updateVS();
+    void updateVS_vel();
+
+    real skinHalf;
+    shared_ptr<FixedVSList> vs_list_;
+    void checkConsistence(int postfix = 0);
+};
+}  // namespace integrator
+}  // namespace espressopp
+
+#endif

--- a/src/integrator/VelocityVerletHybrid.py
+++ b/src/integrator/VelocityVerletHybrid.py
@@ -1,20 +1,20 @@
 #  Copyright (C) 2016
 #      Jakub Krajniak (jkrajniak at gmail.com)
-#  
+#
 #  This file is part of ESPResSo++.
-#  
+#
 #  ESPResSo++ is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
-#  
+#
 #  ESPResSo++ is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  
+#
 #  You should have received a copy of the GNU General Public License
-#  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 r"""
@@ -34,16 +34,18 @@ from espressopp import pmi
 from espressopp.integrator.MDIntegrator import *
 from _espressopp import integrator_VelocityVerletHybrid
 
+
 class VelocityVerletHybridLocal(MDIntegratorLocal, integrator_VelocityVerletHybrid):
 
     def __init__(self, system, vs_list):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             cxxinit(self, integrator_VelocityVerletHybrid, system, vs_list)
 
-if pmi.isController :
+
+if pmi.isController:
     class VelocityVerletHybrid(MDIntegrator, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-          cls =  'espressopp.integrator.VelocityVerletHybridLocal',
-          pmicall = ['resetTimers'],
-          pmiinvoke = ['getTimers']
+            cls='espressopp.integrator.VelocityVerletHybridLocal',
+            pmicall=['resetTimers'],
+            pmiinvoke=['getTimers']
         )

--- a/src/integrator/VelocityVerletHybrid.py
+++ b/src/integrator/VelocityVerletHybrid.py
@@ -1,0 +1,49 @@
+#  Copyright (C) 2016
+#      Jakub Krajniak (jkrajniak at gmail.com)
+#  
+#  This file is part of ESPResSo++.
+#  
+#  ESPResSo++ is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  
+#  ESPResSo++ is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+
+
+r"""
+****************************************
+**espressopp.integrator.VelocityVerletHybrid**
+****************************************
+
+
+.. function:: espressopp.integrator.VelocityVerletHybrid(system)
+
+		:param system: 
+		:type system: 
+"""
+from espressopp.esutil import cxxinit
+from espressopp import pmi
+
+from espressopp.integrator.MDIntegrator import *
+from _espressopp import integrator_VelocityVerletHybrid
+
+class VelocityVerletHybridLocal(MDIntegratorLocal, integrator_VelocityVerletHybrid):
+
+    def __init__(self, system, vs_list):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            cxxinit(self, integrator_VelocityVerletHybrid, system, vs_list)
+
+if pmi.isController :
+    class VelocityVerletHybrid(MDIntegrator, metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+          cls =  'espressopp.integrator.VelocityVerletHybridLocal',
+          pmicall = ['resetTimers'],
+          pmiinvoke = ['getTimers']
+        )

--- a/src/integrator/__init__.py
+++ b/src/integrator/__init__.py
@@ -65,3 +65,6 @@ from espressopp.integrator.VelocityVerletOnRadius import *
 from espressopp.integrator.AssociationReaction import *
 from espressopp.integrator.EmptyExtension import *
 from espressopp.integrator.MinimizeEnergy import *
+
+from espressopp.integrator.DynamicResolution import *
+from espressopp.integrator.VelocityVerletHybrid import *

--- a/src/integrator/bindings.cpp
+++ b/src/integrator/bindings.cpp
@@ -61,6 +61,8 @@
 #include "VelocityVerletOnRadius.hpp"
 #include "AssociationReaction.hpp"
 #include "MinimizeEnergy.hpp"
+#include "VelocityVerletHybrid.hpp"
+#include "DynamicResolution.hpp"
 
 #include "EmptyExtension.hpp"
 
@@ -108,6 +110,8 @@ void registerPython()
     VelocityVerletOnRadius::registerPython();
     AssociationReaction::registerPython();
     MinimizeEnergy::registerPython();
+    VelocityVerletHybrid::registerPython();
+    DynamicResolution::registerPython();
     EmptyExtension::registerPython();
 }
 }  // namespace integrator

--- a/src/interaction/AngularHarmonic.cpp
+++ b/src/interaction/AngularHarmonic.cpp
@@ -23,6 +23,7 @@
 #include "python.hpp"
 #include "AngularHarmonic.hpp"
 #include "FixedTripleListInteractionTemplate.hpp"
+#include "FixedTripleListAdressInteractionTemplate.hpp"
 
 namespace espressopp
 {
@@ -43,6 +44,9 @@ void AngularHarmonic::registerPython()
     typedef class FixedTripleListInteractionTemplate<AngularHarmonic>
         FixedTripleListAngularHarmonic;
 
+    typedef class FixedTripleListAdressInteractionTemplate<AngularHarmonic>
+        FixedTripleListAdressAngularHarmonic;
+
     class_<FixedTripleListAngularHarmonic, bases<Interaction> >(
         "interaction_FixedTripleListAngularHarmonic",
         init<std::shared_ptr<System>, std::shared_ptr<FixedTripleList>,
@@ -51,6 +55,16 @@ void AngularHarmonic::registerPython()
                   std::shared_ptr<AngularHarmonic> >())
         .def("setPotential", &FixedTripleListAngularHarmonic::setPotential)
         .def("getFixedTripleList", &FixedTripleListAngularHarmonic::getFixedTripleList);
+    ;
+
+    class_<FixedTripleListAdressAngularHarmonic, bases<Interaction> >(
+        "interaction_FixedTripleListAdressAngularHarmonic",
+        init<std::shared_ptr<System>, std::shared_ptr<FixedTripleList>, std::shared_ptr<AngularHarmonic>, bool>())
+        .def(init<std::shared_ptr<System>, std::shared_ptr<FixedTripleListAdress>,
+                  std::shared_ptr<AngularHarmonic>, bool>())
+        .def("setPotential", &FixedTripleListAdressAngularHarmonic::setPotential)
+        .def("getPotential", &FixedTripleListAdressAngularHarmonic::getPotential)
+        .def("getFixedTripleList", &FixedTripleListAdressAngularHarmonic::getFixedTripleList);
     ;
 }
 }  // namespace interaction

--- a/src/interaction/AngularHarmonic.cpp
+++ b/src/interaction/AngularHarmonic.cpp
@@ -59,7 +59,8 @@ void AngularHarmonic::registerPython()
 
     class_<FixedTripleListAdressAngularHarmonic, bases<Interaction> >(
         "interaction_FixedTripleListAdressAngularHarmonic",
-        init<std::shared_ptr<System>, std::shared_ptr<FixedTripleList>, std::shared_ptr<AngularHarmonic>, bool>())
+        init<std::shared_ptr<System>, std::shared_ptr<FixedTripleList>,
+             std::shared_ptr<AngularHarmonic>, bool>())
         .def(init<std::shared_ptr<System>, std::shared_ptr<FixedTripleListAdress>,
                   std::shared_ptr<AngularHarmonic>, bool>())
         .def("setPotential", &FixedTripleListAdressAngularHarmonic::setPotential)

--- a/src/interaction/AngularHarmonic.py
+++ b/src/interaction/AngularHarmonic.py
@@ -101,6 +101,7 @@ from _espressopp import interaction_AngularHarmonic, \
     interaction_FixedTripleListAngularHarmonic, \
     interaction_FixedTripleListAdressAngularHarmonic
 
+
 class AngularHarmonicLocal(AngularPotentialLocal, interaction_AngularHarmonic):
 
     def __init__(self, K=1.0, theta0=0.0):
@@ -108,21 +109,26 @@ class AngularHarmonicLocal(AngularPotentialLocal, interaction_AngularHarmonic):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             cxxinit(self, interaction_AngularHarmonic, K, theta0)
 
+
 class FixedTripleListAngularHarmonicLocal(InteractionLocal, interaction_FixedTripleListAngularHarmonic):
 
     def __init__(self, system, vl, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedTripleListAngularHarmonic, system, vl, potential)
+            cxxinit(self, interaction_FixedTripleListAngularHarmonic,
+                    system, vl, potential)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotential(self, type1, type2, potential)
 
+
 class FixedTripleListAdressAngularHarmonicLocal(InteractionLocal, interaction_FixedTripleListAdressAngularHarmonic):
     'The (local) AngularHarmonic interaction using Adress FixedTriple lists.'
+
     def __init__(self, system, vl, potential, is_cg=False):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedTripleListAdressAngularHarmonic, system, vl, potential, is_cg)
+            cxxinit(self, interaction_FixedTripleListAdressAngularHarmonic,
+                    system, vl, potential, is_cg)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -132,17 +138,18 @@ class FixedTripleListAdressAngularHarmonicLocal(InteractionLocal, interaction_Fi
 if pmi.isController:
     class AngularHarmonic(AngularPotential):
         pmiproxydefs = dict(
-            cls = 'espressopp.interaction.AngularHarmonicLocal',
-            pmiproperty = ['K', 'theta0']
-            )
+            cls='espressopp.interaction.AngularHarmonicLocal',
+            pmiproperty=['K', 'theta0']
+        )
 
     class FixedTripleListAngularHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedTripleListAngularHarmonicLocal',
-            pmicall = ['setPotential', 'getFixedTripleList']
-            )
+            cls='espressopp.interaction.FixedTripleListAngularHarmonicLocal',
+            pmicall=['setPotential', 'getFixedTripleList']
+        )
+
     class FixedTripleListAdressAngularHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedTripleListAdressAngularHarmonicLocal',
-            pmicall = ['setPotential', 'getFixedTripleList']
-            )
+            cls='espressopp.interaction.FixedTripleListAdressAngularHarmonicLocal',
+            pmicall=['setPotential', 'getFixedTripleList']
+        )

--- a/src/interaction/AngularHarmonic.py
+++ b/src/interaction/AngularHarmonic.py
@@ -97,7 +97,9 @@ from espressopp.esutil import *
 
 from espressopp.interaction.AngularPotential import *
 from espressopp.interaction.Interaction import *
-from _espressopp import interaction_AngularHarmonic, interaction_FixedTripleListAngularHarmonic
+from _espressopp import interaction_AngularHarmonic, \
+    interaction_FixedTripleListAngularHarmonic, \
+    interaction_FixedTripleListAdressAngularHarmonic
 
 class AngularHarmonicLocal(AngularPotentialLocal, interaction_AngularHarmonic):
 
@@ -116,6 +118,17 @@ class FixedTripleListAngularHarmonicLocal(InteractionLocal, interaction_FixedTri
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotential(self, type1, type2, potential)
 
+class FixedTripleListAdressAngularHarmonicLocal(InteractionLocal, interaction_FixedTripleListAdressAngularHarmonic):
+    'The (local) AngularHarmonic interaction using Adress FixedTriple lists.'
+    def __init__(self, system, vl, potential, is_cg=False):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            cxxinit(self, interaction_FixedTripleListAdressAngularHarmonic, system, vl, potential, is_cg)
+
+    def setPotential(self, type1, type2, potential):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            self.cxxclass.setPotential(self, type1, type2, potential)
+
+
 if pmi.isController:
     class AngularHarmonic(AngularPotential):
         pmiproxydefs = dict(
@@ -126,5 +139,10 @@ if pmi.isController:
     class FixedTripleListAngularHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
             cls =  'espressopp.interaction.FixedTripleListAngularHarmonicLocal',
+            pmicall = ['setPotential', 'getFixedTripleList']
+            )
+    class FixedTripleListAdressAngularHarmonic(Interaction, metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+            cls =  'espressopp.interaction.FixedTripleListAdressAngularHarmonicLocal',
             pmicall = ['setPotential', 'getFixedTripleList']
             )

--- a/src/interaction/DihedralHarmonicNCos.cpp
+++ b/src/interaction/DihedralHarmonicNCos.cpp
@@ -26,6 +26,7 @@
 #include "DihedralHarmonicNCos.hpp"
 #include "FixedQuadrupleListInteractionTemplate.hpp"
 #include "FixedQuadrupleListTypesInteractionTemplate.hpp"
+#include "FixedQuadrupleListAdressInteractionTemplate.hpp"
 
 namespace espressopp
 {
@@ -68,6 +69,20 @@ void DihedralHarmonicNCos::registerPython()
              &FixedQuadrupleListTypesDihedralHarmonicNCos::setFixedQuadrupleList)
         .def("getFixedQuadrupleList",
              &FixedQuadrupleListTypesDihedralHarmonicNCos::getFixedQuadrupleList);
+
+    typedef class FixedQuadrupleListAdressInteractionTemplate<DihedralHarmonicNCos>
+        FixedQuadrupleListAdressDihedralHarmonicNCos;
+
+    class_<FixedQuadrupleListAdressDihedralHarmonicNCos, bases<Interaction> >(
+        "interaction_FixedQuadrupleListAdressDihedralHarmonicNCos",
+        init<std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleList>, std::shared_ptr<DihedralHarmonicNCos>,
+             bool>())
+        .def(init<std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleListAdress>,
+                  std::shared_ptr<DihedralHarmonicNCos>, bool>())
+        .def("setPotential", &FixedQuadrupleListAdressDihedralHarmonicNCos::setPotential)
+        .def("getPotential", &FixedQuadrupleListAdressDihedralHarmonicNCos::getPotential)
+        .def("getFixedQuadrupleList",
+             &FixedQuadrupleListAdressDihedralHarmonicNCos::getFixedQuadrupleList);
 }
 }  // namespace interaction
 }  // namespace espressopp

--- a/src/interaction/DihedralHarmonicNCos.cpp
+++ b/src/interaction/DihedralHarmonicNCos.cpp
@@ -75,8 +75,8 @@ void DihedralHarmonicNCos::registerPython()
 
     class_<FixedQuadrupleListAdressDihedralHarmonicNCos, bases<Interaction> >(
         "interaction_FixedQuadrupleListAdressDihedralHarmonicNCos",
-        init<std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleList>, std::shared_ptr<DihedralHarmonicNCos>,
-             bool>())
+        init<std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleList>,
+             std::shared_ptr<DihedralHarmonicNCos>, bool>())
         .def(init<std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleListAdress>,
                   std::shared_ptr<DihedralHarmonicNCos>, bool>())
         .def("setPotential", &FixedQuadrupleListAdressDihedralHarmonicNCos::setPotential)

--- a/src/interaction/DihedralHarmonicNCos.py
+++ b/src/interaction/DihedralHarmonicNCos.py
@@ -80,6 +80,7 @@ from espressopp.interaction.Interaction import *
 # pylint: disable=F0401
 from _espressopp import interaction_DihedralHarmonicNCos
 from _espressopp import interaction_FixedQuadrupleListDihedralHarmonicNCos
+from _espressopp import interaction_FixedQuadrupleListAdressDihedralHarmonicNCos
 from _espressopp import interaction_FixedQuadrupleListTypesDihedralHarmonicNCos
 
 
@@ -112,9 +113,21 @@ class FixedQuadrupleListDihedralHarmonicNCosLocal(
             or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup()):
             return self.cxxclass.getFixedQuadrupleList(self)
 
+class FixedQuadrupleListAdressDihedralHarmonicNCosLocal(
+    InteractionLocal, interaction_FixedQuadrupleListAdressDihedralHarmonicNCos):
+    'The (local) DihedralHarmonicNCos interaction using FixedQuadruple lists Adress.'
+    def __init__(self, system, fql, potential, is_cg=False):
+        if (not (pmi._PMIComm and pmi._PMIComm.isActive())
+                or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup()):
+            cxxinit(self,
+                    interaction_FixedQuadrupleListAdressDihedralHarmonicNCos,
+                    system,
+                    fql,
+                    potential,
+                    is_cg)
 
-class FixedQuadrupleListTypesDihedralHarmonicNCosLocal(InteractionLocal,
-                                                   interaction_FixedQuadrupleListTypesDihedralHarmonicNCos):
+
+class FixedQuadrupleListTypesDihedralHarmonicNCosLocal(InteractionLocal, interaction_FixedQuadrupleListTypesDihedralHarmonicNCos):
     def __init__(self, system, fql):
         if pmi.workerIsActive():
             cxxinit(self, interaction_FixedQuadrupleListTypesDihedralHarmonicNCos, system, fql)
@@ -146,4 +159,10 @@ if pmi.isController:
         pmiproxydefs = dict(
           cls =  'espressopp.interaction.FixedQuadrupleListTypesDihedralHarmonicNCosLocal',
           pmicall = ['setPotential','getPotential','setFixedQuadrupleList','getFixedQuadrupleList']
+        )
+
+    class FixedQuadrupleListAdressDihedralHarmonicNCos(Interaction, metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+          cls='espressopp.interaction.FixedQuadrupleListAdressDihedralHarmonicNCosLocal',
+          pmicall=['setPotential', 'getFixedQuadrupleList']
         )

--- a/src/interaction/DihedralHarmonicNCos.py
+++ b/src/interaction/DihedralHarmonicNCos.py
@@ -90,32 +90,37 @@ class DihedralHarmonicNCosLocal(DihedralPotentialLocal, interaction_DihedralHarm
 
         # pylint: disable=W0212
         if (not (pmi._PMIComm and pmi._PMIComm.isActive())
-            or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup()):
-            cxxinit(self, interaction_DihedralHarmonicNCos, K, phi0, multiplicity)
+                or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup()):
+            cxxinit(self, interaction_DihedralHarmonicNCos,
+                    K, phi0, multiplicity)
 
 
 class FixedQuadrupleListDihedralHarmonicNCosLocal(
-    InteractionLocal,
-    interaction_FixedQuadrupleListDihedralHarmonicNCos):
+        InteractionLocal,
+        interaction_FixedQuadrupleListDihedralHarmonicNCos):
     'The (local) DihedralHarmonicNCos interaction using FixedQuadruple lists.'
+
     def __init__(self, system, fql, potential):
         if (not (pmi._PMIComm and pmi._PMIComm.isActive())
-            or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup()):
-            cxxinit(self, interaction_FixedQuadrupleListDihedralHarmonicNCos, system, fql, potential)
+                or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup()):
+            cxxinit(self, interaction_FixedQuadrupleListDihedralHarmonicNCos,
+                    system, fql, potential)
 
     def setPotential(self, potential):
         if (not (pmi._PMIComm and pmi._PMIComm.isActive())
-            or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup()):
+                or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup()):
             self.cxxclass.setPotential(self, potential)
 
     def getFixedQuadrupleList(self):
         if (not (pmi._PMIComm and pmi._PMIComm.isActive())
-            or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup()):
+                or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup()):
             return self.cxxclass.getFixedQuadrupleList(self)
 
+
 class FixedQuadrupleListAdressDihedralHarmonicNCosLocal(
-    InteractionLocal, interaction_FixedQuadrupleListAdressDihedralHarmonicNCos):
+        InteractionLocal, interaction_FixedQuadrupleListAdressDihedralHarmonicNCos):
     'The (local) DihedralHarmonicNCos interaction using FixedQuadruple lists Adress.'
+
     def __init__(self, system, fql, potential, is_cg=False):
         if (not (pmi._PMIComm and pmi._PMIComm.isActive())
                 or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup()):
@@ -130,11 +135,13 @@ class FixedQuadrupleListAdressDihedralHarmonicNCosLocal(
 class FixedQuadrupleListTypesDihedralHarmonicNCosLocal(InteractionLocal, interaction_FixedQuadrupleListTypesDihedralHarmonicNCos):
     def __init__(self, system, fql):
         if pmi.workerIsActive():
-            cxxinit(self, interaction_FixedQuadrupleListTypesDihedralHarmonicNCos, system, fql)
+            cxxinit(
+                self, interaction_FixedQuadrupleListTypesDihedralHarmonicNCos, system, fql)
 
     def setPotential(self, type1, type2, type3, type4, potential):
         if pmi.workerIsActive():
-            self.cxxclass.setPotential(self, type1, type2, type3, type4, potential)
+            self.cxxclass.setPotential(
+                self, type1, type2, type3, type4, potential)
 
     def getPotential(self, type1, type2, type3, type4):
         if pmi.workerIsActive():
@@ -145,24 +152,25 @@ if pmi.isController:
     class DihedralHarmonicNCos(DihedralPotential):
         'The DihedralHarmonicNCos potential.'
         pmiproxydefs = dict(
-          cls='espressopp.interaction.DihedralHarmonicNCosLocal',
-          pmiproperty=['K', 'phi0', 'multiplicity']
+            cls='espressopp.interaction.DihedralHarmonicNCosLocal',
+            pmiproperty=['K', 'phi0', 'multiplicity']
         )
 
     class FixedQuadrupleListDihedralHarmonicNCos(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-          cls='espressopp.interaction.FixedQuadrupleListDihedralHarmonicNCosLocal',
-          pmicall=['setPotential', 'getFixedQuadrupleList']
+            cls='espressopp.interaction.FixedQuadrupleListDihedralHarmonicNCosLocal',
+            pmicall=['setPotential', 'getFixedQuadrupleList']
         )
 
     class FixedQuadrupleListTypesDihedralHarmonicNCos(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-          cls =  'espressopp.interaction.FixedQuadrupleListTypesDihedralHarmonicNCosLocal',
-          pmicall = ['setPotential','getPotential','setFixedQuadrupleList','getFixedQuadrupleList']
+            cls='espressopp.interaction.FixedQuadrupleListTypesDihedralHarmonicNCosLocal',
+            pmicall=['setPotential', 'getPotential',
+                     'setFixedQuadrupleList', 'getFixedQuadrupleList']
         )
 
     class FixedQuadrupleListAdressDihedralHarmonicNCos(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-          cls='espressopp.interaction.FixedQuadrupleListAdressDihedralHarmonicNCosLocal',
-          pmicall=['setPotential', 'getFixedQuadrupleList']
+            cls='espressopp.interaction.FixedQuadrupleListAdressDihedralHarmonicNCosLocal',
+            pmicall=['setPotential', 'getFixedQuadrupleList']
         )

--- a/src/interaction/FixedPairListAdressInteractionTemplate.hpp
+++ b/src/interaction/FixedPairListAdressInteractionTemplate.hpp
@@ -1,0 +1,365 @@
+/*
+  Copyright (c) 2015,
+      Jakub Krajniak (jkrajniak (at) gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// ESPP_CLASS
+#ifndef _INTERACTION_FIXEDPAIRLISTADRESSINTERACTIONTEMPLATE_HPP
+#define _INTERACTION_FIXEDPAIRLISTADRESSINTERACTIONTEMPLATE_HPP
+
+#include <algorithm>
+#include <functional>
+#include <vector>
+#include "mpi.hpp"
+#include "integrator/Adress.hpp"
+#include "Real3D.hpp"
+#include "Tensor.hpp"
+#include "Particle.hpp"
+#include "FixedPairList.hpp"
+#include "FixedPairListAdress.hpp"
+#include "esutil/Array2D.hpp"
+#include "bc/BC.hpp"
+#include "SystemAccess.hpp"
+#include "Interaction.hpp"
+#include "types.hpp"
+
+namespace espressopp
+{
+namespace interaction
+{
+template <typename _Potential>
+class FixedPairListAdressInteractionTemplate : public Interaction, SystemAccess
+{
+protected:
+    typedef _Potential Potential;
+
+public:
+    FixedPairListAdressInteractionTemplate(std::shared_ptr<System> system,
+                                           std::shared_ptr<FixedPairList> _fixedpairList,
+                                           std::shared_ptr<Potential> _potential,
+                                           bool _cgpotential)
+        : SystemAccess(system),
+          fixedpairList(_fixedpairList),
+          potential(_potential),
+          cgPotential(_cgpotential)
+    {
+        if (!potential)
+        {
+            LOG4ESPP_ERROR(theLogger, "NULL potential");
+        }
+        scaleFactor_ = 1.0;
+    }
+
+    virtual ~FixedPairListAdressInteractionTemplate() {}
+
+    void setFixedPairList(std::shared_ptr<FixedPairList> _fixedpairList)
+    {
+        fixedpairList = _fixedpairList;
+    }
+
+    std::shared_ptr<FixedPairList> getFixedPairList() { return fixedpairList; }
+
+    void setPotential(std::shared_ptr<Potential> _potential)
+    {
+        if (_potential)
+        {
+            potential = _potential;
+        }
+        else
+        {
+            LOG4ESPP_ERROR(theLogger, "NULL potential");
+        }
+    }
+
+    std::shared_ptr<Potential> getPotential() { return potential; }
+
+    void setScaleFactor(real s) { scaleFactor_ = s; }
+    real scaleFactor() { return scaleFactor_; }
+
+    virtual void addForces();
+    virtual real computeEnergy();
+    virtual real computeEnergyDeriv();
+    virtual real computeEnergyAA();
+    virtual real computeEnergyCG();
+    virtual real computeEnergyAA(int atomtype);
+    virtual real computeEnergyCG(int atomtype);
+    virtual void computeVirialX(std::vector<real> &p_xx_total, int bins);
+    virtual real computeVirial();
+    virtual void computeVirialTensor(Tensor &w);
+    virtual void computeVirialTensor(Tensor &w, real z);
+    virtual void computeVirialTensor(Tensor *w, int n);
+    virtual real getMaxCutoff();
+    virtual int bondType() { return Pair; }
+
+protected:
+    int ntypes;
+    std::shared_ptr<FixedPairList> fixedpairList;
+    std::shared_ptr<Potential> potential;
+    bool cgPotential;
+    real scaleFactor_;
+};
+
+//////////////////////////////////////////////////
+// INLINE IMPLEMENTATION
+//////////////////////////////////////////////////
+template <typename _Potential>
+inline void FixedPairListAdressInteractionTemplate<_Potential>::addForces()
+{
+    LOG4ESPP_INFO(_Potential::theLogger, "Adding forces of FixedPairListAdress");
+    const bc::BC &bc = *getSystemRef().bc;  // boundary conditions
+    real ltMaxBondSqr = fixedpairList->getLongtimeMaxBondSqr();
+    for (FixedPairList::PairList::Iterator it(*fixedpairList); it.isValid(); ++it)
+    {
+        Particle &p1 = *it->first;
+        Particle &p2 = *it->second;
+
+        Real3D dist;
+        bc.getMinimumImageVectorBox(dist, p1.position(), p2.position());
+        Real3D force;
+        real d = dist.sqr();
+        if (d > ltMaxBondSqr)
+        {
+            fixedpairList->setLongtimeMaxBondSqr(d);
+            ltMaxBondSqr = d;
+        }
+
+        // Scaling for the Adress extension. If this potential works between CG beads
+        // then the Force is scalded by (1-w12) otherwise it works across the beads,
+        // with scaling w12.
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0)) continue;
+
+        real w12 = p1lambda * p2lambda;
+        if (w12 < 0.0) w12 = 0.0;
+        real forcescale12 = w12;
+        if (cgPotential)
+        {
+            forcescale12 = (1 - w12);
+        }
+
+        forcescale12 *= scaleFactor_;
+
+        if (!isAlmostZero(forcescale12))
+        {
+            if (potential->_computeForce(force, dist))
+            {
+                p1.force() += forcescale12 * force;
+                p2.force() -= forcescale12 * force;
+            }
+        }
+    }
+}
+
+template <typename _Potential>
+inline real FixedPairListAdressInteractionTemplate<_Potential>::computeEnergy()
+{
+    LOG4ESPP_INFO(theLogger, "compute energy of the FixedPairListAdress pairs");
+
+    real e_local = 0.0;
+    const bc::BC &bc = *getSystemRef().bc;  // boundary conditions
+    for (FixedPairList::PairList::Iterator it(*fixedpairList); it.isValid(); ++it)
+    {
+        const Particle &p1 = *it->first;
+        const Particle &p2 = *it->second;
+
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0)) continue;
+
+        real w12 = p1lambda * p2lambda;
+        if (w12 < 0.0) w12 = 0.0;
+        real energyscale12 = w12;
+        if (cgPotential) energyscale12 = 1.0 - w12;
+
+        energyscale12 *= scaleFactor_;
+
+        if (!isAlmostZero(energyscale12))
+        {
+            Real3D r21;
+            bc.getMinimumImageVectorBox(r21, p1.position(), p2.position());
+            e_local += energyscale12 * potential->_computeEnergy(r21);
+        }
+    }
+    real esum = 0.0;
+    boost::mpi::all_reduce(*mpiWorld, e_local, esum, std::plus<real>());
+    return esum;
+}
+
+template <typename _Potential>
+inline real FixedPairListAdressInteractionTemplate<_Potential>::computeEnergyDeriv()
+{
+    std::cout << "Warning! At the moment computeEnergyDeriv() in "
+                 "FixedPairListAdressInteractionTemplate does not work."
+              << std::endl;
+    return 0.0;
+}
+
+template <typename _Potential>
+inline real FixedPairListAdressInteractionTemplate<_Potential>::computeEnergyAA()
+{
+    if (!cgPotential) return computeEnergy();
+    return 0.0;
+}
+
+template <typename _Potential>
+inline real FixedPairListAdressInteractionTemplate<_Potential>::computeEnergyCG()
+{
+    if (cgPotential) return computeEnergy();
+    return 0.0;
+}
+
+template <typename _Potential>
+inline real FixedPairListAdressInteractionTemplate<_Potential>::computeEnergyAA(int atomtype)
+{
+    std::cout << "Warning! At the moment computeEnergyAA() in "
+                 "FixedPairListAdressInteractionTemplate does not work."
+              << std::endl;
+    return 0.0;
+}
+
+template <typename _Potential>
+inline real FixedPairListAdressInteractionTemplate<_Potential>::computeEnergyCG(int atomtype)
+{
+    std::cout << "Warning! At the moment computeEnergyCG() in "
+                 "FixedPairListAdressInteractionTemplate does not work."
+              << std::endl;
+    return 0.0;
+}
+
+template <typename _Potential>
+inline void FixedPairListAdressInteractionTemplate<_Potential>::computeVirialX(
+    std::vector<real> &p_xx_total, int bins)
+{
+    std::cout << "Warning! At the moment computeVirialX() in "
+              << "FixedPairListAdressInteractionTemplate does not work." << std::endl;
+}
+
+template <typename _Potential>
+inline real FixedPairListAdressInteractionTemplate<_Potential>::computeVirial()
+{
+    LOG4ESPP_INFO(theLogger, "compute the virial for the FixedPair List");
+
+    real w_virial = 0.0;
+    const bc::BC &bc = *getSystemRef().bc;  // boundary conditions
+    for (FixedPairList::PairList::Iterator it(*fixedpairList); it.isValid(); ++it)
+    {
+        const Particle &p1 = *it->first;
+        const Particle &p2 = *it->second;
+
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0)) continue;
+
+        real w12 = p1lambda * p2lambda;
+        if (w12 < 0.0) w12 = 0.0;
+        real forcescale = w12;
+        if (cgPotential)
+        {
+            forcescale = (1.0 - w12);
+        }
+
+        forcescale *= scaleFactor_;
+
+        if (!isAlmostZero(forcescale))
+        {
+            Real3D r21;
+            bc.getMinimumImageVectorBox(r21, p1.position(), p2.position());
+            Real3D force;
+            if (potential->_computeForce(force, r21))
+            {
+                w_virial += r21 * forcescale * force;
+            }
+        }
+    }
+
+    real wsum;
+    boost::mpi::all_reduce(*mpiWorld, w_virial, wsum, std::plus<real>());
+    return wsum;
+}
+
+template <typename _Potential>
+inline void FixedPairListAdressInteractionTemplate<_Potential>::computeVirialTensor(Tensor &w)
+{
+    LOG4ESPP_INFO(theLogger, "compute the virial tensor for the FixedPair List");
+
+    Tensor w_wlocal = 0.0;
+    const bc::BC &bc = *getSystemRef().bc;  // boundary conditions
+    for (FixedPairList::PairList::Iterator it(*fixedpairList); it.isValid(); ++it)
+    {
+        const Particle &p1 = *it->first;
+        const Particle &p2 = *it->second;
+
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0)) continue;
+
+        real w12 = p1lambda * p2lambda;
+        if (w12 < 0.0) w12 = 0.0;
+        real forcescale = w12;
+        if (cgPotential)
+        {
+            forcescale = (1.0 - w12);
+        }
+
+        forcescale *= scaleFactor_;
+
+        if (!isAlmostZero(forcescale))
+        {
+            Real3D r21;
+            bc.getMinimumImageVectorBox(r21, p1.position(), p2.position());
+            Real3D force;
+            if (potential->_computeForce(force, r21))
+            {
+                w_wlocal += Tensor(r21, forcescale * force);
+            }
+        }
+    }
+
+    // reduce over all CPUs
+    Tensor wsum(0.0);
+    boost::mpi::all_reduce(*mpiWorld, reinterpret_cast<double *>(&w_wlocal), 6,
+                           reinterpret_cast<double *>(&wsum), std::plus<double>());
+    w += wsum;
+}
+
+template <typename _Potential>
+inline void FixedPairListAdressInteractionTemplate<_Potential>::computeVirialTensor(Tensor &w,
+                                                                                    real z)
+{
+    LOG4ESPP_ERROR(theLogger,
+                   "compute the virial tensor for the FixedPair List Adress not implemented");
+}
+
+template <typename _Potential>
+inline void FixedPairListAdressInteractionTemplate<_Potential>::computeVirialTensor(Tensor *w,
+                                                                                    int n)
+{
+    LOG4ESPP_INFO(theLogger,
+                  "compute the virial tensor for the FixedPair List Adress not implemented");
+}
+
+template <typename _Potential>
+inline real FixedPairListAdressInteractionTemplate<_Potential>::getMaxCutoff()
+{
+    return potential->getCutoff();
+}
+
+}  // end namespace interaction
+}  // end namespace espressopp
+#endif

--- a/src/interaction/FixedQuadrupleListAdressInteractionTemplate.hpp
+++ b/src/interaction/FixedQuadrupleListAdressInteractionTemplate.hpp
@@ -49,10 +49,11 @@ protected:
     typedef _DihedralPotential Potential;
 
 public:
-    FixedQuadrupleListAdressInteractionTemplate(std::shared_ptr<System> _system,
-                                                std::shared_ptr<FixedQuadrupleList> _fixedquadrupleList,
-                                                std::shared_ptr<Potential> _potential,
-                                                bool _cgPotential)
+    FixedQuadrupleListAdressInteractionTemplate(
+        std::shared_ptr<System> _system,
+        std::shared_ptr<FixedQuadrupleList> _fixedquadrupleList,
+        std::shared_ptr<Potential> _potential,
+        bool _cgPotential)
         : SystemAccess(_system),
           fixedquadrupleList(_fixedquadrupleList),
           potential(_potential),

--- a/src/interaction/FixedQuadrupleListAdressInteractionTemplate.hpp
+++ b/src/interaction/FixedQuadrupleListAdressInteractionTemplate.hpp
@@ -1,0 +1,348 @@
+/*
+  Copyright (c) 2015
+      Jakub Krajniak (jkrajniak at gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// ESPP_CLASS
+#ifndef _INTERACTION_FIXEDQUADRUPLELISTADRESSINTERACTIONTEMPLATE_HPP
+#define _INTERACTION_FIXEDQUADRUPLELISTADRESSINTERACTIONTEMPLATE_HPP
+
+#include <functional>
+#include <vector>
+
+#include "mpi.hpp"
+#include "integrator/Adress.hpp"
+#include "Interaction.hpp"
+#include "Real3D.hpp"
+#include "Tensor.hpp"
+#include "Particle.hpp"
+#include "FixedQuadrupleList.hpp"
+#include "FixedQuadrupleListAdress.hpp"
+#include "esutil/Array2D.hpp"
+#include "bc/BC.hpp"
+#include "SystemAccess.hpp"
+#include "types.hpp"
+
+namespace espressopp
+{
+namespace interaction
+{
+template <typename _DihedralPotential>
+class FixedQuadrupleListAdressInteractionTemplate : public Interaction, SystemAccess
+{
+protected:
+    typedef _DihedralPotential Potential;
+
+public:
+    FixedQuadrupleListAdressInteractionTemplate(std::shared_ptr<System> _system,
+                                                std::shared_ptr<FixedQuadrupleList> _fixedquadrupleList,
+                                                std::shared_ptr<Potential> _potential,
+                                                bool _cgPotential)
+        : SystemAccess(_system),
+          fixedquadrupleList(_fixedquadrupleList),
+          potential(_potential),
+          cgPotential(_cgPotential)
+    {
+        if (!potential)
+        {
+            LOG4ESPP_ERROR(theLogger, "FixedQuadrupleListAdressInteraction potential");
+        }
+    }
+
+    void setFixedQuadrupleList(std::shared_ptr<FixedQuadrupleList> _fixedquadrupleList)
+    {
+        fixedquadrupleList = _fixedquadrupleList;
+    }
+
+    virtual ~FixedQuadrupleListAdressInteractionTemplate() {}
+
+    std::shared_ptr<FixedQuadrupleList> getFixedQuadrupleList() { return fixedquadrupleList; }
+
+    void setPotential(std::shared_ptr<Potential> _potential)
+    {
+        if (_potential)
+        {
+            potential = _potential;
+        }
+        else
+        {
+            LOG4ESPP_ERROR(theLogger, "NULL potential");
+        }
+    }
+
+    std::shared_ptr<Potential> getPotential() { return potential; }
+
+    virtual void addForces();
+    virtual real computeEnergy();
+    virtual real computeEnergyDeriv();
+    virtual real computeEnergyAA();
+    virtual real computeEnergyCG();
+    virtual real computeEnergyAA(int atomtype);
+    virtual real computeEnergyCG(int atomtype);
+    virtual void computeVirialX(std::vector<real> &p_xx_total, int bins);
+    virtual real computeVirial();
+    virtual void computeVirialTensor(Tensor &w);
+    virtual void computeVirialTensor(Tensor &w, real z);
+    virtual void computeVirialTensor(Tensor *w, int n);
+    virtual real getMaxCutoff();
+    virtual int bondType() { return Dihedral; }
+
+protected:
+    int ntypes;
+    std::shared_ptr<FixedQuadrupleList> fixedquadrupleList;
+    std::shared_ptr<Potential> potential;
+    bool cgPotential;
+};
+
+/** Inline implementation */
+template <typename _DihedralPotential>
+inline void FixedQuadrupleListAdressInteractionTemplate<_DihedralPotential>::addForces()
+{
+    LOG4ESPP_INFO(theLogger, "add forces computed by FixedQuadrupleList");
+
+    const bc::BC &bc = *getSystemRef().bc;  // boundary conditions
+
+    for (FixedQuadrupleList::QuadrupleList::Iterator it(*fixedquadrupleList); it.isValid(); ++it)
+    {
+        Particle &p1 = *it->first;
+        Particle &p2 = *it->second;
+        Particle &p3 = *it->third;
+        Particle &p4 = *it->fourth;
+
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        real p3lambda = p3.lambda();
+        real p4lambda = p4.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0 || p3lambda < 0.0 || p4lambda < 0.0))
+            continue;
+
+        real w1234 = pow(p1lambda * p2lambda * p3lambda * p4lambda, 0.5);
+        if (w1234 < 0.0) w1234 = 0.0;
+        real forcescale1234 = w1234;
+        if (cgPotential)
+        {
+            forcescale1234 = (1.0 - w1234);
+        }
+
+        if (!isAlmostZero(forcescale1234))
+        {
+            LOG4ESPP_DEBUG(theLogger,
+                           "scalling quadruple list force with weight " << forcescale1234);
+            Real3D dist21, dist32, dist43;
+
+            bc.getMinimumImageVectorBox(dist21, p2.position(), p1.position());
+            bc.getMinimumImageVectorBox(dist32, p3.position(), p2.position());
+            bc.getMinimumImageVectorBox(dist43, p4.position(), p3.position());
+
+            Real3D force1, force2, force3, force4;  // result forces
+
+            potential->_computeForce(force1, force2, force3, force4, dist21, dist32, dist43);
+            p1.force() += forcescale1234 * force1;
+            p2.force() += forcescale1234 * force2;
+            p3.force() += forcescale1234 * force3;
+            p4.force() += forcescale1234 * force4;
+        }
+    }
+}
+
+template <typename _DihedralPotential>
+inline real FixedQuadrupleListAdressInteractionTemplate<_DihedralPotential>::computeEnergy()
+{
+    LOG4ESPP_INFO(theLogger, "compute energy of the quadruples");
+
+    const bc::BC &bc = *getSystemRef().bc;  // boundary conditions
+    real e = 0.0;
+    for (FixedQuadrupleList::QuadrupleList::Iterator it(*fixedquadrupleList); it.isValid(); ++it)
+    {
+        const Particle &p1 = *it->first;
+        const Particle &p2 = *it->second;
+        const Particle &p3 = *it->third;
+        const Particle &p4 = *it->fourth;
+
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        real p3lambda = p3.lambda();
+        real p4lambda = p4.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0 || p3lambda < 0.0 || p4lambda < 0.0))
+            continue;
+
+        real w1234 = pow(p1lambda * p2lambda * p3lambda * p4lambda, 0.5);
+        if (w1234 < 0.0) w1234 = 0.0;
+        real forcescale1234 = w1234;
+        if (cgPotential)
+        {
+            forcescale1234 = (1.0 - w1234);
+        }
+
+        if (!isAlmostZero(forcescale1234))
+        {
+            Real3D dist21, dist32, dist43;
+
+            bc.getMinimumImageVectorBox(dist21, p2.position(), p1.position());
+            bc.getMinimumImageVectorBox(dist32, p3.position(), p2.position());
+            bc.getMinimumImageVectorBox(dist43, p4.position(), p3.position());
+
+            e += forcescale1234 * potential->_computeEnergy(dist21, dist32, dist43);
+        }
+    }
+    real esum;
+    boost::mpi::all_reduce(*mpiWorld, e, esum, std::plus<real>());
+    return esum;
+}
+
+template <typename _Potential>
+inline real FixedQuadrupleListAdressInteractionTemplate<_Potential>::computeEnergyDeriv()
+{
+    std::cout << "Warning! At the moment computeEnergyDeriv() in "
+                 "FixedQuadrupleListAdressInteractionTemplate does not work."
+              << std::endl;
+    return 0.0;
+}
+
+template <typename _DihedralPotential>
+inline real FixedQuadrupleListAdressInteractionTemplate<_DihedralPotential>::computeEnergyAA()
+{
+    if (!cgPotential) return computeEnergy();
+    return 0.0;
+}
+
+template <typename _DihedralPotential>
+inline real FixedQuadrupleListAdressInteractionTemplate<_DihedralPotential>::computeEnergyCG()
+{
+    if (cgPotential) return computeEnergy();
+    return 0.0;
+}
+
+template <typename _Potential>
+inline real FixedQuadrupleListAdressInteractionTemplate<_Potential>::computeEnergyAA(int atomtype)
+{
+    std::cout << "Warning! At the moment computeEnergyAA() in "
+                 "FixedQuadrupleListAdressInteractionTemplate does not work."
+              << std::endl;
+    return 0.0;
+}
+
+template <typename _Potential>
+inline real FixedQuadrupleListAdressInteractionTemplate<_Potential>::computeEnergyCG(int atomtype)
+{
+    std::cout << "Warning! At the moment computeEnergyCG() in "
+                 "FixedQuadrupleListAdressInteractionTemplate does not work."
+              << std::endl;
+    return 0.0;
+}
+
+template <typename _DihedralPotential>
+inline void FixedQuadrupleListAdressInteractionTemplate<_DihedralPotential>::computeVirialX(
+    std::vector<real> &p_xx_total, int bins)
+{
+    std::cout << "Warning! At the moment computeVirialX in ";
+    std::cout << "FixedQuadrupleListAdressInteractionTemplate does not work." << std::endl
+              << "Therefore, the corresponding interactions won't be included in calculation."
+              << std::endl;
+}
+
+template <typename _DihedralPotential>
+inline real FixedQuadrupleListAdressInteractionTemplate<_DihedralPotential>::computeVirial()
+{
+    LOG4ESPP_INFO(theLogger, "compute scalar virial of the quadruples");
+
+    real w = 0.0;
+    const bc::BC &bc = *getSystemRef().bc;  // boundary conditions
+    for (FixedQuadrupleList::QuadrupleList::Iterator it(*fixedquadrupleList); it.isValid(); ++it)
+    {
+        const Particle &p1 = *it->first;
+        const Particle &p2 = *it->second;
+        const Particle &p3 = *it->third;
+        const Particle &p4 = *it->fourth;
+
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        real p3lambda = p3.lambda();
+        real p4lambda = p4.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0 || p3lambda < 0.0 || p4lambda < 0.0))
+            continue;
+
+        real w1234 = pow(p1lambda * p2lambda * p3lambda * p4lambda, 0.5);
+        if (w1234 < 0.0) w1234 = 0.0;
+        real forcescale1234 = w1234;
+        if (cgPotential)
+        {
+            forcescale1234 = (1.0 - w1234);
+        }
+
+        if (!isAlmostZero(forcescale1234))
+        {
+            Real3D dist21, dist32, dist43;
+
+            bc.getMinimumImageVectorBox(dist21, p2.position(), p1.position());
+            bc.getMinimumImageVectorBox(dist32, p3.position(), p2.position());
+            bc.getMinimumImageVectorBox(dist43, p4.position(), p3.position());
+
+            Real3D force1, force2, force3, force4;
+
+            potential->_computeForce(force1, force2, force3, force4, dist21, dist32, dist43);
+
+            w += dist21 * force1 + dist32 * force2;
+        }
+    }
+
+    real wsum;
+    boost::mpi::all_reduce(*mpiWorld, w, wsum, std::plus<real>());
+    return w;
+}
+
+template <typename _DihedralPotential>
+inline void FixedQuadrupleListAdressInteractionTemplate<_DihedralPotential>::computeVirialTensor(
+    Tensor &w)
+{
+    LOG4ESPP_INFO(theLogger, "compute the virial tensor of the quadruples");
+
+    std::cout << "Warning!!! computeVirialTensor in specified volume doesn't work for "
+                 "FixedQuadrupleListAdressInteractionTemplate at the moment"
+              << std::endl;
+}
+
+template <typename _DihedralPotential>
+inline void FixedQuadrupleListAdressInteractionTemplate<_DihedralPotential>::computeVirialTensor(
+    Tensor &w, real z)
+{
+    LOG4ESPP_INFO(theLogger, "compute the virial tensor of the quadruples");
+
+    std::cout << "Warning!!! computeVirialTensor in "
+              << "specified volume doesn't work for "
+              << "FixedQuadrupleListAdressInteractionTemplate at the moment" << std::endl;
+}
+
+template <typename _DihedralPotential>
+inline void FixedQuadrupleListAdressInteractionTemplate<_DihedralPotential>::computeVirialTensor(
+    Tensor *w, int n)
+{
+    std::cout << "Warning!!! computeVirialTensor in specified volume doesn't work for "
+                 "FixedQuadrupleListAdressInteractionTemplate at the moment"
+              << std::endl;
+}
+
+template <typename _DihedralPotential>
+inline real FixedQuadrupleListAdressInteractionTemplate<_DihedralPotential>::getMaxCutoff()
+{
+    return potential->getCutoff();
+}
+
+}  // end namespace interaction
+}  // end namespace espressopp
+#endif

--- a/src/interaction/FixedTripleListAdressInteractionTemplate.hpp
+++ b/src/interaction/FixedTripleListAdressInteractionTemplate.hpp
@@ -1,0 +1,358 @@
+/*
+  Copyright (C) 2015-2016
+      Jakub Krajniak (jkrajniak at gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// ESPP_CLASS
+#ifndef _INTERACTION_FIXEDTRIPLELISTADRESSINTERACTIONTEMPLATE_HPP
+#define _INTERACTION_FIXEDTRIPLELISTADRESSINTERACTIONTEMPLATE_HPP
+
+#include <functional>
+#include <vector>
+
+#include "mpi.hpp"
+#include "Interaction.hpp"
+#include "Real3D.hpp"
+#include "Tensor.hpp"
+#include "Particle.hpp"
+#include "FixedTripleList.hpp"
+#include "integrator/Adress.hpp"
+#include "FixedTripleListAdress.hpp"
+#include "esutil/Array2D.hpp"
+#include "bc/BC.hpp"
+#include "SystemAccess.hpp"
+#include "types.hpp"
+
+namespace espressopp
+{
+namespace interaction
+{
+template <typename _AngularPotential>
+class FixedTripleListAdressInteractionTemplate : public Interaction, SystemAccess
+{
+protected:
+    typedef _AngularPotential Potential;
+
+public:
+    FixedTripleListAdressInteractionTemplate(std::shared_ptr<System> _system,
+                                             std::shared_ptr<FixedTripleList> _fixedtripleList,
+                                             std::shared_ptr<Potential> _potential,
+                                             bool _cg_potential)
+        : SystemAccess(_system),
+          fixedtripleList(_fixedtripleList),
+          potential(_potential),
+          cgPotential(_cg_potential)
+    {
+        if (!potential)
+        {
+            LOG4ESPP_ERROR(theLogger, "NULL potential");
+        }
+    }
+
+    virtual ~FixedTripleListAdressInteractionTemplate() {}
+
+    void setFixedTripleList(std::shared_ptr<FixedTripleList> _fixedtripleList)
+    {
+        fixedtripleList = _fixedtripleList;
+    }
+
+    std::shared_ptr<FixedTripleList> getFixedTripleList() { return fixedtripleList; }
+
+    void setPotential(std::shared_ptr<Potential> _potential)
+    {
+        if (_potential)
+        {
+            potential = _potential;
+        }
+        else
+        {
+            LOG4ESPP_ERROR(theLogger, "NULL potential");
+        }
+    }
+
+    std::shared_ptr<Potential> getPotential() { return potential; }
+
+    virtual void addForces();
+    virtual real computeEnergy();
+    virtual real computeEnergyDeriv();
+    virtual real computeEnergyAA();
+    virtual real computeEnergyCG();
+    virtual real computeEnergyAA(int atomtype);
+    virtual real computeEnergyCG(int atomtype);
+    virtual void computeVirialX(std::vector<real> &p_xx_total, int bins);
+    virtual real computeVirial();
+    virtual void computeVirialTensor(Tensor &w);
+    virtual void computeVirialTensor(Tensor &w, real z);
+    virtual void computeVirialTensor(Tensor *w, int n);
+    virtual real getMaxCutoff();
+    virtual int bondType() { return Angular; }
+
+protected:
+    int ntypes;
+    std::shared_ptr<FixedTripleList> fixedtripleList;
+    std::shared_ptr<Potential> potential;
+    bool cgPotential;
+};
+
+//////////////////////////////////////////////////
+// INLINE IMPLEMENTATION
+//////////////////////////////////////////////////
+template <typename _AngularPotential>
+inline void FixedTripleListAdressInteractionTemplate<_AngularPotential>::addForces()
+{
+    LOG4ESPP_INFO(theLogger, "add forces computed by FixedTripleList");
+    const bc::BC &bc = *getSystemRef().bc;  // boundary conditions
+    for (FixedTripleList::TripleList::Iterator it(*fixedtripleList); it.isValid(); ++it)
+    {
+        Particle &p1 = *it->first;
+        Particle &p2 = *it->second;
+        Particle &p3 = *it->third;
+
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        real p3lambda = p3.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0 || p3lambda < 0.0)) continue;
+
+        real w123 = pow(p1lambda * p2lambda * p3lambda, 2.0 / 3.0);
+        if (w123 < 0.0) w123 = 0.0;
+        real forcescale123 = w123;
+        if (cgPotential)
+        {
+            forcescale123 = (1.0 - w123);
+        }
+
+        if (!isAlmostZero(forcescale123))
+        {
+            LOG4ESPP_DEBUG(theLogger,
+                           "scalling triple list potential with weight: " << forcescale123);
+            Real3D dist12, dist32;
+            bc.getMinimumImageVectorBox(dist12, p1.position(), p2.position());
+            bc.getMinimumImageVectorBox(dist32, p3.position(), p2.position());
+            Real3D force12, force32;
+
+            potential->_computeForce(force12, force32, dist12, dist32);
+
+            p1.force() += forcescale123 * force12;
+            p2.force() -= forcescale123 * force12 + forcescale123 * force32;
+            p3.force() += forcescale123 * force32;
+        }
+    }
+}
+
+template <typename _AngularPotential>
+inline real FixedTripleListAdressInteractionTemplate<_AngularPotential>::computeEnergy()
+{
+    LOG4ESPP_INFO(theLogger, "compute energy of the triples");
+
+    const bc::BC &bc = *getSystemRef().bc;
+    real e = 0.0;
+    for (FixedTripleList::TripleList::Iterator it(*fixedtripleList); it.isValid(); ++it)
+    {
+        const Particle &p1 = *it->first;
+        const Particle &p2 = *it->second;
+        const Particle &p3 = *it->third;
+
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        real p3lambda = p3.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0 || p3lambda < 0.0)) continue;
+
+        real w123 = pow(p1lambda * p2lambda * p3lambda, 2.0 / 3.0);
+        if (w123 < 0.0) w123 = 0.0;
+        real energyscale123 = w123;
+        if (cgPotential)
+        {
+            energyscale123 = (1.0 - w123);
+        }
+        if (!isAlmostZero(energyscale123))
+        {
+            Real3D dist12 = bc.getMinimumImageVector(p1.position(), p2.position());
+            Real3D dist32 = bc.getMinimumImageVector(p3.position(), p2.position());
+            e += energyscale123 * potential->_computeEnergy(dist12, dist32);
+        }
+    }
+    real esum = 0.0;
+    boost::mpi::all_reduce(*mpiWorld, e, esum, std::plus<real>());
+    return esum;
+}
+
+template <typename _Potential>
+inline real FixedTripleListAdressInteractionTemplate<_Potential>::computeEnergyDeriv()
+{
+    std::cout << "Warning! At the moment computeEnergyDeriv() in "
+                 "FixedTripleListAdressInteractionTemplate does not work."
+              << std::endl;
+    return 0.0;
+}
+
+template <typename _AngularPotential>
+inline real FixedTripleListAdressInteractionTemplate<_AngularPotential>::computeEnergyAA()
+{
+    std::cout << "Warning! At the moment computeEnergyAA() in ";
+    std::cout << "FixedTripleListAdressInteractionTemplate does not work." << std::endl;
+    return 0.0;
+}
+
+template <typename _AngularPotential>
+inline real FixedTripleListAdressInteractionTemplate<_AngularPotential>::computeEnergyCG()
+{
+    std::cout << "Warning! At the moment computeEnergyCG() in ";
+    std::cout << "FixedTripleListAdressInteractionTemplate does not work." << std::endl;
+    return 0.0;
+}
+
+template <typename _Potential>
+inline real FixedTripleListAdressInteractionTemplate<_Potential>::computeEnergyAA(int atomtype)
+{
+    std::cout << "Warning! At the moment computeEnergyAA() in "
+                 "FixedTripleListAdressInteractionTemplate does not work."
+              << std::endl;
+    return 0.0;
+}
+
+template <typename _Potential>
+inline real FixedTripleListAdressInteractionTemplate<_Potential>::computeEnergyCG(int atomtype)
+{
+    std::cout << "Warning! At the moment computeEnergyCG() in "
+                 "FixedTripleListAdressInteractionTemplate does not work."
+              << std::endl;
+    return 0.0;
+}
+
+template <typename _AngularPotential>
+inline void FixedTripleListAdressInteractionTemplate<_AngularPotential>::computeVirialX(
+    std::vector<real> &p_xx_total, int bins)
+{
+    std::cout << "Warning! At the moment computeVirialX in "
+              << "FixedTripleListAdressInteractionTemplate does not work." << std::endl
+              << "Therefore, the corresponding interactions won't be included in calculation."
+              << std::endl;
+}
+
+template <typename _AngularPotential>
+inline real FixedTripleListAdressInteractionTemplate<_AngularPotential>::computeVirial()
+{
+    LOG4ESPP_INFO(theLogger, "compute scalar virial of the triples");
+
+    const bc::BC &bc = *getSystemRef().bc;
+    real w = 0.0;
+    for (FixedTripleList::TripleList::Iterator it(*fixedtripleList); it.isValid(); ++it)
+    {
+        const Particle &p1 = *it->first;
+        const Particle &p2 = *it->second;
+        const Particle &p3 = *it->third;
+
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        real p3lambda = p3.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0 || p3lambda < 0.0)) continue;
+
+        real w123 = pow(p1lambda * p2lambda * p3lambda, 2.0 / 3.0);
+        if (w123 < 0.0) w123 = 0.0;
+        real forcescale123 = w123;
+        if (cgPotential)
+        {
+            forcescale123 = (1.0 - w123);
+        }
+        if (!isAlmostZero(forcescale123))
+        {
+            Real3D dist12, dist32;
+            bc.getMinimumImageVectorBox(dist12, p1.position(), p2.position());
+            bc.getMinimumImageVectorBox(dist32, p3.position(), p2.position());
+            Real3D force12, force32;
+            potential->_computeForce(force12, force32, dist12, dist32);
+            w += dist12 * force12 + dist32 * force32;
+        }
+    }
+    real wsum;
+    boost::mpi::all_reduce(*mpiWorld, w, wsum, std::plus<real>());
+    return wsum;
+}
+
+template <typename _AngularPotential>
+inline void FixedTripleListAdressInteractionTemplate<_AngularPotential>::computeVirialTensor(
+    Tensor &w)
+{
+    LOG4ESPP_INFO(theLogger, "compute the virial tensor of the triples");
+
+    Tensor wlocal(0.0);
+    const bc::BC &bc = *getSystemRef().bc;
+    for (FixedTripleList::TripleList::Iterator it(*fixedtripleList); it.isValid(); ++it)
+    {
+        const Particle &p1 = *it->first;
+        const Particle &p2 = *it->second;
+        const Particle &p3 = *it->third;
+
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        real p3lambda = p3.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0 || p3lambda < 0.0)) continue;
+
+        real w123 = pow(p1lambda * p2lambda * p3lambda, 2.0 / 3.0);
+        if (w123 < 0.0) w123 = 0.0;
+        real forcescale123 = w123;
+        if (cgPotential)
+        {
+            forcescale123 = (1.0 - w123);
+        }
+        if (!isAlmostZero(forcescale123))
+        {
+            Real3D r12, r32;
+            bc.getMinimumImageVectorBox(r12, p1.position(), p2.position());
+            bc.getMinimumImageVectorBox(r32, p3.position(), p2.position());
+            Real3D force12, force32;
+            potential->_computeForce(force12, force32, r12, r32);
+            wlocal += Tensor(r12, force12) + Tensor(r32, force32);
+        }
+    }
+
+    // reduce over all CPUs
+    Tensor wsum(0.0);
+    boost::mpi::all_reduce(*mpiWorld, reinterpret_cast<double *>(&wlocal), 6,
+                           reinterpret_cast<double *>(&wsum), std::plus<double>());
+    w += wsum;
+}
+
+template <typename _AngularPotential>
+inline void FixedTripleListAdressInteractionTemplate<_AngularPotential>::computeVirialTensor(
+    Tensor &w, real z)
+{
+    LOG4ESPP_INFO(theLogger, "compute the virial tensor of the triples");
+
+    std::cout << "Warning! At the moment IK computeVirialTensor "
+              << "for fixed triples does'n work" << std::endl;
+}
+
+template <typename _AngularPotential>
+inline void FixedTripleListAdressInteractionTemplate<_AngularPotential>::computeVirialTensor(
+    Tensor *w, int n)
+{
+    LOG4ESPP_INFO(theLogger, "compute the virial tensor of the triples");
+
+    std::cout << "Warning! At the moment IK computeVirialTensor "
+              << "for fixed triples does'n work" << std::endl;
+}
+
+template <typename _AngularPotential>
+inline real FixedTripleListAdressInteractionTemplate<_AngularPotential>::getMaxCutoff()
+{
+    return potential->getCutoff();
+}
+}  // namespace interaction
+}  // namespace espressopp
+#endif

--- a/src/interaction/Harmonic.cpp
+++ b/src/interaction/Harmonic.cpp
@@ -29,6 +29,7 @@
 #include "VerletListAdressCGInteractionTemplate.hpp"
 #include "VerletListHadressATInteractionTemplate.hpp"
 #include "VerletListHadressCGInteractionTemplate.hpp"
+#include "FixedPairListAdressInteractionTemplate.hpp"
 
 namespace espressopp
 {
@@ -53,6 +54,7 @@ void Harmonic::registerPython()
     typedef class VerletListAdressATInteractionTemplate<Harmonic> VerletListAdressATHarmonic;
     typedef class VerletListAdressCGInteractionTemplate<Harmonic> VerletListAdressCGHarmonic;
     typedef class VerletListInteractionTemplate<Harmonic> VerletListHarmonic;
+    typedef class FixedPairListAdressInteractionTemplate<Harmonic> FixedPairListAdressHarmonic;
 
     class_<FixedPairListHarmonic, bases<Interaction> >(
         "interaction_FixedPairListHarmonic",
@@ -106,6 +108,18 @@ void Harmonic::registerPython()
         .def("getVerletList", &VerletListHadressCGHarmonic::getVerletList)
         .def("setPotential", &VerletListHadressCGHarmonic::setPotential)
         .def("getPotential", &VerletListHadressCGHarmonic::getPotentialPtr);
+
+    class_<FixedPairListAdressHarmonic, bases<Interaction> >(
+        "interaction_FixedPairListAdressHarmonic",
+        init<shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<Harmonic>, bool>())
+        .def(
+            init<shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<Harmonic>, bool>())
+        .def("setPotential", &FixedPairListAdressHarmonic::setPotential)
+        .def("getPotential", &FixedPairListAdressHarmonic::getPotential)
+        .def("setFixedPairList", &FixedPairListAdressHarmonic::setFixedPairList)
+        .def("getFixedPairList", &FixedPairListAdressHarmonic::getFixedPairList)
+        .add_property("scale_factor", &FixedPairListAdressHarmonic::scaleFactor,
+                      &FixedPairListAdressHarmonic::setScaleFactor);
 }
 
 }  // namespace interaction

--- a/src/interaction/Harmonic.py
+++ b/src/interaction/Harmonic.py
@@ -297,7 +297,8 @@ from _espressopp import interaction_Harmonic, interaction_FixedPairListHarmonic,
                       interaction_VerletListAdressCGHarmonic, \
                       interaction_VerletListHadressATHarmonic, \
                       interaction_VerletListHadressCGHarmonic, \
-                      interaction_VerletListHarmonic
+                      interaction_VerletListHarmonic, \
+                      interaction_FixedPairListAdressHarmonic
 
 class HarmonicLocal(PotentialLocal, interaction_Harmonic):
 
@@ -435,6 +436,20 @@ class VerletListHarmonicLocal(InteractionLocal, interaction_VerletListHarmonic):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getPotential(self, type1, type2)
 
+class FixedPairListAdressHarmonicLocal(InteractionLocal, interaction_FixedPairListAdressHarmonic):
+    'The (local) Harmonic interaction using FixedPair lists.'
+    def __init__(self, system, vl, potential, is_cg=False):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            cxxinit(self, interaction_FixedPairListAdressHarmonic, system, vl, potential, is_cg)
+
+    def setPotential(self, potential):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            self.cxxclass.setPotential(self, potential)
+
+    def setFixedPairList(self, fixedpairlist):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            self.cxxclass.setFixedPairList(self, fixedpairlist)
+
 if pmi.isController:
     class Harmonic(Potential):
         'The Harmonic potential.'
@@ -483,4 +498,11 @@ if pmi.isController:
         pmiproxydefs = dict(
             cls =  'espresso.interaction.VerletListHarmonicLocal',
             pmicall = ['setPotential','getPotential']
+            )
+
+    class FixedPairListAdressHarmonic(Interaction, metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+            cls =  'espressopp.interaction.FixedPairListAdressHarmonicLocal',
+            pmicall = ['setPotential','getPotential','setFixedPairList','getFixedPairList'],
+            pmiproperty = ['scale_factor']
             )

--- a/src/interaction/Harmonic.py
+++ b/src/interaction/Harmonic.py
@@ -292,13 +292,14 @@ from espressopp.esutil import *
 from espressopp.interaction.Potential import *
 from espressopp.interaction.Interaction import *
 from _espressopp import interaction_Harmonic, interaction_FixedPairListHarmonic, \
-                      interaction_FixedPairListTypesHarmonic, \
-                      interaction_VerletListAdressATHarmonic, \
-                      interaction_VerletListAdressCGHarmonic, \
-                      interaction_VerletListHadressATHarmonic, \
-                      interaction_VerletListHadressCGHarmonic, \
-                      interaction_VerletListHarmonic, \
-                      interaction_FixedPairListAdressHarmonic
+    interaction_FixedPairListTypesHarmonic, \
+    interaction_VerletListAdressATHarmonic, \
+    interaction_VerletListAdressCGHarmonic, \
+    interaction_VerletListHadressATHarmonic, \
+    interaction_VerletListHadressCGHarmonic, \
+    interaction_VerletListHarmonic, \
+    interaction_FixedPairListAdressHarmonic
+
 
 class HarmonicLocal(PotentialLocal, interaction_Harmonic):
 
@@ -311,11 +312,13 @@ class HarmonicLocal(PotentialLocal, interaction_Harmonic):
             else:
                 cxxinit(self, interaction_Harmonic, K, r0, cutoff, shift)
 
+
 class FixedPairListHarmonicLocal(InteractionLocal, interaction_FixedPairListHarmonic):
 
     def __init__(self, system, vl, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedPairListHarmonic, system, vl, potential)
+            cxxinit(self, interaction_FixedPairListHarmonic,
+                    system, vl, potential)
 
     def setPotential(self, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -325,10 +328,10 @@ class FixedPairListHarmonicLocal(InteractionLocal, interaction_FixedPairListHarm
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setFixedPairList(self, fixedpairlist)
 
-
     def getFixedPairList(self):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getFixedPairList(self)
+
 
 class FixedPairListTypesHarmonicLocal(InteractionLocal, interaction_FixedPairListTypesHarmonic):
     def __init__(self, system, vl):
@@ -351,11 +354,13 @@ class FixedPairListTypesHarmonicLocal(InteractionLocal, interaction_FixedPairLis
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getFixedPairList(self)
 
+
 class VerletListAdressATHarmonicLocal(InteractionLocal, interaction_VerletListAdressATHarmonic):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressATHarmonic, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListAdressATHarmonic,
+                    vl, fixedtupleList)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -368,12 +373,14 @@ class VerletListAdressATHarmonicLocal(InteractionLocal, interaction_VerletListAd
     def getVerletListLocal(self):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getVerletList(self)
+
 
 class VerletListAdressCGHarmonicLocal(InteractionLocal, interaction_VerletListAdressCGHarmonic):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressCGHarmonic, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListAdressCGHarmonic,
+                    vl, fixedtupleList)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -386,12 +393,14 @@ class VerletListAdressCGHarmonicLocal(InteractionLocal, interaction_VerletListAd
     def getVerletListLocal(self):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getVerletList(self)
+
 
 class VerletListHadressATHarmonicLocal(InteractionLocal, interaction_VerletListHadressATHarmonic):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressATHarmonic, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListHadressATHarmonic,
+                    vl, fixedtupleList)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -404,12 +413,14 @@ class VerletListHadressATHarmonicLocal(InteractionLocal, interaction_VerletListH
     def getVerletListLocal(self):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getVerletList(self)
+
 
 class VerletListHadressCGHarmonicLocal(InteractionLocal, interaction_VerletListHadressCGHarmonic):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressCGHarmonic, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListHadressCGHarmonic,
+                    vl, fixedtupleList)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -422,6 +433,7 @@ class VerletListHadressCGHarmonicLocal(InteractionLocal, interaction_VerletListH
     def getVerletListLocal(self):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getVerletList(self)
+
 
 class VerletListHarmonicLocal(InteractionLocal, interaction_VerletListHarmonic):
     def __init__(self, vl):
@@ -436,11 +448,14 @@ class VerletListHarmonicLocal(InteractionLocal, interaction_VerletListHarmonic):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getPotential(self, type1, type2)
 
+
 class FixedPairListAdressHarmonicLocal(InteractionLocal, interaction_FixedPairListAdressHarmonic):
     'The (local) Harmonic interaction using FixedPair lists.'
+
     def __init__(self, system, vl, potential, is_cg=False):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedPairListAdressHarmonic, system, vl, potential, is_cg)
+            cxxinit(self, interaction_FixedPairListAdressHarmonic,
+                    system, vl, potential, is_cg)
 
     def setPotential(self, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -450,59 +465,63 @@ class FixedPairListAdressHarmonicLocal(InteractionLocal, interaction_FixedPairLi
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setFixedPairList(self, fixedpairlist)
 
+
 if pmi.isController:
     class Harmonic(Potential):
         'The Harmonic potential.'
         pmiproxydefs = dict(
-            cls = 'espressopp.interaction.HarmonicLocal',
-            pmiproperty = ['K', 'r0']
-            )
+            cls='espressopp.interaction.HarmonicLocal',
+            pmiproperty=['K', 'r0']
+        )
 
     class FixedPairListHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedPairListHarmonicLocal',
-            pmicall = ['setPotential','getPotential','setFixedPairList','getFixedPairList']
-            )
+            cls='espressopp.interaction.FixedPairListHarmonicLocal',
+            pmicall=['setPotential', 'getPotential',
+                     'setFixedPairList', 'getFixedPairList']
+        )
 
     class FixedPairListTypesHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedPairListTypesHarmonicLocal',
-            pmicall = ['setPotential','getPotential','setFixedPairList','getFixedPairList']
-            )
+            cls='espressopp.interaction.FixedPairListTypesHarmonicLocal',
+            pmicall=['setPotential', 'getPotential',
+                     'setFixedPairList', 'getFixedPairList']
+        )
 
     class VerletListAdressATHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressATHarmonicLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList']
-            )
+            cls='espressopp.interaction.VerletListAdressATHarmonicLocal',
+            pmicall=['setPotential', 'getPotential', 'getVerletList']
+        )
 
     class VerletListAdressCGHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressCGHarmonicLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList']
-            )
+            cls='espressopp.interaction.VerletListAdressCGHarmonicLocal',
+            pmicall=['setPotential', 'getPotential', 'getVerletList']
+        )
 
     class VerletListHadressATHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressATHarmonicLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList']
-            )
+            cls='espressopp.interaction.VerletListHadressATHarmonicLocal',
+            pmicall=['setPotential', 'getPotential', 'getVerletList']
+        )
 
     class VerletListHadressCGHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressCGHarmonicLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList']
-            )
+            cls='espressopp.interaction.VerletListHadressCGHarmonicLocal',
+            pmicall=['setPotential', 'getPotential', 'getVerletList']
+        )
 
     class VerletListHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espresso.interaction.VerletListHarmonicLocal',
-            pmicall = ['setPotential','getPotential']
-            )
+            cls='espresso.interaction.VerletListHarmonicLocal',
+            pmicall=['setPotential', 'getPotential']
+        )
 
     class FixedPairListAdressHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedPairListAdressHarmonicLocal',
-            pmicall = ['setPotential','getPotential','setFixedPairList','getFixedPairList'],
-            pmiproperty = ['scale_factor']
-            )
+            cls='espressopp.interaction.FixedPairListAdressHarmonicLocal',
+            pmicall=['setPotential', 'getPotential',
+                     'setFixedPairList', 'getFixedPairList'],
+            pmiproperty=['scale_factor']
+        )

--- a/src/interaction/LennardJones.cpp
+++ b/src/interaction/LennardJones.cpp
@@ -228,8 +228,7 @@ void LennardJones::registerPython()
     ;
 
     class_<VerletListHybridLennardJones, bases<Interaction> >(
-        "interaction_VerletListHybridLennardJones",
-        init<std::shared_ptr<VerletList>, bool>())
+        "interaction_VerletListHybridLennardJones", init<std::shared_ptr<VerletList>, bool>())
         .def("getVerletList", &VerletListHybridLennardJones::getVerletList)
         .def("setPotential", &VerletListHybridLennardJones::setPotential)
         .def("getPotential", &VerletListHybridLennardJones::getPotentialPtr)
@@ -265,14 +264,14 @@ void LennardJones::registerPython()
 
     class_<FixedPairListAdressLennardJones, bases<Interaction> >(
         "interaction_FixedPairListAdressLennardJones",
-        init<std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<LennardJones>, bool>())
-        .def(init<std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<LennardJones>,
+        init<std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<LennardJones>,
              bool>())
+        .def(init<std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>,
+                  std::shared_ptr<LennardJones>, bool>())
         .def("setPotential", &FixedPairListAdressLennardJones::setPotential)
         .def("getPotential", &FixedPairListAdressLennardJones::getPotential)
         .def("setFixedPairList", &FixedPairListAdressLennardJones::setFixedPairList)
-        .def("getFixedPairList", &FixedPairListAdressLennardJones::getFixedPairList)
-        ;
+        .def("getFixedPairList", &FixedPairListAdressLennardJones::getFixedPairList);
 }
 
 }  // namespace interaction

--- a/src/interaction/LennardJones.cpp
+++ b/src/interaction/LennardJones.cpp
@@ -26,6 +26,7 @@
 #include "Harmonic.hpp"
 #include "ReactionFieldGeneralized.hpp"
 #include "VerletListInteractionTemplate.hpp"
+#include "VerletListHybridInteractionTemplate.hpp"
 #include "VerletListAdressInteractionTemplate.hpp"
 #include "VerletListAdressATInteractionTemplate.hpp"
 #include "VerletListAdressCGInteractionTemplate.hpp"
@@ -39,12 +40,14 @@
 #include "CellListAllPairsInteractionTemplate.hpp"
 #include "FixedPairListInteractionTemplate.hpp"
 #include "FixedPairListTypesInteractionTemplate.hpp"
+#include "FixedPairListAdressInteractionTemplate.hpp"
 
 namespace espressopp
 {
 namespace interaction
 {
 typedef class VerletListInteractionTemplate<LennardJones> VerletListLennardJones;
+typedef class VerletListHybridInteractionTemplate<LennardJones> VerletListHybridLennardJones;
 typedef class VerletListAdressInteractionTemplate<LennardJones, Tabulated>
     VerletListAdressLennardJones;
 typedef class VerletListAdressATInteractionTemplate<LennardJones> VerletListAdressATLennardJones;
@@ -84,8 +87,8 @@ typedef class VerletListHadressInteractionTemplate<LennardJones, Harmonic>
 typedef class CellListAllPairsInteractionTemplate<LennardJones> CellListLennardJones;
 typedef class FixedPairListInteractionTemplate<LennardJones> FixedPairListLennardJones;
 typedef class FixedPairListTypesInteractionTemplate<LennardJones> FixedPairListTypesLennardJones;
+typedef class FixedPairListAdressInteractionTemplate<LennardJones> FixedPairListAdressLennardJones;
 LOG4ESPP_LOGGER(LennardJones::theLogger, "LennardJones");
-// LOG4ESPP_LOGGER(VerletListLennardJones::theLogger, "VerletListLennardJones");
 
 //////////////////////////////////////////////////
 // REGISTRATION WITH PYTHON
@@ -224,6 +227,17 @@ void LennardJones::registerPython()
         .def("setPotentialCG", &VerletListHadressLennardJonesHarmonic::setPotentialCG);
     ;
 
+    class_<VerletListHybridLennardJones, bases<Interaction> >(
+        "interaction_VerletListHybridLennardJones",
+        init<std::shared_ptr<VerletList>, bool>())
+        .def("getVerletList", &VerletListHybridLennardJones::getVerletList)
+        .def("setPotential", &VerletListHybridLennardJones::setPotential)
+        .def("getPotential", &VerletListHybridLennardJones::getPotentialPtr)
+        .add_property("scale_factor", &VerletListHybridLennardJones::scaleFactor,
+                      &VerletListHybridLennardJones::setScaleFactor)
+        .add_property("max_force", &VerletListHybridLennardJones::maxForce,
+                      &VerletListHybridLennardJones::setMaxForce);
+
     class_<CellListLennardJones, bases<Interaction> >("interaction_CellListLennardJones",
                                                       init<std::shared_ptr<storage::Storage> >())
         .def("setPotential", &CellListLennardJones::setPotential);
@@ -248,6 +262,17 @@ void LennardJones::registerPython()
         .def("getFixedPairList", &FixedPairListTypesLennardJones::getFixedPairList)
         .def("setPotential", &FixedPairListTypesLennardJones::setPotential)
         .def("getPotential", &FixedPairListTypesLennardJones::getPotentialPtr);
+
+    class_<FixedPairListAdressLennardJones, bases<Interaction> >(
+        "interaction_FixedPairListAdressLennardJones",
+        init<std::shared_ptr<System>, std::shared_ptr<FixedPairList>, std::shared_ptr<LennardJones>, bool>())
+        .def(init<std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>, std::shared_ptr<LennardJones>,
+             bool>())
+        .def("setPotential", &FixedPairListAdressLennardJones::setPotential)
+        .def("getPotential", &FixedPairListAdressLennardJones::getPotential)
+        .def("setFixedPairList", &FixedPairListAdressLennardJones::setFixedPairList)
+        .def("getFixedPairList", &FixedPairListAdressLennardJones::getFixedPairList)
+        ;
 }
 
 }  // namespace interaction

--- a/src/interaction/LennardJones.py
+++ b/src/interaction/LennardJones.py
@@ -697,28 +697,29 @@ from espressopp.esutil import *
 from espressopp.interaction.Potential import *
 from espressopp.interaction.Interaction import *
 from _espressopp import interaction_LennardJones, \
-                      interaction_VerletListLennardJones, \
-                      interaction_VerletListHybridLennardJones, \
-                      interaction_VerletListAdressLennardJones, \
-                      interaction_VerletListAdressATLennardJones, \
-                      interaction_VerletListAdressATLenJonesReacFieldGen, \
-                      interaction_VerletListAdressATLJReacFieldGenTab, \
-                      interaction_VerletListAdressATLJReacFieldGenHarmonic, \
-                      interaction_VerletListAdressCGLennardJones, \
-                      interaction_VerletListAdressLennardJones2, \
-                      interaction_VerletListAdressLennardJonesHarmonic, \
-                      interaction_VerletListHadressLennardJones, \
-                      interaction_VerletListHadressATLennardJones, \
-                      interaction_VerletListHadressATLenJonesReacFieldGen, \
-                      interaction_VerletListHadressATLJReacFieldGenTab, \
-                      interaction_VerletListHadressATLJReacFieldGenHarmonic, \
-                      interaction_VerletListHadressCGLennardJones, \
-                      interaction_VerletListHadressLennardJones2, \
-                      interaction_VerletListHadressLennardJonesHarmonic, \
-                      interaction_CellListLennardJones, \
-                      interaction_FixedPairListLennardJones, \
-                      interaction_FixedPairListTypesLennardJones, \
-                      interaction_FixedPairListAdressLennardJones
+    interaction_VerletListLennardJones, \
+    interaction_VerletListHybridLennardJones, \
+    interaction_VerletListAdressLennardJones, \
+    interaction_VerletListAdressATLennardJones, \
+    interaction_VerletListAdressATLenJonesReacFieldGen, \
+    interaction_VerletListAdressATLJReacFieldGenTab, \
+    interaction_VerletListAdressATLJReacFieldGenHarmonic, \
+    interaction_VerletListAdressCGLennardJones, \
+    interaction_VerletListAdressLennardJones2, \
+    interaction_VerletListAdressLennardJonesHarmonic, \
+    interaction_VerletListHadressLennardJones, \
+    interaction_VerletListHadressATLennardJones, \
+    interaction_VerletListHadressATLenJonesReacFieldGen, \
+    interaction_VerletListHadressATLJReacFieldGenTab, \
+    interaction_VerletListHadressATLJReacFieldGenHarmonic, \
+    interaction_VerletListHadressCGLennardJones, \
+    interaction_VerletListHadressLennardJones2, \
+    interaction_VerletListHadressLennardJonesHarmonic, \
+    interaction_CellListLennardJones, \
+    interaction_FixedPairListLennardJones, \
+    interaction_FixedPairListTypesLennardJones, \
+    interaction_FixedPairListAdressLennardJones
+
 
 class LennardJonesLocal(PotentialLocal, interaction_LennardJones):
 
@@ -726,12 +727,13 @@ class LennardJonesLocal(PotentialLocal, interaction_LennardJones):
                  cutoff=infinity, shift="auto"):
         """Initialize the local Lennard Jones object."""
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            if shift =="auto":
+            if shift == "auto":
                 cxxinit(self, interaction_LennardJones,
                         epsilon, sigma, cutoff)
             else:
                 cxxinit(self, interaction_LennardJones,
                         epsilon, sigma, cutoff, shift)
+
 
 class VerletListLennardJonesLocal(InteractionLocal, interaction_VerletListLennardJones):
 
@@ -751,10 +753,12 @@ class VerletListLennardJonesLocal(InteractionLocal, interaction_VerletListLennar
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getVerletList(self)
 
+
 class VerletListHybridLennardJonesLocal(InteractionLocal, interaction_VerletListHybridLennardJones):
     def __init__(self, vl, cg_potential=False):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHybridLennardJones, vl, cg_potential)
+            cxxinit(self, interaction_VerletListHybridLennardJones,
+                    vl, cg_potential)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -767,12 +771,14 @@ class VerletListHybridLennardJonesLocal(InteractionLocal, interaction_VerletList
     def getVerletListLocal(self):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getVerletList(self)
+
 
 class VerletListAdressATLennardJonesLocal(InteractionLocal, interaction_VerletListAdressATLennardJones):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressATLennardJones, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListAdressATLennardJones,
+                    vl, fixedtupleList)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -785,12 +791,14 @@ class VerletListAdressATLennardJonesLocal(InteractionLocal, interaction_VerletLi
     def getVerletListLocal(self):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getVerletList(self)
+
 
 class VerletListAdressATLenJonesReacFieldGenLocal(InteractionLocal, interaction_VerletListAdressATLenJonesReacFieldGen):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressATLenJonesReacFieldGen, vl, fixedtupleList)
+            cxxinit(
+                self, interaction_VerletListAdressATLenJonesReacFieldGen, vl, fixedtupleList)
 
     def setPotential1(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -799,12 +807,14 @@ class VerletListAdressATLenJonesReacFieldGenLocal(InteractionLocal, interaction_
     def setPotential2(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotential2(self, type1, type2, potential)
+
 
 class VerletListAdressATLJReacFieldGenTabLocal(InteractionLocal, interaction_VerletListAdressATLJReacFieldGenTab):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressATLJReacFieldGenTab, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListAdressATLJReacFieldGenTab,
+                    vl, fixedtupleList)
 
     def setPotentialAT1(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -817,12 +827,14 @@ class VerletListAdressATLJReacFieldGenTabLocal(InteractionLocal, interaction_Ver
     def setPotentialCG(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotentialCG(self, type1, type2, potential)
+
 
 class VerletListAdressATLJReacFieldGenHarmonicLocal(InteractionLocal, interaction_VerletListAdressATLJReacFieldGenHarmonic):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressATLJReacFieldGenHarmonic, vl, fixedtupleList)
+            cxxinit(
+                self, interaction_VerletListAdressATLJReacFieldGenHarmonic, vl, fixedtupleList)
 
     def setPotentialAT1(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -836,11 +848,13 @@ class VerletListAdressATLJReacFieldGenHarmonicLocal(InteractionLocal, interactio
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotentialCG(self, type1, type2, potential)
 
+
 class VerletListAdressCGLennardJonesLocal(InteractionLocal, interaction_VerletListAdressCGLennardJones):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressCGLennardJones, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListAdressCGLennardJones,
+                    vl, fixedtupleList)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -853,12 +867,14 @@ class VerletListAdressCGLennardJonesLocal(InteractionLocal, interaction_VerletLi
     def getVerletListLocal(self):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getVerletList(self)
+
 
 class VerletListAdressLennardJonesLocal(InteractionLocal, interaction_VerletListAdressLennardJones):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressLennardJones, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListAdressLennardJones,
+                    vl, fixedtupleList)
 
     def setPotentialAT(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -867,12 +883,14 @@ class VerletListAdressLennardJonesLocal(InteractionLocal, interaction_VerletList
     def setPotentialCG(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotentialCG(self, type1, type2, potential)
+
 
 class VerletListAdressLennardJones2Local(InteractionLocal, interaction_VerletListAdressLennardJones2):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressLennardJones2, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListAdressLennardJones2,
+                    vl, fixedtupleList)
 
     def setPotentialAT(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -881,12 +899,14 @@ class VerletListAdressLennardJones2Local(InteractionLocal, interaction_VerletLis
     def setPotentialCG(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotentialCG(self, type1, type2, potential)
+
 
 class VerletListAdressLennardJonesHarmonicLocal(InteractionLocal, interaction_VerletListAdressLennardJonesHarmonic):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressLennardJonesHarmonic, vl, fixedtupleList)
+            cxxinit(
+                self, interaction_VerletListAdressLennardJonesHarmonic, vl, fixedtupleList)
 
     def setPotentialAT(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -896,11 +916,13 @@ class VerletListAdressLennardJonesHarmonicLocal(InteractionLocal, interaction_Ve
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotentialCG(self, type1, type2, potential)
 
+
 class VerletListHadressATLennardJonesLocal(InteractionLocal, interaction_VerletListHadressATLennardJones):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressATLennardJones, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListHadressATLennardJones,
+                    vl, fixedtupleList)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -914,11 +936,13 @@ class VerletListHadressATLennardJonesLocal(InteractionLocal, interaction_VerletL
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getVerletList(self)
 
+
 class VerletListHadressATLenJonesReacFieldGenLocal(InteractionLocal, interaction_VerletListHadressATLenJonesReacFieldGen):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressATLenJonesReacFieldGen, vl, fixedtupleList)
+            cxxinit(
+                self, interaction_VerletListHadressATLenJonesReacFieldGen, vl, fixedtupleList)
 
     def setPotential1(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -928,11 +952,13 @@ class VerletListHadressATLenJonesReacFieldGenLocal(InteractionLocal, interaction
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotential2(self, type1, type2, potential)
 
+
 class VerletListHadressATLJReacFieldGenTabLocal(InteractionLocal, interaction_VerletListHadressATLJReacFieldGenTab):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressATLJReacFieldGenTab, vl, fixedtupleList)
+            cxxinit(
+                self, interaction_VerletListHadressATLJReacFieldGenTab, vl, fixedtupleList)
 
     def setPotentialAT1(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -945,12 +971,14 @@ class VerletListHadressATLJReacFieldGenTabLocal(InteractionLocal, interaction_Ve
     def setPotentialCG(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotentialCG(self, type1, type2, potential)
+
 
 class VerletListHadressATLJReacFieldGenHarmonicLocal(InteractionLocal, interaction_VerletListHadressATLJReacFieldGenHarmonic):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressATLJReacFieldGenHarmonic, vl, fixedtupleList)
+            cxxinit(
+                self, interaction_VerletListHadressATLJReacFieldGenHarmonic, vl, fixedtupleList)
 
     def setPotentialAT1(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -964,11 +992,13 @@ class VerletListHadressATLJReacFieldGenHarmonicLocal(InteractionLocal, interacti
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotentialCG(self, type1, type2, potential)
 
+
 class VerletListHadressCGLennardJonesLocal(InteractionLocal, interaction_VerletListHadressCGLennardJones):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressCGLennardJones, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListHadressCGLennardJones,
+                    vl, fixedtupleList)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -982,11 +1012,13 @@ class VerletListHadressCGLennardJonesLocal(InteractionLocal, interaction_VerletL
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getVerletList(self)
 
+
 class VerletListHadressLennardJonesLocal(InteractionLocal, interaction_VerletListHadressLennardJones):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressLennardJones, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListHadressLennardJones,
+                    vl, fixedtupleList)
 
     def setPotentialAT(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -995,12 +1027,14 @@ class VerletListHadressLennardJonesLocal(InteractionLocal, interaction_VerletLis
     def setPotentialCG(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotentialCG(self, type1, type2, potential)
+
 
 class VerletListHadressLennardJones2Local(InteractionLocal, interaction_VerletListHadressLennardJones2):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressLennardJones2, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListHadressLennardJones2,
+                    vl, fixedtupleList)
 
     def setPotentialAT(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -1009,12 +1043,14 @@ class VerletListHadressLennardJones2Local(InteractionLocal, interaction_VerletLi
     def setPotentialCG(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotentialCG(self, type1, type2, potential)
+
 
 class VerletListHadressLennardJonesHarmonicLocal(InteractionLocal, interaction_VerletListHadressLennardJonesHarmonic):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressLennardJonesHarmonic, vl, fixedtupleList)
+            cxxinit(
+                self, interaction_VerletListHadressLennardJonesHarmonic, vl, fixedtupleList)
 
     def setPotentialAT(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -1023,6 +1059,7 @@ class VerletListHadressLennardJonesHarmonicLocal(InteractionLocal, interaction_V
     def setPotentialCG(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotentialCG(self, type1, type2, potential)
+
 
 class CellListLennardJonesLocal(InteractionLocal, interaction_CellListLennardJones):
 
@@ -1034,11 +1071,13 @@ class CellListLennardJonesLocal(InteractionLocal, interaction_CellListLennardJon
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotential(self, type1, type2, potential)
 
+
 class FixedPairListLennardJonesLocal(InteractionLocal, interaction_FixedPairListLennardJones):
 
     def __init__(self, system, vl, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedPairListLennardJones, system, vl, potential)
+            cxxinit(self, interaction_FixedPairListLennardJones,
+                    system, vl, potential)
 
     def setPotential(self, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -1052,10 +1091,10 @@ class FixedPairListLennardJonesLocal(InteractionLocal, interaction_FixedPairList
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setFixedPairList(self, fixedpairlist)
 
-
     def getFixedPairList(self):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getFixedPairList(self)
+
 
 class FixedPairListTypesLennardJonesLocal(InteractionLocal, interaction_FixedPairListTypesLennardJones):
     def __init__(self, system, vl):
@@ -1078,11 +1117,14 @@ class FixedPairListTypesLennardJonesLocal(InteractionLocal, interaction_FixedPai
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setFixedPairList(self, fixedpairlist)
 
+
 class FixedPairListAdressLennardJonesLocal(InteractionLocal, interaction_FixedPairListAdressLennardJones):
     'The (local) Lennard-Jones interaction using FixedPair lists.'
+
     def __init__(self, system, vl, potential, cg_potential=False):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedPairListAdressLennardJones, system, vl, potential, cg_potential)
+            cxxinit(self, interaction_FixedPairListAdressLennardJones,
+                    system, vl, potential, cg_potential)
 
     def setPotential(self, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -1096,148 +1138,151 @@ class FixedPairListAdressLennardJonesLocal(InteractionLocal, interaction_FixedPa
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setFixedPairList(self, fixedpairlist)
 
-
     def getFixedPairList(self):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getFixedPairList(self)
+
 
 if pmi.isController:
     class LennardJones(Potential):
         'The Lennard-Jones potential.'
         pmiproxydefs = dict(
-            cls = 'espressopp.interaction.LennardJonesLocal',
-            pmiproperty = ['epsilon', 'sigma']
-            )
+            cls='espressopp.interaction.LennardJonesLocal',
+            pmiproperty=['epsilon', 'sigma']
+        )
 
     class VerletListLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListLennardJonesLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList']
-            )
+            cls='espressopp.interaction.VerletListLennardJonesLocal',
+            pmicall=['setPotential', 'getPotential', 'getVerletList']
+        )
 
     class VerletListHybridLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHybridLennardJonesLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList'],
-            pmiproprty = ['scale_factor', 'max_force']
+            cls='espressopp.interaction.VerletListHybridLennardJonesLocal',
+            pmicall=['setPotential', 'getPotential', 'getVerletList'],
+            pmiproprty=['scale_factor', 'max_force']
         )
 
     class VerletListAdressATLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressATLennardJonesLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList']
-            )
+            cls='espressopp.interaction.VerletListAdressATLennardJonesLocal',
+            pmicall=['setPotential', 'getPotential', 'getVerletList']
+        )
 
     class VerletListAdressATLenJonesReacFieldGen(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressATLenJonesReacFieldGenLocal',
-            pmicall = ['setPotential1', 'setPotential2']
-            )
+            cls='espressopp.interaction.VerletListAdressATLenJonesReacFieldGenLocal',
+            pmicall=['setPotential1', 'setPotential2']
+        )
 
     class VerletListAdressATLJReacFieldGenTab(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressATLJReacFieldGenTabLocal',
-            pmicall = ['setPotentialAT1', 'setPotentialAT2', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListAdressATLJReacFieldGenTabLocal',
+            pmicall=['setPotentialAT1', 'setPotentialAT2', 'setPotentialCG']
+        )
 
     class VerletListAdressATLJReacFieldGenHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressATLJReacFieldGenHarmonicLocal',
-            pmicall = ['setPotentialAT1', 'setPotentialAT2', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListAdressATLJReacFieldGenHarmonicLocal',
+            pmicall=['setPotentialAT1', 'setPotentialAT2', 'setPotentialCG']
+        )
 
     class VerletListAdressCGLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressCGLennardJonesLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList']
-            )
+            cls='espressopp.interaction.VerletListAdressCGLennardJonesLocal',
+            pmicall=['setPotential', 'getPotential', 'getVerletList']
+        )
 
     class VerletListAdressLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressLennardJonesLocal',
-            pmicall = ['setPotentialAT', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListAdressLennardJonesLocal',
+            pmicall=['setPotentialAT', 'setPotentialCG']
+        )
 
     class VerletListAdressLennardJones2(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressLennardJones2Local',
-            pmicall = ['setPotentialAT', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListAdressLennardJones2Local',
+            pmicall=['setPotentialAT', 'setPotentialCG']
+        )
 
     class VerletListAdressLennardJonesHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressLennardJonesHarmonicLocal',
-            pmicall = ['setPotentialAT', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListAdressLennardJonesHarmonicLocal',
+            pmicall=['setPotentialAT', 'setPotentialCG']
+        )
 
     class VerletListHadressATLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressATLennardJonesLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList']
-            )
+            cls='espressopp.interaction.VerletListHadressATLennardJonesLocal',
+            pmicall=['setPotential', 'getPotential', 'getVerletList']
+        )
 
     class VerletListHadressATLenJonesReacFieldGen(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressATLenJonesReacFieldGenLocal',
-            pmicall = ['setPotential1', 'setPotential2']
-            )
+            cls='espressopp.interaction.VerletListHadressATLenJonesReacFieldGenLocal',
+            pmicall=['setPotential1', 'setPotential2']
+        )
 
     class VerletListHadressATLJReacFieldGenTab(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressATLJReacFieldGenTabLocal',
-            pmicall = ['setPotentialAT1', 'setPotentialAT2', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListHadressATLJReacFieldGenTabLocal',
+            pmicall=['setPotentialAT1', 'setPotentialAT2', 'setPotentialCG']
+        )
 
     class VerletListHadressATLJReacFieldGenHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressATLJReacFieldGenHarmonicLocal',
-            pmicall = ['setPotentialAT1', 'setPotentialAT2', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListHadressATLJReacFieldGenHarmonicLocal',
+            pmicall=['setPotentialAT1', 'setPotentialAT2', 'setPotentialCG']
+        )
 
     class VerletListHadressCGLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressCGLennardJonesLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList']
-            )
+            cls='espressopp.interaction.VerletListHadressCGLennardJonesLocal',
+            pmicall=['setPotential', 'getPotential', 'getVerletList']
+        )
 
     class VerletListHadressLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressLennardJonesLocal',
-            pmicall = ['setPotentialAT', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListHadressLennardJonesLocal',
+            pmicall=['setPotentialAT', 'setPotentialCG']
+        )
 
     class VerletListHadressLennardJones2(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressLennardJones2Local',
-            pmicall = ['setPotentialAT', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListHadressLennardJones2Local',
+            pmicall=['setPotentialAT', 'setPotentialCG']
+        )
 
     class VerletListHadressLennardJonesHarmonic(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressLennardJonesHarmonicLocal',
-            pmicall = ['setPotentialAT', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListHadressLennardJonesHarmonicLocal',
+            pmicall=['setPotentialAT', 'setPotentialCG']
+        )
 
     class CellListLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.CellListLennardJonesLocal',
-            pmicall = ['setPotential']
-            )
+            cls='espressopp.interaction.CellListLennardJonesLocal',
+            pmicall=['setPotential']
+        )
 
     class FixedPairListLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedPairListLennardJonesLocal',
-            pmicall = ['getPotential', 'setPotential', 'setFixedPairList','getFixedPairList' ]
-            )
+            cls='espressopp.interaction.FixedPairListLennardJonesLocal',
+            pmicall=['getPotential', 'setPotential',
+                     'setFixedPairList', 'getFixedPairList']
+        )
 
     class FixedPairListTypesLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedPairListTypesLennardJonesLocal',
-            pmicall = ['setPotential', 'getPotential', 'setFixedPairList','getFixedPairList' ]
-            )
+            cls='espressopp.interaction.FixedPairListTypesLennardJonesLocal',
+            pmicall=['setPotential', 'getPotential',
+                     'setFixedPairList', 'getFixedPairList']
+        )
 
     class FixedPairListAdressLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedPairListAdressLennardJonesLocal',
-            pmicall = ['setPotential', 'getPotential', 'setFixedPairList','getFixedPairList' ]
+            cls='espressopp.interaction.FixedPairListAdressLennardJonesLocal',
+            pmicall=['setPotential', 'getPotential',
+                     'setFixedPairList', 'getFixedPairList']
         )

--- a/src/interaction/LennardJones.py
+++ b/src/interaction/LennardJones.py
@@ -754,7 +754,7 @@ class VerletListLennardJonesLocal(InteractionLocal, interaction_VerletListLennar
 class VerletListHybridLennardJonesLocal(InteractionLocal, interaction_VerletListHybridLennardJones):
     def __init__(self, vl, cg_potential=False):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListLennardJones, vl, cg_potential)
+            cxxinit(self, interaction_VerletListHybridLennardJones, vl, cg_potential)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -1118,7 +1118,8 @@ if pmi.isController:
     class VerletListHybridLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
             cls =  'espressopp.interaction.VerletListHybridLennardJonesLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList']
+            pmicall = ['setPotential', 'getPotential', 'getVerletList'],
+            pmiproprty = ['scale_factor', 'max_force']
         )
 
     class VerletListAdressATLennardJones(Interaction, metaclass=pmi.Proxy):

--- a/src/interaction/LennardJones.py
+++ b/src/interaction/LennardJones.py
@@ -698,6 +698,7 @@ from espressopp.interaction.Potential import *
 from espressopp.interaction.Interaction import *
 from _espressopp import interaction_LennardJones, \
                       interaction_VerletListLennardJones, \
+                      interaction_VerletListHybridLennardJones, \
                       interaction_VerletListAdressLennardJones, \
                       interaction_VerletListAdressATLennardJones, \
                       interaction_VerletListAdressATLenJonesReacFieldGen, \
@@ -716,7 +717,8 @@ from _espressopp import interaction_LennardJones, \
                       interaction_VerletListHadressLennardJonesHarmonic, \
                       interaction_CellListLennardJones, \
                       interaction_FixedPairListLennardJones, \
-                      interaction_FixedPairListTypesLennardJones
+                      interaction_FixedPairListTypesLennardJones, \
+                      interaction_FixedPairListAdressLennardJones
 
 class LennardJonesLocal(PotentialLocal, interaction_LennardJones):
 
@@ -736,6 +738,23 @@ class VerletListLennardJonesLocal(InteractionLocal, interaction_VerletListLennar
     def __init__(self, vl):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             cxxinit(self, interaction_VerletListLennardJones, vl)
+
+    def setPotential(self, type1, type2, potential):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            self.cxxclass.setPotential(self, type1, type2, potential)
+
+    def getPotential(self, type1, type2):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            return self.cxxclass.getPotential(self, type1, type2)
+
+    def getVerletListLocal(self):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            return self.cxxclass.getVerletList(self)
+
+class VerletListHybridLennardJonesLocal(InteractionLocal, interaction_VerletListHybridLennardJones):
+    def __init__(self, vl, cg_potential=False):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            cxxinit(self, interaction_VerletListLennardJones, vl, cg_potential)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -1059,6 +1078,29 @@ class FixedPairListTypesLennardJonesLocal(InteractionLocal, interaction_FixedPai
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setFixedPairList(self, fixedpairlist)
 
+class FixedPairListAdressLennardJonesLocal(InteractionLocal, interaction_FixedPairListAdressLennardJones):
+    'The (local) Lennard-Jones interaction using FixedPair lists.'
+    def __init__(self, system, vl, potential, cg_potential=False):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            cxxinit(self, interaction_FixedPairListAdressLennardJones, system, vl, potential, cg_potential)
+
+    def setPotential(self, potential):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            self.cxxclass.setPotential(self, potential)
+
+    def getPotential(self):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            return self.cxxclass.getPotential(self)
+
+    def setFixedPairList(self, fixedpairlist):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            self.cxxclass.setFixedPairList(self, fixedpairlist)
+
+
+    def getFixedPairList(self):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            return self.cxxclass.getFixedPairList(self)
+
 if pmi.isController:
     class LennardJones(Potential):
         'The Lennard-Jones potential.'
@@ -1072,6 +1114,12 @@ if pmi.isController:
             cls =  'espressopp.interaction.VerletListLennardJonesLocal',
             pmicall = ['setPotential', 'getPotential', 'getVerletList']
             )
+
+    class VerletListHybridLennardJones(Interaction, metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+            cls =  'espressopp.interaction.VerletListHybridLennardJonesLocal',
+            pmicall = ['setPotential', 'getPotential', 'getVerletList']
+        )
 
     class VerletListAdressATLennardJones(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
@@ -1186,3 +1234,9 @@ if pmi.isController:
             cls =  'espressopp.interaction.FixedPairListTypesLennardJonesLocal',
             pmicall = ['setPotential', 'getPotential', 'setFixedPairList','getFixedPairList' ]
             )
+
+    class FixedPairListAdressLennardJones(Interaction, metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+            cls =  'espressopp.interaction.FixedPairListAdressLennardJonesLocal',
+            pmicall = ['setPotential', 'getPotential', 'setFixedPairList','getFixedPairList' ]
+        )

--- a/src/interaction/LennardJonesCapped.cpp
+++ b/src/interaction/LennardJonesCapped.cpp
@@ -28,6 +28,7 @@
 #include "VerletListHadressInteractionTemplate.hpp"
 #include "CellListAllPairsInteractionTemplate.hpp"
 #include "FixedPairListInteractionTemplate.hpp"
+#include "FixedPairListAdressInteractionTemplate.hpp"
 
 namespace espressopp
 {
@@ -40,6 +41,8 @@ typedef class VerletListHadressInteractionTemplate<LennardJonesCapped, Tabulated
     VerletListHadressLennardJonesCapped;
 typedef class CellListAllPairsInteractionTemplate<LennardJonesCapped> CellListLennardJonesCapped;
 typedef class FixedPairListInteractionTemplate<LennardJonesCapped> FixedPairListLennardJonesCapped;
+typedef class FixedPairListAdressInteractionTemplate<LennardJonesCapped>
+    FixedPairListAdressLennardJonesCapped;
 
 //////////////////////////////////////////////////
 // REGISTRATION WITH PYTHON
@@ -99,6 +102,14 @@ void LennardJonesCapped::registerPython()
         .def(init<std::shared_ptr<System>, std::shared_ptr<FixedPairListAdress>,
                   std::shared_ptr<LennardJonesCapped> >())
         .def("setPotential", &FixedPairListLennardJonesCapped::setPotential);
+    ;
+    class_<FixedPairListAdressLennardJonesCapped, bases<Interaction> >(
+        "interaction_FixedPairListAdressLennardJonesCapped",
+        init<shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<LennardJonesCapped>,
+             bool>())
+        .def(init<shared_ptr<System>, shared_ptr<FixedPairListAdress>,
+                  shared_ptr<LennardJonesCapped>, bool>())
+        .def("setPotential", &FixedPairListAdressLennardJonesCapped::setPotential);
     ;
 }
 

--- a/src/interaction/LennardJonesEnergyCapped.cpp
+++ b/src/interaction/LennardJonesEnergyCapped.cpp
@@ -26,6 +26,7 @@
 #include "VerletListInteractionTemplate.hpp"
 #include "VerletListAdressInteractionTemplate.hpp"
 #include "VerletListHadressInteractionTemplate.hpp"
+#include "VerletListHybridInteractionTemplate.hpp"
 #include "CellListAllPairsInteractionTemplate.hpp"
 #include "FixedPairListInteractionTemplate.hpp"
 
@@ -43,6 +44,8 @@ typedef class CellListAllPairsInteractionTemplate<LennardJonesEnergyCapped>
     CellListLennardJonesEnergyCapped;
 typedef class FixedPairListInteractionTemplate<LennardJonesEnergyCapped>
     FixedPairListLennardJonesEnergyCapped;
+typedef class VerletListHybridInteractionTemplate<LennardJonesEnergyCapped>
+    VerletListHybridLennardJonesEnergyCapped;
 
 //////////////////////////////////////////////////
 // REGISTRATION WITH PYTHON
@@ -106,6 +109,17 @@ void LennardJonesEnergyCapped::registerPython()
                   std::shared_ptr<LennardJonesEnergyCapped> >())
         .def("setPotential", &FixedPairListLennardJonesEnergyCapped::setPotential);
     ;
+
+    class_<VerletListHybridLennardJonesEnergyCapped, bases<Interaction> >(
+        "interaction_VerletListHybridLennardJonesEnergyCapped",
+        init<std::shared_ptr<VerletList>, bool>())
+        .def("getVerletList", &VerletListHybridLennardJonesEnergyCapped::getVerletList)
+        .def("setPotential", &VerletListHybridLennardJonesEnergyCapped::setPotential)
+        .def("getPotential", &VerletListHybridLennardJonesEnergyCapped::getPotentialPtr)
+        .add_property("scale_factor", &VerletListHybridLennardJonesEnergyCapped::scaleFactor,
+                      &VerletListHybridLennardJonesEnergyCapped::setScaleFactor)
+        .add_property("max_force", &VerletListHybridLennardJonesEnergyCapped::maxForce,
+                      &VerletListHybridLennardJonesEnergyCapped::setMaxForce);
 }
 
 }  // namespace interaction

--- a/src/interaction/LennardJonesEnergyCapped.py
+++ b/src/interaction/LennardJonesEnergyCapped.py
@@ -200,25 +200,27 @@ from espressopp.esutil import *
 from espressopp.interaction.Potential import *
 from espressopp.interaction.Interaction import *
 from _espressopp import interaction_LennardJonesEnergyCapped, \
-                      interaction_VerletListLennardJonesEnergyCapped, \
-                      interaction_VerletListHybridLennardJonesEnergyCapped, \
-                      interaction_VerletListAdressLennardJonesEnergyCapped, \
-                      interaction_VerletListHadressLennardJonesEnergyCapped, \
-                      interaction_CellListLennardJonesEnergyCapped, \
-                      interaction_FixedPairListLennardJonesEnergyCapped
+    interaction_VerletListLennardJonesEnergyCapped, \
+    interaction_VerletListHybridLennardJonesEnergyCapped, \
+    interaction_VerletListAdressLennardJonesEnergyCapped, \
+    interaction_VerletListHadressLennardJonesEnergyCapped, \
+    interaction_CellListLennardJonesEnergyCapped, \
+    interaction_FixedPairListLennardJonesEnergyCapped
+
 
 class LennardJonesEnergyCappedLocal(PotentialLocal, interaction_LennardJonesEnergyCapped):
 
     def __init__(self, epsilon=1.0, sigma=1.0,
-                 cutoff=infinity, caprad=0.0 ,shift="auto"):
+                 cutoff=infinity, caprad=0.0, shift="auto"):
         """Initialize the local Lennard Jones object."""
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            if shift =="auto":
+            if shift == "auto":
                 cxxinit(self, interaction_LennardJonesEnergyCapped,
                         epsilon, sigma, cutoff, caprad)
             else:
                 cxxinit(self, interaction_LennardJonesEnergyCapped,
                         epsilon, sigma, cutoff, caprad, shift)
+
 
 class VerletListLennardJonesEnergyCappedLocal(InteractionLocal, interaction_VerletListLennardJonesEnergyCapped):
 
@@ -234,11 +236,13 @@ class VerletListLennardJonesEnergyCappedLocal(InteractionLocal, interaction_Verl
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getPotential(self, type1, type2)
 
+
 class VerletListAdressLennardJonesEnergyCappedLocal(InteractionLocal, interaction_VerletListAdressLennardJonesEnergyCapped):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressLennardJonesEnergyCapped, vl, fixedtupleList)
+            cxxinit(
+                self, interaction_VerletListAdressLennardJonesEnergyCapped, vl, fixedtupleList)
 
     def setPotentialAT(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -255,12 +259,14 @@ class VerletListAdressLennardJonesEnergyCappedLocal(InteractionLocal, interactio
     def getPotentialCG(self, type1, type2):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getPotentialCG(self, type1, type2)
+
 
 class VerletListHadressLennardJonesEnergyCappedLocal(InteractionLocal, interaction_VerletListHadressLennardJonesEnergyCapped):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressLennardJonesEnergyCapped, vl, fixedtupleList)
+            cxxinit(
+                self, interaction_VerletListHadressLennardJonesEnergyCapped, vl, fixedtupleList)
 
     def setPotentialAT(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -277,6 +283,7 @@ class VerletListHadressLennardJonesEnergyCappedLocal(InteractionLocal, interacti
     def getPotentialCG(self, type1, type2):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getPotentialCG(self, type1, type2)
+
 
 class CellListLennardJonesEnergyCappedLocal(InteractionLocal, interaction_CellListLennardJonesEnergyCapped):
 
@@ -292,11 +299,13 @@ class CellListLennardJonesEnergyCappedLocal(InteractionLocal, interaction_CellLi
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getPotential(self, type1, type2)
 
+
 class FixedPairListLennardJonesEnergyCappedLocal(InteractionLocal, interaction_FixedPairListLennardJonesEnergyCapped):
 
     def __init__(self, system, vl, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedPairListLennardJonesEnergyCapped, system, vl, potential)
+            cxxinit(self, interaction_FixedPairListLennardJonesEnergyCapped,
+                    system, vl, potential)
 
     def setPotential(self, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -306,10 +315,12 @@ class FixedPairListLennardJonesEnergyCappedLocal(InteractionLocal, interaction_F
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getPotential(self)
 
+
 class VerletListHybridLennardJonesEnergyCappedLocal(InteractionLocal, interaction_VerletListHybridLennardJonesEnergyCapped):
     def __init__(self, vl, cg_potential=False):
         if pmi.workerIsActive():
-            cxxinit(self, interaction_VerletListHybridLennardJonesEnergyCapped, vl, cg_potential)
+            cxxinit(
+                self, interaction_VerletListHybridLennardJonesEnergyCapped, vl, cg_potential)
 
     def setPotential(self, type1, type2, potential):
         if pmi.workerIsActive():
@@ -328,43 +339,45 @@ if pmi.isController:
     class LennardJonesEnergyCapped(Potential):
         'The Lennard-Jones potential.'
         pmiproxydefs = dict(
-            cls = 'espressopp.interaction.LennardJonesEnergyCappedLocal',
-            pmiproperty = ['epsilon', 'sigma', 'cutoff', 'caprad']
-            )
+            cls='espressopp.interaction.LennardJonesEnergyCappedLocal',
+            pmiproperty=['epsilon', 'sigma', 'cutoff', 'caprad']
+        )
 
     class VerletListLennardJonesEnergyCapped(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListLennardJonesEnergyCappedLocal',
-            pmicall = ['setPotential', 'getPotential']
-            )
+            cls='espressopp.interaction.VerletListLennardJonesEnergyCappedLocal',
+            pmicall=['setPotential', 'getPotential']
+        )
 
     class VerletListAdressLennardJonesEnergyCapped(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressLennardJonesEnergyCappedLocal',
-            pmicall = ['setPotentialAT', 'setPotentialCG', 'getPotentialAT', 'getPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListAdressLennardJonesEnergyCappedLocal',
+            pmicall=['setPotentialAT', 'setPotentialCG',
+                     'getPotentialAT', 'getPotentialCG']
+        )
 
     class VerletListHadressLennardJonesEnergyCapped(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressLennardJonesEnergyCappedLocal',
-            pmicall = ['setPotentialAT', 'setPotentialCG', 'getPotentialAT', 'getPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListHadressLennardJonesEnergyCappedLocal',
+            pmicall=['setPotentialAT', 'setPotentialCG',
+                     'getPotentialAT', 'getPotentialCG']
+        )
 
     class CellListLennardJonesEnergyCapped(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.CellListLennardJonesEnergyCappedLocal',
-            pmicall = ['setPotential', 'getPotential']
-            )
+            cls='espressopp.interaction.CellListLennardJonesEnergyCappedLocal',
+            pmicall=['setPotential', 'getPotential']
+        )
 
     class FixedPairListLennardJonesEnergyCapped(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedPairListLennardJonesEnergyCappedLocal',
-            pmicall = ['setPotential']
-            )
+            cls='espressopp.interaction.FixedPairListLennardJonesEnergyCappedLocal',
+            pmicall=['setPotential']
+        )
 
     class VerletListHybridLennardJonesEnergyCapped(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHybridLennardJonesEnergyCappedLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList'],
-            pmiproperty = ['scale_factor', 'max_force']
+            cls='espressopp.interaction.VerletListHybridLennardJonesEnergyCappedLocal',
+            pmicall=['setPotential', 'getPotential', 'getVerletList'],
+            pmiproperty=['scale_factor', 'max_force']
         )

--- a/src/interaction/ReactionFieldGeneralized.cpp
+++ b/src/interaction/ReactionFieldGeneralized.cpp
@@ -28,8 +28,8 @@
 #include "VerletListAdressATInteractionTemplate.hpp"
 #include "VerletListHadressInteractionTemplate.hpp"
 #include "VerletListHadressATInteractionTemplate.hpp"
+#include "VerletListHybridInteractionTemplate.hpp"
 #include "CellListAllPairsInteractionTemplate.hpp"
-//#include "FixedPairListInteractionTemplate.hpp"
 
 namespace espressopp
 {
@@ -37,6 +37,9 @@ namespace interaction
 {
 typedef class VerletListInteractionTemplate<ReactionFieldGeneralized>
     VerletListReactionFieldGeneralized;
+
+typedef class VerletListHybridInteractionTemplate<ReactionFieldGeneralized>
+    VerletListHybridReactionFieldGeneralized;
 
 typedef class VerletListAdressInteractionTemplate<ReactionFieldGeneralized, Tabulated>
     VerletListAdressReactionFieldGeneralized;
@@ -52,9 +55,6 @@ typedef class VerletListHadressATInteractionTemplate<ReactionFieldGeneralized>
 
 typedef class CellListAllPairsInteractionTemplate<ReactionFieldGeneralized>
     CellListReactionFieldGeneralized;
-
-/*typedef class FixedPairListInteractionTemplate<ReactionFieldGeneralized>
-    FixedPairListReactionFieldGeneralized;*/
 
 //////////////////////////////////////////////////
 // REGISTRATION WITH PYTHON
@@ -81,6 +81,16 @@ void ReactionFieldGeneralized::registerPython()
         .def("setPotential", &VerletListAdressATReactionFieldGeneralized::setPotential)
         .def("getPotential", &VerletListAdressATReactionFieldGeneralized::getPotentialPtr);
 
+    class_<VerletListHybridReactionFieldGeneralized, bases<Interaction> >(
+        "interaction_VerletListHybridReactionFieldGeneralized",
+        init<shared_ptr<VerletList>, bool>())
+        .def("setPotential", &VerletListHybridReactionFieldGeneralized::setPotential)
+        .def("getPotential", &VerletListHybridReactionFieldGeneralized::getPotentialPtr)
+        .add_property("scale_factor", &VerletListHybridReactionFieldGeneralized::scaleFactor,
+                      &VerletListHybridReactionFieldGeneralized::setScaleFactor)
+        .add_property("max_force", &VerletListHybridReactionFieldGeneralized::maxForce,
+                      &VerletListHybridReactionFieldGeneralized::setMaxForce);
+
     class_<VerletListAdressReactionFieldGeneralized, bases<Interaction> >(
         "interaction_VerletListAdressReactionFieldGeneralized",
         init<std::shared_ptr<VerletListAdress>, std::shared_ptr<FixedTupleListAdress> >())
@@ -105,14 +115,6 @@ void ReactionFieldGeneralized::registerPython()
         "interaction_CellListReactionFieldGeneralized", init<std::shared_ptr<storage::Storage> >())
         .def("setPotential", &CellListReactionFieldGeneralized::setPotential);
     ;
-
-    /*
-      class_<FixedPairListReactionFieldGeneralized, bases<Interaction> >
-        ("interaction_FixedPairListReactionFieldGeneralized",
-          init<std::shared_ptr<System>, std::shared_ptr<FixedPairList>,
-      std::shared_ptr<ReactionFieldGeneralized> >()) .def("setPotential",
-      &FixedPairListReactionFieldGeneralized::setPotential);
-        ;*/
 }
 }  // namespace interaction
 }  // namespace espressopp

--- a/src/interaction/ReactionFieldGeneralized.py
+++ b/src/interaction/ReactionFieldGeneralized.py
@@ -234,7 +234,8 @@ from _espressopp import interaction_ReactionFieldGeneralized, \
                       interaction_VerletListAdressATReactionFieldGeneralized, \
                       interaction_VerletListHadressReactionFieldGeneralized, \
                       interaction_VerletListHadressATReactionFieldGeneralized, \
-                      interaction_CellListReactionFieldGeneralized
+                      interaction_CellListReactionFieldGeneralized, \
+                      interaction_VerletListHybridReactionFieldGeneralized
                       #interaction_FixedPairListReactionFieldGeneralized
 
 class ReactionFieldGeneralizedLocal(PotentialLocal, interaction_ReactionFieldGeneralized):
@@ -267,6 +268,20 @@ class VerletListAdressATReactionFieldGeneralizedLocal(InteractionLocal, interact
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             cxxinit(self, interaction_VerletListAdressATReactionFieldGeneralized, vl, fixedtupleList)
+
+    def setPotential(self, type1, type2, potential):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            self.cxxclass.setPotential(self, type1, type2, potential)
+
+    def getPotential(self, type1, type2):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            return self.cxxclass.getPotential(self, type1, type2)
+
+class VerletListHybridReactionFieldGeneralizedLocal(InteractionLocal, interaction_VerletListHybridReactionFieldGeneralized):
+
+    def __init__(self, vl, is_cg=False):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            cxxinit(self, interaction_VerletListHybridReactionFieldGeneralized, vl, is_cg)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -383,6 +398,13 @@ if pmi.isController:
             cls =  'espressopp.interaction.CellListReactionFieldGeneralizedLocal',
             pmicall = ['setPotential']
             )
+
+    class VerletListHybridReactionFieldGeneralized(Interaction, metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+            cls =  'espressopp.interaction.VerletListHybridReactionFieldGeneralizedLocal',
+            pmicall = ['setPotential','getPotential'],
+            pmiproperty = ['scale_factor', 'max_force']
+        )
 
     #class FixedPairListReactionFieldGeneralized(Interaction):
     #    __metaclass__ = pmi.Proxy

--- a/src/interaction/ReactionFieldGeneralized.py
+++ b/src/interaction/ReactionFieldGeneralized.py
@@ -229,25 +229,29 @@ from espressopp.esutil import *
 from espressopp.interaction.Potential import *
 from espressopp.interaction.Interaction import *
 from _espressopp import interaction_ReactionFieldGeneralized, \
-                      interaction_VerletListReactionFieldGeneralized, \
-                      interaction_VerletListAdressReactionFieldGeneralized, \
-                      interaction_VerletListAdressATReactionFieldGeneralized, \
-                      interaction_VerletListHadressReactionFieldGeneralized, \
-                      interaction_VerletListHadressATReactionFieldGeneralized, \
-                      interaction_CellListReactionFieldGeneralized, \
-                      interaction_VerletListHybridReactionFieldGeneralized
-                      #interaction_FixedPairListReactionFieldGeneralized
+    interaction_VerletListReactionFieldGeneralized, \
+    interaction_VerletListAdressReactionFieldGeneralized, \
+    interaction_VerletListAdressATReactionFieldGeneralized, \
+    interaction_VerletListHadressReactionFieldGeneralized, \
+    interaction_VerletListHadressATReactionFieldGeneralized, \
+    interaction_CellListReactionFieldGeneralized, \
+    interaction_VerletListHybridReactionFieldGeneralized
+# interaction_FixedPairListReactionFieldGeneralized
+
 
 class ReactionFieldGeneralizedLocal(PotentialLocal, interaction_ReactionFieldGeneralized):
 
     def __init__(self, prefactor=1.0, kappa=0.0, epsilon1=1.0, epsilon2=80.0, cutoff=infinity, shift="auto"):
 
-        if shift =="auto":
+        if shift == "auto":
             if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-                cxxinit(self, interaction_ReactionFieldGeneralized, prefactor, kappa, epsilon1, epsilon2, cutoff)
+                cxxinit(self, interaction_ReactionFieldGeneralized,
+                        prefactor, kappa, epsilon1, epsilon2, cutoff)
         else:
             if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-                cxxinit(self, interaction_ReactionFieldGeneralized, prefactor, kappa, epsilon1, epsilon2, cutoff, shift)
+                cxxinit(self, interaction_ReactionFieldGeneralized,
+                        prefactor, kappa, epsilon1, epsilon2, cutoff, shift)
+
 
 class VerletListReactionFieldGeneralizedLocal(InteractionLocal, interaction_VerletListReactionFieldGeneralized):
 
@@ -263,11 +267,13 @@ class VerletListReactionFieldGeneralizedLocal(InteractionLocal, interaction_Verl
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getPotential(self, type1, type2)
 
+
 class VerletListAdressATReactionFieldGeneralizedLocal(InteractionLocal, interaction_VerletListAdressATReactionFieldGeneralized):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressATReactionFieldGeneralized, vl, fixedtupleList)
+            cxxinit(
+                self, interaction_VerletListAdressATReactionFieldGeneralized, vl, fixedtupleList)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -276,12 +282,14 @@ class VerletListAdressATReactionFieldGeneralizedLocal(InteractionLocal, interact
     def getPotential(self, type1, type2):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getPotential(self, type1, type2)
+
 
 class VerletListHybridReactionFieldGeneralizedLocal(InteractionLocal, interaction_VerletListHybridReactionFieldGeneralized):
 
     def __init__(self, vl, is_cg=False):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHybridReactionFieldGeneralized, vl, is_cg)
+            cxxinit(
+                self, interaction_VerletListHybridReactionFieldGeneralized, vl, is_cg)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -291,11 +299,13 @@ class VerletListHybridReactionFieldGeneralizedLocal(InteractionLocal, interactio
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getPotential(self, type1, type2)
 
+
 class VerletListAdressReactionFieldGeneralizedLocal(InteractionLocal, interaction_VerletListAdressReactionFieldGeneralized):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressReactionFieldGeneralized, vl, fixedtupleList)
+            cxxinit(
+                self, interaction_VerletListAdressReactionFieldGeneralized, vl, fixedtupleList)
 
     def setPotentialAT(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -305,11 +315,13 @@ class VerletListAdressReactionFieldGeneralizedLocal(InteractionLocal, interactio
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotentialCG(self, type1, type2, potential)
 
+
 class VerletListHadressATReactionFieldGeneralizedLocal(InteractionLocal, interaction_VerletListHadressATReactionFieldGeneralized):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressATReactionFieldGeneralized, vl, fixedtupleList)
+            cxxinit(
+                self, interaction_VerletListHadressATReactionFieldGeneralized, vl, fixedtupleList)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -319,11 +331,13 @@ class VerletListHadressATReactionFieldGeneralizedLocal(InteractionLocal, interac
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getPotential(self, type1, type2)
 
+
 class VerletListHadressReactionFieldGeneralizedLocal(InteractionLocal, interaction_VerletListHadressReactionFieldGeneralized):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressReactionFieldGeneralized, vl, fixedtupleList)
+            cxxinit(
+                self, interaction_VerletListHadressReactionFieldGeneralized, vl, fixedtupleList)
 
     def setPotentialAT(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -345,7 +359,7 @@ class CellListReactionFieldGeneralizedLocal(InteractionLocal, interaction_CellLi
             self.cxxclass.setPotential(self, type1, type2, potential)
 
 
-#class FixedPairListReactionFieldGeneralizedLocal(InteractionLocal, interaction_FixedPairListReactionFieldGeneralized):
+# class FixedPairListReactionFieldGeneralizedLocal(InteractionLocal, interaction_FixedPairListReactionFieldGeneralized):
 #    'The (local) ReactionFieldGeneralized interaction using FixedPair lists.'
 #    def __init__(self, system, vl, potential):
 #        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -359,54 +373,54 @@ if pmi.isController:
     class ReactionFieldGeneralized(Potential):
         'The ReactionFieldGeneralized potential.'
         pmiproxydefs = dict(
-            cls = 'espressopp.interaction.ReactionFieldGeneralizedLocal',
-            pmiproperty = ['prefactor']#['qq']
-            )
+            cls='espressopp.interaction.ReactionFieldGeneralizedLocal',
+            pmiproperty=['prefactor']  # ['qq']
+        )
 
     class VerletListReactionFieldGeneralized(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListReactionFieldGeneralizedLocal',
-            pmicall = ['setPotential','getPotential']
-            )
+            cls='espressopp.interaction.VerletListReactionFieldGeneralizedLocal',
+            pmicall=['setPotential', 'getPotential']
+        )
 
     class VerletListAdressATReactionFieldGeneralized(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressATReactionFieldGeneralizedLocal',
-            pmicall = ['setPotential','getPotential']
-            )
+            cls='espressopp.interaction.VerletListAdressATReactionFieldGeneralizedLocal',
+            pmicall=['setPotential', 'getPotential']
+        )
 
     class VerletListAdressReactionFieldGeneralized(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressReactionFieldGeneralizedLocal',
-            pmicall = ['setPotentialAT', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListAdressReactionFieldGeneralizedLocal',
+            pmicall=['setPotentialAT', 'setPotentialCG']
+        )
 
     class VerletListHadressATReactionFieldGeneralized(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressATReactionFieldGeneralizedLocal',
-            pmicall = ['setPotential','getPotential']
-            )
+            cls='espressopp.interaction.VerletListHadressATReactionFieldGeneralizedLocal',
+            pmicall=['setPotential', 'getPotential']
+        )
 
     class VerletListHadressReactionFieldGeneralized(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressReactionFieldGeneralizedLocal',
-            pmicall = ['setPotentialAT', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListHadressReactionFieldGeneralizedLocal',
+            pmicall=['setPotentialAT', 'setPotentialCG']
+        )
 
     class CellListReactionFieldGeneralized(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.CellListReactionFieldGeneralizedLocal',
-            pmicall = ['setPotential']
-            )
+            cls='espressopp.interaction.CellListReactionFieldGeneralizedLocal',
+            pmicall=['setPotential']
+        )
 
     class VerletListHybridReactionFieldGeneralized(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHybridReactionFieldGeneralizedLocal',
-            pmicall = ['setPotential','getPotential'],
-            pmiproperty = ['scale_factor', 'max_force']
+            cls='espressopp.interaction.VerletListHybridReactionFieldGeneralizedLocal',
+            pmicall=['setPotential', 'getPotential'],
+            pmiproperty=['scale_factor', 'max_force']
         )
 
-    #class FixedPairListReactionFieldGeneralized(Interaction):
+    # class FixedPairListReactionFieldGeneralized(Interaction):
     #    __metaclass__ = pmi.Proxy
     #    pmiproxydefs = dict(
     #        cls =  'espressopp.interaction.FixedPairListReactionFieldGeneralizedLocal',

--- a/src/interaction/Tabulated.cpp
+++ b/src/interaction/Tabulated.cpp
@@ -232,6 +232,19 @@ void Tabulated::registerPython()
         .def("setSpeedup", &FixedPairListPIadressTabulated::setSpeedup)
         .def("getSpeedup", &FixedPairListPIadressTabulated::getSpeedup);
     ;
+
+    class_<FixedPairListAdressTabulated, bases<Interaction> >(
+        "interaction_FixedPairListAdressTabulated",
+        init<shared_ptr<System>, shared_ptr<FixedPairList>, shared_ptr<Tabulated>, bool>())
+        .def(init<shared_ptr<System>, shared_ptr<FixedPairListAdress>, shared_ptr<Tabulated>,
+                  bool>())
+        .def("setPotential", &FixedPairListAdressTabulated::setPotential)
+        .def("getPotential", &FixedPairListAdressTabulated::getPotential)
+        .def("setFixedPairList", &FixedPairListAdressTabulated::setFixedPairList)
+        .def("getFixedPairList", &FixedPairListAdressTabulated::getFixedPairList)
+        .add_property("scale_factor", &FixedPairListAdressTabulated::scaleFactor,
+                      &FixedPairListAdressTabulated::setScaleFactor);
+    ;
 }
 
 }  // namespace interaction

--- a/src/interaction/Tabulated.cpp
+++ b/src/interaction/Tabulated.cpp
@@ -180,8 +180,7 @@ void Tabulated::registerPython()
     ;
 
     class_<VerletListHybridTabulated, bases<Interaction> >(
-        "interaction_VerletListHybridTabulated",
-        init<std::shared_ptr<VerletList>, bool>())
+        "interaction_VerletListHybridTabulated", init<std::shared_ptr<VerletList>, bool>())
         .def("getVerletList", &VerletListHybridTabulated::getVerletList)
         .def("setPotential", &VerletListHybridTabulated::setPotential)
         .def("getPotential", &VerletListHybridTabulated::getPotentialPtr)

--- a/src/interaction/Tabulated.cpp
+++ b/src/interaction/Tabulated.cpp
@@ -31,6 +31,7 @@
 #include "InterpolationAkima.hpp"
 #include "InterpolationCubic.hpp"
 #include "VerletListInteractionTemplate.hpp"
+#include "VerletListHybridInteractionTemplate.hpp"
 #include "VerletListAdressInteractionTemplate.hpp"
 #include "VerletListAdressCGInteractionTemplate.hpp"
 #include "VerletListHadressInteractionTemplate.hpp"
@@ -41,6 +42,7 @@
 #include "FixedPairListInteractionTemplate.hpp"
 #include "FixedPairListTypesInteractionTemplate.hpp"
 #include "FixedPairListPIadressInteractionTemplate.hpp"
+#include "FixedPairListAdressInteractionTemplate.hpp"
 
 namespace espressopp
 {
@@ -71,6 +73,7 @@ void Tabulated::setFilename(int itype, const char* _filename)
 }
 
 typedef class VerletListInteractionTemplate<Tabulated> VerletListTabulated;
+typedef class VerletListHybridInteractionTemplate<Tabulated> VerletListHybridTabulated;
 typedef class VerletListAdressInteractionTemplate<Tabulated, Tabulated> VerletListAdressTabulated;
 typedef class VerletListAdressCGInteractionTemplate<Tabulated> VerletListAdressCGTabulated;
 typedef class VerletListHadressInteractionTemplate<Tabulated, Tabulated> VerletListHadressTabulated;
@@ -85,6 +88,8 @@ typedef class CellListAllPairsInteractionTemplate<Tabulated> CellListTabulated;
 typedef class FixedPairListInteractionTemplate<Tabulated> FixedPairListTabulated;
 typedef class FixedPairListTypesInteractionTemplate<Tabulated> FixedPairListTypesTabulated;
 typedef class FixedPairListPIadressInteractionTemplate<Tabulated> FixedPairListPIadressTabulated;
+typedef class FixedPairListAdressInteractionTemplate<Tabulated> FixedPairListAdressTabulated;
+LOG4ESPP_LOGGER(Tabulated::theLogger, "Tabulated");
 
 //////////////////////////////////////////////////
 // REGISTRATION WITH PYTHON
@@ -172,6 +177,18 @@ void Tabulated::registerPython()
         .def("getNTrotter", &VerletListPIadressNoDriftTabulated::getNTrotter)
         .def("setSpeedup", &VerletListPIadressNoDriftTabulated::setSpeedup)
         .def("getSpeedup", &VerletListPIadressNoDriftTabulated::getSpeedup);
+    ;
+
+    class_<VerletListHybridTabulated, bases<Interaction> >(
+        "interaction_VerletListHybridTabulated",
+        init<std::shared_ptr<VerletList>, bool>())
+        .def("getVerletList", &VerletListHybridTabulated::getVerletList)
+        .def("setPotential", &VerletListHybridTabulated::setPotential)
+        .def("getPotential", &VerletListHybridTabulated::getPotentialPtr)
+        .add_property("scale_factor", &VerletListHybridTabulated::scaleFactor,
+                      &VerletListHybridTabulated::setScaleFactor)
+        .add_property("max_force", &VerletListHybridTabulated::maxForce,
+                      &VerletListHybridTabulated::setMaxForce);
     ;
 
     class_<CellListTabulated, bases<Interaction> >("interaction_CellListTabulated",

--- a/src/interaction/Tabulated.hpp
+++ b/src/interaction/Tabulated.hpp
@@ -27,6 +27,7 @@
 //#include <stdexcept>
 #include "Potential.hpp"
 #include "Interpolation.hpp"
+#include "FixedPairListAdressInteractionTemplate.hpp"
 
 namespace espressopp
 {
@@ -48,6 +49,8 @@ private:
     int interpolationType;
 
 public:
+    static LOG4ESPP_DECL_LOGGER(theLogger);
+
     static void registerPython();
 
     Tabulated()

--- a/src/interaction/Tabulated.py
+++ b/src/interaction/Tabulated.py
@@ -594,20 +594,21 @@ from espressopp.esutil import *
 from espressopp.interaction.Potential import *
 from espressopp.interaction.Interaction import *
 from _espressopp import interaction_Tabulated, \
-                      interaction_VerletListTabulated, \
-                      interaction_VerletListHybridTabulated, \
-                      interaction_VerletListAdressTabulated, \
-                      interaction_VerletListAdressCGTabulated, \
-                      interaction_VerletListHadressTabulated, \
-                      interaction_VerletListHadressCGTabulated, \
-                      interaction_VerletListPIadressTabulated, \
-                      interaction_VerletListPIadressTabulatedLJ, \
-                      interaction_VerletListPIadressNoDriftTabulated, \
-                      interaction_CellListTabulated, \
-                      interaction_FixedPairListTabulated, \
-                      interaction_FixedPairListTypesTabulated, \
-                      interaction_FixedPairListPIadressTabulated, \
-                      interaction_FixedPairListAdressTabulated
+    interaction_VerletListTabulated, \
+    interaction_VerletListHybridTabulated, \
+    interaction_VerletListAdressTabulated, \
+    interaction_VerletListAdressCGTabulated, \
+    interaction_VerletListHadressTabulated, \
+    interaction_VerletListHadressCGTabulated, \
+    interaction_VerletListPIadressTabulated, \
+    interaction_VerletListPIadressTabulatedLJ, \
+    interaction_VerletListPIadressNoDriftTabulated, \
+    interaction_CellListTabulated, \
+    interaction_FixedPairListTabulated, \
+    interaction_FixedPairListTypesTabulated, \
+    interaction_FixedPairListPIadressTabulated, \
+    interaction_FixedPairListAdressTabulated
+
 
 class TabulatedLocal(PotentialLocal, interaction_Tabulated):
 
@@ -616,11 +617,13 @@ class TabulatedLocal(PotentialLocal, interaction_Tabulated):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             cxxinit(self, interaction_Tabulated, itype, filename, cutoff)
 
+
 class VerletListAdressCGTabulatedLocal(InteractionLocal, interaction_VerletListAdressCGTabulated):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressCGTabulated, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListAdressCGTabulated,
+                    vl, fixedtupleList)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -633,12 +636,14 @@ class VerletListAdressCGTabulatedLocal(InteractionLocal, interaction_VerletListA
     def getVerletListLocal(self):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getVerletList(self)
+
 
 class VerletListAdressTabulatedLocal(InteractionLocal, interaction_VerletListAdressTabulated):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListAdressTabulated, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListAdressTabulated,
+                    vl, fixedtupleList)
 
     def setPotentialAT(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -648,11 +653,13 @@ class VerletListAdressTabulatedLocal(InteractionLocal, interaction_VerletListAdr
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotentialCG(self, type1, type2, potential)
 
+
 class VerletListHadressCGTabulatedLocal(InteractionLocal, interaction_VerletListHadressCGTabulated):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressCGTabulated, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListHadressCGTabulated,
+                    vl, fixedtupleList)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -666,11 +673,13 @@ class VerletListHadressCGTabulatedLocal(InteractionLocal, interaction_VerletList
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getVerletList(self)
 
+
 class VerletListHadressTabulatedLocal(InteractionLocal, interaction_VerletListHadressTabulated):
 
     def __init__(self, vl, fixedtupleList):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListHadressTabulated, vl, fixedtupleList)
+            cxxinit(self, interaction_VerletListHadressTabulated,
+                    vl, fixedtupleList)
 
     def setPotentialAT(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -679,6 +688,7 @@ class VerletListHadressTabulatedLocal(InteractionLocal, interaction_VerletListHa
     def setPotentialCG(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotentialCG(self, type1, type2, potential)
+
 
 class VerletListTabulatedLocal(InteractionLocal, interaction_VerletListTabulated):
 
@@ -693,6 +703,7 @@ class VerletListTabulatedLocal(InteractionLocal, interaction_VerletListTabulated
     def getPotential(self, type1, type2):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getPotential(self, type1, type2)
+
 
 class VerletListHybridTabulatedLocal(InteractionLocal, interaction_VerletListHybridTabulated):
     def __init__(self, vl, cg_potential=False):
@@ -711,7 +722,8 @@ class VerletListHybridTabulatedLocal(InteractionLocal, interaction_VerletListHyb
 class VerletListPIadressTabulatedLocal(InteractionLocal, interaction_VerletListPIadressTabulated):
     def __init__(self, vl, fixedtupleList, ntrotter, speedup):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListPIadressTabulated, vl, fixedtupleList, ntrotter, speedup)
+            cxxinit(self, interaction_VerletListPIadressTabulated,
+                    vl, fixedtupleList, ntrotter, speedup)
 
     def setPotentialQM(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -757,7 +769,8 @@ class VerletListPIadressTabulatedLocal(InteractionLocal, interaction_VerletListP
 class VerletListPIadressTabulatedLJLocal(InteractionLocal, interaction_VerletListPIadressTabulatedLJ):
     def __init__(self, vl, fixedtupleList, ntrotter, speedup):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListPIadressTabulatedLJ, vl, fixedtupleList, ntrotter, speedup)
+            cxxinit(self, interaction_VerletListPIadressTabulatedLJ,
+                    vl, fixedtupleList, ntrotter, speedup)
 
     def setPotentialQM(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -803,7 +816,8 @@ class VerletListPIadressTabulatedLJLocal(InteractionLocal, interaction_VerletLis
 class VerletListPIadressNoDriftTabulatedLocal(InteractionLocal, interaction_VerletListPIadressNoDriftTabulated):
     def __init__(self, vl, fixedtupleList, ntrotter, speedup):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_VerletListPIadressNoDriftTabulated, vl, fixedtupleList, ntrotter, speedup)
+            cxxinit(self, interaction_VerletListPIadressNoDriftTabulated,
+                    vl, fixedtupleList, ntrotter, speedup)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -856,6 +870,7 @@ class VerletListTabulatedLocal(InteractionLocal, interaction_VerletListTabulated
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             return self.cxxclass.getPotential(self, type1, type2)
 
+
 class CellListTabulatedLocal(InteractionLocal, interaction_CellListTabulated):
 
     def __init__(self, stor):
@@ -871,7 +886,8 @@ class FixedPairListTabulatedLocal(InteractionLocal, interaction_FixedPairListTab
 
     def __init__(self, system, vl, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedPairListTabulated, system, vl, potential)
+            cxxinit(self, interaction_FixedPairListTabulated,
+                    system, vl, potential)
 
     def setPotential(self, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -903,7 +919,8 @@ class FixedPairListTypesTabulatedLocal(InteractionLocal, interaction_FixedPairLi
 class FixedPairListPIadressTabulatedLocal(InteractionLocal, interaction_FixedPairListPIadressTabulated):
     def __init__(self, system, fpl, fixedtupleList, potential, ntrotter, speedup):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedPairListPIadressTabulated, system, fpl, fixedtupleList, potential, ntrotter, speedup)
+            cxxinit(self, interaction_FixedPairListPIadressTabulated,
+                    system, fpl, fixedtupleList, potential, ntrotter, speedup)
 
     def setPotential(self, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -948,103 +965,111 @@ class FixedPairListPIadressTabulatedLocal(InteractionLocal, interaction_FixedPai
 
 class FixedPairListAdressTabulatedLocal(InteractionLocal, interaction_FixedPairListAdressTabulated):
     'The (local) tabulated interaction using FixedPair lists.'
+
     def __init__(self, system, vl, potential, is_cg=False):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedPairListAdressTabulated, system, vl, potential, is_cg)
+            cxxinit(self, interaction_FixedPairListAdressTabulated,
+                    system, vl, potential, is_cg)
 
     def setPotential(self, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotential(self, potential)
 
+
 if pmi.isController:
     class Tabulated(Potential):
         'The Tabulated potential.'
         pmiproxydefs = dict(
-            cls = 'espressopp.interaction.TabulatedLocal',
-            pmiproperty = ['itype', 'filename', 'cutoff']
-            )
+            cls='espressopp.interaction.TabulatedLocal',
+            pmiproperty=['itype', 'filename', 'cutoff']
+        )
 
     class VerletListAdressCGTabulated(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressCGTabulatedLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList']
-            )
+            cls='espressopp.interaction.VerletListAdressCGTabulatedLocal',
+            pmicall=['setPotential', 'getPotential', 'getVerletList']
+        )
 
     class VerletListAdressTabulated(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListAdressTabulatedLocal',
-            pmicall = ['setPotentialAT', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListAdressTabulatedLocal',
+            pmicall=['setPotentialAT', 'setPotentialCG']
+        )
 
     class VerletListHadressCGTabulated(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressCGTabulatedLocal',
-            pmicall = ['setPotential', 'getPotential', 'getVerletList']
-            )
+            cls='espressopp.interaction.VerletListHadressCGTabulatedLocal',
+            pmicall=['setPotential', 'getPotential', 'getVerletList']
+        )
 
     class VerletListHadressTabulated(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHadressTabulatedLocal',
-            pmicall = ['setPotentialAT', 'setPotentialCG']
-            )
+            cls='espressopp.interaction.VerletListHadressTabulatedLocal',
+            pmicall=['setPotentialAT', 'setPotentialCG']
+        )
 
     class VerletListPIadressTabulated(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListPIadressTabulatedLocal',
-            pmicall = ['setPotentialQM','setPotentialCL','setVerletList', 'getVerletList', 'setFixedTupleList', 'getFixedTupleList', 'setNTrotter', 'getNTrotter', 'setSpeedup', 'getSpeedup']
-            )
+            cls='espressopp.interaction.VerletListPIadressTabulatedLocal',
+            pmicall=['setPotentialQM', 'setPotentialCL', 'setVerletList', 'getVerletList', 'setFixedTupleList',
+                     'getFixedTupleList', 'setNTrotter', 'getNTrotter', 'setSpeedup', 'getSpeedup']
+        )
 
     class VerletListPIadressTabulatedLJ(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListPIadressTabulatedLJLocal',
-            pmicall = ['setPotentialQM','setPotentialCL','setVerletList', 'getVerletList', 'setFixedTupleList', 'getFixedTupleList', 'setNTrotter', 'getNTrotter', 'setSpeedup', 'getSpeedup']
-            )
+            cls='espressopp.interaction.VerletListPIadressTabulatedLJLocal',
+            pmicall=['setPotentialQM', 'setPotentialCL', 'setVerletList', 'getVerletList', 'setFixedTupleList',
+                     'getFixedTupleList', 'setNTrotter', 'getNTrotter', 'setSpeedup', 'getSpeedup']
+        )
 
     class VerletListPIadressNoDriftTabulated(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListPIadressNoDriftTabulatedLocal',
-            pmicall = ['setPotential','setVerletList', 'getVerletList', 'setFixedTupleList', 'getFixedTupleList', 'setNTrotter', 'getNTrotter', 'setSpeedup', 'getSpeedup']
-            )
+            cls='espressopp.interaction.VerletListPIadressNoDriftTabulatedLocal',
+            pmicall=['setPotential', 'setVerletList', 'getVerletList', 'setFixedTupleList',
+                     'getFixedTupleList', 'setNTrotter', 'getNTrotter', 'setSpeedup', 'getSpeedup']
+        )
 
     class VerletListTabulated(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListTabulatedLocal',
-            pmicall = ['setPotential','getPotential']
-            )
+            cls='espressopp.interaction.VerletListTabulatedLocal',
+            pmicall=['setPotential', 'getPotential']
+        )
 
     class VerletListHybridTabulated(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.VerletListHybridTabulatedLocal',
-            pmicall = ['setPotential','getPotential'],
-            pmiproperty = ('scale_factor', 'max_force')
+            cls='espressopp.interaction.VerletListHybridTabulatedLocal',
+            pmicall=['setPotential', 'getPotential'],
+            pmiproperty=('scale_factor', 'max_force')
         )
 
     class CellListTabulated(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.CellListTabulatedLocal',
-            pmicall = ['setPotential']
-            )
+            cls='espressopp.interaction.CellListTabulatedLocal',
+            pmicall=['setPotential']
+        )
 
     class FixedPairListTabulated(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedPairListTabulatedLocal',
-            pmicall = ['setPotential', 'setFixedPairList', 'getFixedPairList']
-            )
+            cls='espressopp.interaction.FixedPairListTabulatedLocal',
+            pmicall=['setPotential', 'setFixedPairList', 'getFixedPairList']
+        )
 
     class FixedPairListTypesTabulated(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedPairListTypesTabulatedLocal',
-            pmicall = ['setPotential','getPotential','setFixedPairList','getFixedPairList']
-            )
+            cls='espressopp.interaction.FixedPairListTypesTabulatedLocal',
+            pmicall=['setPotential', 'getPotential',
+                     'setFixedPairList', 'getFixedPairList']
+        )
 
     class FixedPairListPIadressTabulated(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedPairListPIadressTabulatedLocal',
-            pmicall = ['setPotential', 'getPotential', 'setFixedPairList', 'getFixedPairList', 'setFixedTupleList', 'getFixedTupleList', 'setNTrotter', 'getNTrotter', 'setSpeedup', 'getSpeedup']
-            )
+            cls='espressopp.interaction.FixedPairListPIadressTabulatedLocal',
+            pmicall=['setPotential', 'getPotential', 'setFixedPairList', 'getFixedPairList',
+                     'setFixedTupleList', 'getFixedTupleList', 'setNTrotter', 'getNTrotter', 'setSpeedup', 'getSpeedup']
+        )
 
     class FixedPairListAdressTabulated(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedPairListAdressTabulatedLocal',
-            pmicall = ['setPotential', 'setFixedPairList', 'getFixedPairList']
-            )
+            cls='espressopp.interaction.FixedPairListAdressTabulatedLocal',
+            pmicall=['setPotential', 'setFixedPairList', 'getFixedPairList']
+        )

--- a/src/interaction/TabulatedAngular.cpp
+++ b/src/interaction/TabulatedAngular.cpp
@@ -115,7 +115,8 @@ void TabulatedAngular::registerPython()
 
     class_<FixedTripleListAdressTabulatedAngular, bases<Interaction> >(
         "interaction_FixedTripleListAdressTabulatedAngular",
-        init<std::shared_ptr<System>, std::shared_ptr<FixedTripleList>, std::shared_ptr<TabulatedAngular>, bool>())
+        init<std::shared_ptr<System>, std::shared_ptr<FixedTripleList>,
+             std::shared_ptr<TabulatedAngular>, bool>())
         .def("setPotential", &FixedTripleListAdressTabulatedAngular::setPotential)
         .def("getPotential", &FixedTripleListAdressTabulatedAngular::getPotential)
         .def("getFixedTripleList", &FixedTripleListAdressTabulatedAngular::getFixedTripleList);

--- a/src/interaction/TabulatedAngular.cpp
+++ b/src/interaction/TabulatedAngular.cpp
@@ -32,6 +32,7 @@
 #include "FixedTripleListInteractionTemplate.hpp"
 #include "FixedTripleListTypesInteractionTemplate.hpp"
 #include "FixedTripleListPIadressInteractionTemplate.hpp"
+#include "FixedTripleListAdressInteractionTemplate.hpp"
 
 namespace espressopp
 {
@@ -66,6 +67,9 @@ typedef class FixedTripleListTypesInteractionTemplate<TabulatedAngular>
     FixedTripleListTypesTabulatedAngular;
 typedef class FixedTripleListPIadressInteractionTemplate<TabulatedAngular>
     FixedTripleListPIadressTabulatedAngular;
+
+typedef class FixedTripleListAdressInteractionTemplate<TabulatedAngular>
+    FixedTripleListAdressTabulatedAngular;
 
 //////////////////////////////////////////////////
 // REGISTRATION WITH PYTHON
@@ -108,6 +112,13 @@ void TabulatedAngular::registerPython()
         .def("getNTrotter", &FixedTripleListPIadressTabulatedAngular::getNTrotter)
         .def("setSpeedup", &FixedTripleListPIadressTabulatedAngular::setSpeedup)
         .def("getSpeedup", &FixedTripleListPIadressTabulatedAngular::getSpeedup);
+
+    class_<FixedTripleListAdressTabulatedAngular, bases<Interaction> >(
+        "interaction_FixedTripleListAdressTabulatedAngular",
+        init<std::shared_ptr<System>, std::shared_ptr<FixedTripleList>, std::shared_ptr<TabulatedAngular>, bool>())
+        .def("setPotential", &FixedTripleListAdressTabulatedAngular::setPotential)
+        .def("getPotential", &FixedTripleListAdressTabulatedAngular::getPotential)
+        .def("getFixedTripleList", &FixedTripleListAdressTabulatedAngular::getFixedTripleList);
 }
 
 }  // namespace interaction

--- a/src/interaction/TabulatedAngular.py
+++ b/src/interaction/TabulatedAngular.py
@@ -166,10 +166,10 @@ from espressopp.esutil import *
 from espressopp.interaction.AngularPotential import *
 from espressopp.interaction.Interaction import *
 from _espressopp import interaction_TabulatedAngular, \
-                        interaction_FixedTripleListTabulatedAngular, \
-                        interaction_FixedTripleListTypesTabulatedAngular, \
-                        interaction_FixedTripleListPIadressTabulatedAngular, \
-                        interaction_FixedTripleListAdressTabulatedAngular
+    interaction_FixedTripleListTabulatedAngular, \
+    interaction_FixedTripleListTypesTabulatedAngular, \
+    interaction_FixedTripleListPIadressTabulatedAngular, \
+    interaction_FixedTripleListAdressTabulatedAngular
 
 
 class TabulatedAngularLocal(AngularPotentialLocal, interaction_TabulatedAngular):
@@ -177,11 +177,13 @@ class TabulatedAngularLocal(AngularPotentialLocal, interaction_TabulatedAngular)
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             cxxinit(self, interaction_TabulatedAngular, itype, filename)
 
+
 class FixedTripleListTabulatedAngularLocal(InteractionLocal, interaction_FixedTripleListTabulatedAngular):
 
     def __init__(self, system, ftl, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedTripleListTabulatedAngular, system, ftl, potential)
+            cxxinit(self, interaction_FixedTripleListTabulatedAngular,
+                    system, ftl, potential)
 
     def setPotential(self, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -191,7 +193,8 @@ class FixedTripleListTabulatedAngularLocal(InteractionLocal, interaction_FixedTr
 class FixedTripleListTypesTabulatedAngularLocal(InteractionLocal, interaction_FixedTripleListTypesTabulatedAngular):
     def __init__(self, system, ftl):
         if pmi.workerIsActive():
-            cxxinit(self, interaction_FixedTripleListTypesTabulatedAngular, system, ftl)
+            cxxinit(
+                self, interaction_FixedTripleListTypesTabulatedAngular, system, ftl)
 
     def setPotential(self, type1, type2, type3, potential):
         if pmi.workerIsActive():
@@ -212,9 +215,11 @@ class FixedTripleListTypesTabulatedAngularLocal(InteractionLocal, interaction_Fi
 
 class FixedTripleListPIadressTabulatedAngularLocal(InteractionLocal, interaction_FixedTripleListPIadressTabulatedAngular):
     'The (local) tanulated angular interaction using FixedTriple lists.'
+
     def __init__(self, system, ftl, fixedtupleList, potential, ntrotter, speedup):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedTripleListPIadressTabulatedAngular, system, ftl, fixedtupleList, potential, ntrotter, speedup)
+            cxxinit(self, interaction_FixedTripleListPIadressTabulatedAngular,
+                    system, ftl, fixedtupleList, potential, ntrotter, speedup)
 
     def setPotential(self, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -256,11 +261,14 @@ class FixedTripleListPIadressTabulatedAngularLocal(InteractionLocal, interaction
         if pmi.workerIsActive():
             self.cxxclass.getSpeedup(self)
 
+
 class FixedTripleListAdressTabulatedAngularLocal(InteractionLocal, interaction_FixedTripleListAdressTabulatedAngular):
     'The (local) tabulated angular interaction using FixedTriple lists.'
+
     def __init__(self, system, vl, potential, cg_potential=False):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedTripleListAdressTabulatedAngular, system, vl, potential, cg_potential)
+            cxxinit(self, interaction_FixedTripleListAdressTabulatedAngular,
+                    system, vl, potential, cg_potential)
 
     def setPotential(self, type1, type2, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -271,30 +279,32 @@ if pmi.isController:
     class TabulatedAngular(AngularPotential):
         'The TabulatedAngular potential.'
         pmiproxydefs = dict(
-            cls = 'espressopp.interaction.TabulatedAngularLocal',
-            pmiproperty = ['itype', 'filename']
-            )
+            cls='espressopp.interaction.TabulatedAngularLocal',
+            pmiproperty=['itype', 'filename']
+        )
 
     class FixedTripleListTabulatedAngular(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedTripleListTabulatedAngularLocal',
-            pmicall = ['setPotential', 'getFixedTripleList']
-            )
+            cls='espressopp.interaction.FixedTripleListTabulatedAngularLocal',
+            pmicall=['setPotential', 'getFixedTripleList']
+        )
 
     class FixedTripleListTypesTabulatedAngular(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedTripleListTypesTabulatedAngularLocal',
-            pmicall = ['setPotential','getPotential', 'setFixedTripleList', 'getFixedTripleList']
+            cls='espressopp.interaction.FixedTripleListTypesTabulatedAngularLocal',
+            pmicall=['setPotential', 'getPotential',
+                     'setFixedTripleList', 'getFixedTripleList']
         )
 
     class FixedTripleListPIadressTabulatedAngular(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedTripleListPIadressTabulatedAngularLocal',
-            pmicall = ['setPotential', 'getPotential', 'setFixedTripleList', 'getFixedTripleList', 'setFixedTupleList', 'getFixedTupleList', 'setNTrotter', 'getNTrotter', 'setSpeedup', 'getSpeedup']
-            )
+            cls='espressopp.interaction.FixedTripleListPIadressTabulatedAngularLocal',
+            pmicall=['setPotential', 'getPotential', 'setFixedTripleList', 'getFixedTripleList',
+                     'setFixedTupleList', 'getFixedTupleList', 'setNTrotter', 'getNTrotter', 'setSpeedup', 'getSpeedup']
+        )
 
     class FixedTripleListAdressTabulatedAngular(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedTripleListAdressTabulatedAngularLocal',
-            pmicall = ['setPotential', 'getFixedTripleList', 'getPotential']
-            )
+            cls='espressopp.interaction.FixedTripleListAdressTabulatedAngularLocal',
+            pmicall=['setPotential', 'getFixedTripleList', 'getPotential']
+        )

--- a/src/interaction/TabulatedAngular.py
+++ b/src/interaction/TabulatedAngular.py
@@ -168,7 +168,8 @@ from espressopp.interaction.Interaction import *
 from _espressopp import interaction_TabulatedAngular, \
                         interaction_FixedTripleListTabulatedAngular, \
                         interaction_FixedTripleListTypesTabulatedAngular, \
-                        interaction_FixedTripleListPIadressTabulatedAngular
+                        interaction_FixedTripleListPIadressTabulatedAngular, \
+                        interaction_FixedTripleListAdressTabulatedAngular
 
 
 class TabulatedAngularLocal(AngularPotentialLocal, interaction_TabulatedAngular):
@@ -255,6 +256,16 @@ class FixedTripleListPIadressTabulatedAngularLocal(InteractionLocal, interaction
         if pmi.workerIsActive():
             self.cxxclass.getSpeedup(self)
 
+class FixedTripleListAdressTabulatedAngularLocal(InteractionLocal, interaction_FixedTripleListAdressTabulatedAngular):
+    'The (local) tabulated angular interaction using FixedTriple lists.'
+    def __init__(self, system, vl, potential, cg_potential=False):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            cxxinit(self, interaction_FixedTripleListAdressTabulatedAngular, system, vl, potential, cg_potential)
+
+    def setPotential(self, type1, type2, potential):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            self.cxxclass.setPotential(self, type1, type2, potential)
+
 
 if pmi.isController:
     class TabulatedAngular(AngularPotential):
@@ -280,4 +291,10 @@ if pmi.isController:
         pmiproxydefs = dict(
             cls =  'espressopp.interaction.FixedTripleListPIadressTabulatedAngularLocal',
             pmicall = ['setPotential', 'getPotential', 'setFixedTripleList', 'getFixedTripleList', 'setFixedTupleList', 'getFixedTupleList', 'setNTrotter', 'getNTrotter', 'setSpeedup', 'getSpeedup']
+            )
+
+    class FixedTripleListAdressTabulatedAngular(Interaction, metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+            cls =  'espressopp.interaction.FixedTripleListAdressTabulatedAngularLocal',
+            pmicall = ['setPotential', 'getFixedTripleList', 'getPotential']
             )

--- a/src/interaction/TabulatedDihedral.cpp
+++ b/src/interaction/TabulatedDihedral.cpp
@@ -101,8 +101,8 @@ void TabulatedDihedral::registerPython()
 
     class_<FixedQuadrupleListAdressTabulatedDihedral, bases<Interaction> >(
         "interaction_FixedQuadrupleListAdressTabulatedDihedral",
-        init<std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleList>, std::shared_ptr<TabulatedDihedral>,
-             bool>())
+        init<std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleList>,
+             std::shared_ptr<TabulatedDihedral>, bool>())
         .def(init<std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleListAdress>,
                   std::shared_ptr<TabulatedDihedral>, bool>())
         .def("setPotential", &FixedQuadrupleListAdressTabulatedDihedral::setPotential)

--- a/src/interaction/TabulatedDihedral.cpp
+++ b/src/interaction/TabulatedDihedral.cpp
@@ -32,6 +32,7 @@
 #include "FixedTripleListInteractionTemplate.hpp"
 #include "FixedQuadrupleListInteractionTemplate.hpp"
 #include "FixedQuadrupleListTypesInteractionTemplate.hpp"
+#include "FixedQuadrupleListAdressInteractionTemplate.hpp"
 
 namespace espressopp
 {
@@ -66,6 +67,8 @@ typedef class FixedQuadrupleListInteractionTemplate<TabulatedDihedral>
 
 typedef class FixedQuadrupleListTypesInteractionTemplate<TabulatedDihedral>
     FixedQuadrupleListTypesTabulatedDihedral;
+typedef class FixedQuadrupleListAdressInteractionTemplate<TabulatedDihedral>
+    FixedQuadrupleListAdressTabulatedDihedral;
 
 //////////////////////////////////////////////////
 // REGISTRATION WITH PYTHON
@@ -95,6 +98,16 @@ void TabulatedDihedral::registerPython()
              &FixedQuadrupleListTypesTabulatedDihedral::setFixedQuadrupleList)
         .def("getFixedQuadrupleList",
              &FixedQuadrupleListTypesTabulatedDihedral::getFixedQuadrupleList);
+
+    class_<FixedQuadrupleListAdressTabulatedDihedral, bases<Interaction> >(
+        "interaction_FixedQuadrupleListAdressTabulatedDihedral",
+        init<std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleList>, std::shared_ptr<TabulatedDihedral>,
+             bool>())
+        .def(init<std::shared_ptr<System>, std::shared_ptr<FixedQuadrupleListAdress>,
+                  std::shared_ptr<TabulatedDihedral>, bool>())
+        .def("setPotential", &FixedQuadrupleListAdressTabulatedDihedral::setPotential)
+        .def("getFixedQuadrupleList",
+             &FixedQuadrupleListAdressTabulatedDihedral::getFixedQuadrupleList);
 }
 
 }  // namespace interaction

--- a/src/interaction/TabulatedDihedral.py
+++ b/src/interaction/TabulatedDihedral.py
@@ -94,9 +94,10 @@ from espressopp.esutil import *
 from espressopp.interaction.DihedralPotential import *
 from espressopp.interaction.Interaction import *
 from _espressopp import interaction_TabulatedDihedral, \
-                        interaction_FixedQuadrupleListTabulatedDihedral, \
-                        interaction_FixedQuadrupleListTypesTabulatedDihedral, \
-                        interaction_FixedQuadrupleListAdressTabulatedDihedral
+    interaction_FixedQuadrupleListTabulatedDihedral, \
+    interaction_FixedQuadrupleListTypesTabulatedDihedral, \
+    interaction_FixedQuadrupleListAdressTabulatedDihedral
+
 
 class TabulatedDihedralLocal(DihedralPotentialLocal, interaction_TabulatedDihedral):
 
@@ -104,24 +105,29 @@ class TabulatedDihedralLocal(DihedralPotentialLocal, interaction_TabulatedDihedr
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             cxxinit(self, interaction_TabulatedDihedral, itype, filename)
 
+
 class FixedQuadrupleListTabulatedDihedralLocal(InteractionLocal, interaction_FixedQuadrupleListTabulatedDihedral):
 
     def __init__(self, system, fql, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedQuadrupleListTabulatedDihedral, system, fql, potential)
+            cxxinit(self, interaction_FixedQuadrupleListTabulatedDihedral,
+                    system, fql, potential)
 
     def setPotential(self, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.setPotential(self, potential)
 
+
 class FixedQuadrupleListTypesTabulatedDihedralLocal(InteractionLocal, interaction_FixedQuadrupleListTypesTabulatedDihedral):
     def __init__(self, system, fql):
         if pmi.workerIsActive():
-            cxxinit(self, interaction_FixedQuadrupleListTypesTabulatedDihedral, system, fql)
+            cxxinit(
+                self, interaction_FixedQuadrupleListTypesTabulatedDihedral, system, fql)
 
     def setPotential(self, type1, type2, type3, type4, potential):
         if pmi.workerIsActive():
-            self.cxxclass.setPotential(self, type1, type2, type3, type4, potential)
+            self.cxxclass.setPotential(
+                self, type1, type2, type3, type4, potential)
 
     def getPotential(self, type1, type2, type3, type4):
         if pmi.workerIsActive():
@@ -135,11 +141,14 @@ class FixedQuadrupleListTypesTabulatedDihedralLocal(InteractionLocal, interactio
         if pmi.workerIsActive():
             return self.cxxclass.getFixedQuadrupleList(self)
 
+
 class FixedQuadrupleListAdressTabulatedDihedralLocal(InteractionLocal, interaction_FixedQuadrupleListAdressTabulatedDihedral):
     'The (local) tanulated dihedral interaction using FixedQuadruple lists.'
+
     def __init__(self, system, fpl, potential, is_cg=False):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
-            cxxinit(self, interaction_FixedQuadrupleListAdressTabulatedDihedral, system, fpl, potential, is_cg)
+            cxxinit(self, interaction_FixedQuadrupleListAdressTabulatedDihedral,
+                    system, fpl, potential, is_cg)
 
     def setPotential(self, potential):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -150,24 +159,25 @@ if pmi.isController:
     class TabulatedDihedral(DihedralPotential):
         'The TabulatedDihedral potential.'
         pmiproxydefs = dict(
-            cls = 'espressopp.interaction.TabulatedDihedralLocal',
-            pmiproperty = ['itype', 'filename']
-            )
+            cls='espressopp.interaction.TabulatedDihedralLocal',
+            pmiproperty=['itype', 'filename']
+        )
 
     class FixedQuadrupleListTabulatedDihedral(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedQuadrupleListTabulatedDihedralLocal',
-            pmicall = ['setPotential', 'getFixedQuadrupleList']
-            )
+            cls='espressopp.interaction.FixedQuadrupleListTabulatedDihedralLocal',
+            pmicall=['setPotential', 'getFixedQuadrupleList']
+        )
 
     class FixedQuadrupleListTypesTabulatedDihedral(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedQuadrupleListTypesTabulatedDihedralLocal',
-            pmicall = ['setPotential','getPotential','setFixedQuadrupleList','getFixedQuadrupleList']
+            cls='espressopp.interaction.FixedQuadrupleListTypesTabulatedDihedralLocal',
+            pmicall=['setPotential', 'getPotential',
+                     'setFixedQuadrupleList', 'getFixedQuadrupleList']
         )
 
     class FixedQuadrupleListAdressTabulatedDihedral(Interaction, metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            cls =  'espressopp.interaction.FixedQuadrupleListAdressTabulatedDihedralLocal',
-            pmicall = ['setPotential', 'getFixedQuadrupleList']
-            )
+            cls='espressopp.interaction.FixedQuadrupleListAdressTabulatedDihedralLocal',
+            pmicall=['setPotential', 'getFixedQuadrupleList']
+        )

--- a/src/interaction/TabulatedDihedral.py
+++ b/src/interaction/TabulatedDihedral.py
@@ -95,8 +95,8 @@ from espressopp.interaction.DihedralPotential import *
 from espressopp.interaction.Interaction import *
 from _espressopp import interaction_TabulatedDihedral, \
                         interaction_FixedQuadrupleListTabulatedDihedral, \
-                        interaction_FixedQuadrupleListTypesTabulatedDihedral
-
+                        interaction_FixedQuadrupleListTypesTabulatedDihedral, \
+                        interaction_FixedQuadrupleListAdressTabulatedDihedral
 
 class TabulatedDihedralLocal(DihedralPotentialLocal, interaction_TabulatedDihedral):
 
@@ -135,6 +135,17 @@ class FixedQuadrupleListTypesTabulatedDihedralLocal(InteractionLocal, interactio
         if pmi.workerIsActive():
             return self.cxxclass.getFixedQuadrupleList(self)
 
+class FixedQuadrupleListAdressTabulatedDihedralLocal(InteractionLocal, interaction_FixedQuadrupleListAdressTabulatedDihedral):
+    'The (local) tanulated dihedral interaction using FixedQuadruple lists.'
+    def __init__(self, system, fpl, potential, is_cg=False):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            cxxinit(self, interaction_FixedQuadrupleListAdressTabulatedDihedral, system, fpl, potential, is_cg)
+
+    def setPotential(self, potential):
+        if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
+            self.cxxclass.setPotential(self, potential)
+
+
 if pmi.isController:
     class TabulatedDihedral(DihedralPotential):
         'The TabulatedDihedral potential.'
@@ -154,3 +165,9 @@ if pmi.isController:
             cls =  'espressopp.interaction.FixedQuadrupleListTypesTabulatedDihedralLocal',
             pmicall = ['setPotential','getPotential','setFixedQuadrupleList','getFixedQuadrupleList']
         )
+
+    class FixedQuadrupleListAdressTabulatedDihedral(Interaction, metaclass=pmi.Proxy):
+        pmiproxydefs = dict(
+            cls =  'espressopp.interaction.FixedQuadrupleListAdressTabulatedDihedralLocal',
+            pmicall = ['setPotential', 'getFixedQuadrupleList']
+            )

--- a/src/interaction/VerletListHybridInteractionTemplate.hpp
+++ b/src/interaction/VerletListHybridInteractionTemplate.hpp
@@ -1,0 +1,405 @@
+/*
+  Copyright (C) 2016
+      Jakub Krajniak (jkrajniak at gmail.com)
+
+  This file is part of ESPResSo++.
+
+  ESPResSo++ is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ESPResSo++ is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// ESPP_CLASS
+#ifndef _INTERACTION_VERLETLISTHYBRIDINTERACTIONTEMPLATE_HPP
+#define _INTERACTION_VERLETLISTHYBRIDINTERACTIONTEMPLATE_HPP
+
+#include "types.hpp"
+#include "Interaction.hpp"
+#include "Real3D.hpp"
+#include "Tensor.hpp"
+#include "Particle.hpp"
+#include "VerletList.hpp"
+#include "esutil/Array2D.hpp"
+#include "bc/BC.hpp"
+
+#include "storage/Storage.hpp"
+
+namespace espressopp {
+namespace interaction {
+template<typename _Potential>
+class VerletListHybridInteractionTemplate: public Interaction {
+
+ protected:
+  typedef _Potential Potential;
+
+ public:
+  VerletListHybridInteractionTemplate(std::shared_ptr<VerletList> _verletList, bool _cg_potential)
+      : verletList(_verletList), cgPotential(_cg_potential) {
+    potentialArray = esutil::Array2D<Potential, esutil::enlarge>(0, 0, Potential());
+    ntypes = 0;
+    scaleFactor_ = 1.0;
+    hasMaxForce_ = false;
+    maxForce_ = std::numeric_limits<real>::max();
+    LOG4ESPP_DEBUG(_Potential::theLogger, "initialize hybrid potential cg=" << cgPotential);
+  }
+
+  virtual ~VerletListHybridInteractionTemplate() { };
+
+  void setVerletList(std::shared_ptr<VerletList> _verletList) {
+    verletList = _verletList;
+  }
+
+  std::shared_ptr<VerletList> getVerletList() {
+    return verletList;
+  }
+
+  void setPotential(int type1, int type2, const Potential &potential) {
+    // typeX+1 because i<ntypes
+    ntypes = std::max(ntypes, std::max(type1 + 1, type2 + 1));
+    potentialArray.at(type1, type2) = potential;
+    LOG4ESPP_INFO(_Potential::theLogger, "added potential for type1=" << type1 << " type2=" << type2);
+    if (type1 != type2) { // add potential in the other direction
+      potentialArray.at(type2, type1) = potential;
+      LOG4ESPP_INFO(_Potential::theLogger,
+                    "automatically added the same potential for type1=" << type2 << " type2=" << type1);
+    }
+  }
+
+  // this is used in the innermost force-loop
+  Potential &getPotential(int type1, int type2) {
+    return potentialArray.at(type1, type2);
+  }
+
+  // this is mainly used to access the potential from Python (e.g. to change parameters of the potential)
+  std::shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
+    return make_shared<Potential>(potentialArray.at(type1, type2));
+  }
+
+  void setScaleFactor(real s) {
+    scaleFactor_ = s;
+    if (scaleFactor_ >= 1.0)
+      scaleFactor_ = 1.0;
+    else if (scaleFactor_ <= 0.0)
+      scaleFactor_ = 0.0;
+  }
+
+  real scaleFactor() { return scaleFactor_; }
+
+  void setMaxForce(real s) {
+      maxForce_ = s;
+      hasMaxForce_ = s > 0.0;
+  }
+
+  real maxForce() { return maxForce_; }
+
+  virtual void addForces();
+  virtual real computeEnergy();
+  virtual real computeEnergyDeriv();
+  virtual real computeEnergyAA();
+  virtual real computeEnergyCG();
+  virtual real computeEnergyAA(int atomtype);
+  virtual real computeEnergyCG(int atomtype);
+  virtual void computeVirialX(std::vector<real> &p_xx_total, int bins);
+  virtual real computeVirial();
+  virtual void computeVirialTensor(Tensor &w);
+  virtual void computeVirialTensor(Tensor &w, real z);
+  virtual void computeVirialTensor(Tensor *w, int n);
+  virtual real getMaxCutoff();
+  virtual int bondType() { return Nonbonded; }
+
+ protected:
+  int ntypes;
+  std::shared_ptr<VerletList> verletList;
+  esutil::Array2D<Potential, esutil::enlarge> potentialArray;
+
+  bool cgPotential;
+  real scaleFactor_;
+  real maxForce_;
+  bool hasMaxForce_;
+  // not needed esutil::Array2D<std::shared_ptr<Potential>, esutil::enlarge> potentialArrayPtr;
+};
+
+//////////////////////////////////////////////////
+// INLINE IMPLEMENTATION
+//////////////////////////////////////////////////
+template<typename _Potential>
+inline void
+VerletListHybridInteractionTemplate<_Potential>::
+addForces() {
+  LOG4ESPP_DEBUG(_Potential::theLogger, "loop over verlet list pairs and add forces");
+
+  for (PairList::Iterator it(verletList->getPairs()); it.isValid(); ++it) {
+    Particle &p1 = *it->first;
+    Particle &p2 = *it->second;
+    int type1 = p1.type();
+    int type2 = p2.type();
+
+    real p1lambda = p1.lambda();
+    real p2lambda = p2.lambda();
+    if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0))
+      continue;
+
+    real w12 = p1lambda * p2lambda;
+    if (w12 < 0.0)
+      w12 = 0.0;
+    real forcescale12 = w12;
+    if (cgPotential) {
+      forcescale12 = (1 - w12);
+    }
+
+    forcescale12 *= scaleFactor_;
+
+    if (forcescale12 > 0.0) {
+      const Potential &potential = getPotential(type1, type2);
+      Real3D force(0.0);
+      if (potential._computeForce(force, p1, p2)) {
+        if (hasMaxForce_) {
+          if (force.isNaNInf()) {
+            force = 0.0;
+          } else {
+            real abs_force = force.abs();
+            if (abs_force > maxForce_) {
+              force = (force / abs_force) * maxForce_;
+            }
+          }
+        }
+        p1.force() += forcescale12 * force;
+        p2.force() -= forcescale12 * force;
+        LOG4ESPP_TRACE(_Potential::theLogger, "id1=" << p1.id() << " id2=" << p2.id() << " force=" << force);
+      }
+    }
+  }
+}
+
+template<typename _Potential>
+inline real
+VerletListHybridInteractionTemplate<_Potential>::
+computeEnergy() {
+  LOG4ESPP_DEBUG(_Potential::theLogger, "loop over verlet list pairs and sum up potential energies");
+
+  real es = 0.0;
+  for (PairList::Iterator it(verletList->getPairs()); it.isValid(); ++it) {
+    Particle &p1 = *it->first;
+    Particle &p2 = *it->second;
+    int type1 = p1.type();
+    int type2 = p2.type();
+
+    real p1lambda = p1.lambda();
+    real p2lambda = p2.lambda();
+
+    if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0))
+      continue;
+
+    real w12 = p1lambda * p2lambda;
+    if (w12 < 0.0)
+      w12 = 0.0;
+
+    real forcescale12 = w12;
+    if (cgPotential) {
+      forcescale12 = (1 - w12);
+    }
+
+    forcescale12 *= scaleFactor_;
+
+    if (forcescale12 > 0.0) {
+      const Potential &potential = getPotential(type1, type2);
+      real e1 = forcescale12*potential._computeEnergy(p1, p2);
+      if (std::isnan(e1))
+        e1 = 0.0;
+      es += e1;
+      LOG4ESPP_TRACE(_Potential::theLogger, "id1=" << p1.id() << " id2=" << p2.id() << " potential energy=" << es);
+    }
+  }
+
+  // reduce over all CPUs
+  real esum = 0.0;
+  boost::mpi::all_reduce(*getVerletList()->getSystem()->comm, es, esum, std::plus<real>());
+  return esum;
+}
+
+template<typename _Potential>
+inline real
+VerletListHybridInteractionTemplate<_Potential>::
+computeEnergyAA() {
+  return computeEnergy();
+}
+
+template<typename _Potential>
+inline real
+VerletListHybridInteractionTemplate<_Potential>::
+computeEnergyCG() {
+  return computeEnergy();
+}
+
+template <typename _Potential>
+inline real VerletListHybridInteractionTemplate<_Potential>::computeEnergyDeriv()
+{
+    std::cout << "Warning! At the moment computeEnergyDeriv() in VerletListHybridInteractionTemplate "
+                 "does not work."
+              << std::endl;
+    return 0.0;
+}
+
+template <typename _Potential>
+inline real VerletListHybridInteractionTemplate<_Potential>::computeEnergyAA(int atomtype)
+{
+    std::cout << "Warning! At the moment computeEnergyAA(int atomtype) in "
+                 "VerletListHybridInteractionTemplate does not work."
+              << std::endl;
+    return 0.0;
+}
+
+template <typename _Potential>
+inline real VerletListHybridInteractionTemplate<_Potential>::computeEnergyCG(int atomtype)
+{
+    std::cout << "Warning! At the moment computeEnergyCG(int atomtype) in "
+                 "VerletListHybridInteractionTemplate does not work."
+              << std::endl;
+    return 0.0;
+}
+
+template<typename _Potential>
+inline void
+VerletListHybridInteractionTemplate<_Potential>::
+computeVirialX(std::vector<real> &p_xx_total, int bins) {
+  LOG4ESPP_WARN(_Potential::theLogger, "Warning! computeVirialX() is not yet implemented.");
+}
+
+template<typename _Potential>
+inline real
+VerletListHybridInteractionTemplate<_Potential>::
+computeVirial() {
+  LOG4ESPP_DEBUG(_Potential::theLogger, "loop over verlet list pairs and sum up virial");
+
+  real w = 0.0;
+  for (PairList::Iterator it(verletList->getPairs());
+       it.isValid(); ++it) {
+    Particle &p1 = *it->first;
+    Particle &p2 = *it->second;
+    int type1 = p1.type();
+    int type2 = p2.type();
+
+    real p1lambda = p1.lambda();
+    real p2lambda = p2.lambda();
+    if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0))
+      continue;
+
+    real w12 = p1lambda * p2lambda;
+    if (w12 < 0.0)
+      w12 = 0.0;
+    real forcescale12 = w12;
+    if (cgPotential) {
+      forcescale12 = (1 - w12);
+    }
+
+    forcescale12 *= scaleFactor_;
+
+    if (forcescale12 > 0.0) {
+      const Potential &potential = getPotential(type1, type2);
+      // std::shared_ptr<Potential> potential = getPotential(type1, type2);
+
+      Real3D force(0.0, 0.0, 0.0);
+      if (potential._computeForce(force, p1, p2)) {
+        // if(potential->_computeForce(force, p1, p2)) {
+        Real3D r21 = p1.position() - p2.position();
+        w = w + r21 * forcescale12*force;
+      }
+    }
+  }
+
+  // reduce over all CPUs
+  real wsum;
+  boost::mpi::all_reduce(*mpiWorld, w, wsum, std::plus<real>());
+  return wsum;
+}
+
+template<typename _Potential>
+inline void
+VerletListHybridInteractionTemplate<_Potential>::
+computeVirialTensor(Tensor &w) {
+  LOG4ESPP_DEBUG(_Potential::theLogger, "loop over verlet list pairs and sum up virial tensor");
+
+  Tensor wlocal(0.0);
+  for (PairList::Iterator it(verletList->getPairs());
+       it.isValid(); ++it) {
+    Particle &p1 = *it->first;
+    Particle &p2 = *it->second;
+    int type1 = p1.type();
+    int type2 = p2.type();
+
+    real p1lambda = p1.lambda();
+    real p2lambda = p2.lambda();
+    if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0))
+      continue;
+
+    real w12 = p1lambda * p2lambda;
+    if (w12 < 0.0)
+      w12 = 0.0;
+    real forcescale12 = w12;
+    if (cgPotential) {
+      forcescale12 = (1 - w12);
+    }
+
+    forcescale12 *= scaleFactor_;
+
+    if (forcescale12 > 0.0) {
+      const Potential &potential = getPotential(type1, type2);
+      // std::shared_ptr<Potential> potential = getPotential(type1, type2);
+
+      Real3D force(0.0, 0.0, 0.0);
+      if (potential._computeForce(force, p1, p2)) {
+        // if(potential->_computeForce(force, p1, p2)) {
+        Real3D r21 = p1.position() - p2.position();
+        wlocal += Tensor(r21, forcescale12*force);
+      }
+    }
+  }
+
+  // reduce over all CPUs
+  Tensor wsum(0.0);
+  boost::mpi::all_reduce(*mpiWorld, (double *) &wlocal, 6, (double *) &wsum, std::plus<double>());
+  w += wsum;
+}
+
+// local pressure tensor for layer, plane is defined by z coordinate
+template<typename _Potential>
+inline void
+VerletListHybridInteractionTemplate<_Potential>::
+computeVirialTensor(Tensor &w, real z) {
+  LOG4ESPP_ERROR(_Potential::theLogger, "computeVirialTensor not implemented for VerletListHybridInteraction");
+}
+
+// it will calculate the pressure in 'n' layers along Z axis
+// the first layer has coordinate 0.0 the last - (Lz - Lz/n)
+template<typename _Potential>
+inline void
+VerletListHybridInteractionTemplate<_Potential>::
+computeVirialTensor(Tensor *w, int n) {
+  LOG4ESPP_ERROR(_Potential::theLogger, "computeVirialTensor not implemented for VerletListHybridInteraction");
+}
+
+template<typename _Potential>
+inline real
+VerletListHybridInteractionTemplate<_Potential>::
+getMaxCutoff() {
+  real cutoff = 0.0;
+  for (int i = 0; i < ntypes; i++) {
+    for (int j = 0; j < ntypes; j++) {
+      cutoff = std::max(cutoff, getPotential(i, j).getCutoff());
+    }
+  }
+  return cutoff;
+}
+
+}
+}
+#endif

--- a/src/interaction/VerletListHybridInteractionTemplate.hpp
+++ b/src/interaction/VerletListHybridInteractionTemplate.hpp
@@ -33,219 +33,230 @@
 
 #include "storage/Storage.hpp"
 
-namespace espressopp {
-namespace interaction {
-template<typename _Potential>
-class VerletListHybridInteractionTemplate: public Interaction {
+namespace espressopp
+{
+namespace interaction
+{
+template <typename _Potential>
+class VerletListHybridInteractionTemplate : public Interaction
+{
+protected:
+    typedef _Potential Potential;
 
- protected:
-  typedef _Potential Potential;
-
- public:
-  VerletListHybridInteractionTemplate(std::shared_ptr<VerletList> _verletList, bool _cg_potential)
-      : verletList(_verletList), cgPotential(_cg_potential) {
-    potentialArray = esutil::Array2D<Potential, esutil::enlarge>(0, 0, Potential());
-    ntypes = 0;
-    scaleFactor_ = 1.0;
-    hasMaxForce_ = false;
-    maxForce_ = std::numeric_limits<real>::max();
-    LOG4ESPP_DEBUG(_Potential::theLogger, "initialize hybrid potential cg=" << cgPotential);
-  }
-
-  virtual ~VerletListHybridInteractionTemplate() { };
-
-  void setVerletList(std::shared_ptr<VerletList> _verletList) {
-    verletList = _verletList;
-  }
-
-  std::shared_ptr<VerletList> getVerletList() {
-    return verletList;
-  }
-
-  void setPotential(int type1, int type2, const Potential &potential) {
-    // typeX+1 because i<ntypes
-    ntypes = std::max(ntypes, std::max(type1 + 1, type2 + 1));
-    potentialArray.at(type1, type2) = potential;
-    LOG4ESPP_INFO(_Potential::theLogger, "added potential for type1=" << type1 << " type2=" << type2);
-    if (type1 != type2) { // add potential in the other direction
-      potentialArray.at(type2, type1) = potential;
-      LOG4ESPP_INFO(_Potential::theLogger,
-                    "automatically added the same potential for type1=" << type2 << " type2=" << type1);
+public:
+    VerletListHybridInteractionTemplate(std::shared_ptr<VerletList> _verletList, bool _cg_potential)
+        : verletList(_verletList), cgPotential(_cg_potential)
+    {
+        potentialArray = esutil::Array2D<Potential, esutil::enlarge>(0, 0, Potential());
+        ntypes = 0;
+        scaleFactor_ = 1.0;
+        hasMaxForce_ = false;
+        maxForce_ = std::numeric_limits<real>::max();
+        LOG4ESPP_DEBUG(_Potential::theLogger, "initialize hybrid potential cg=" << cgPotential);
     }
-  }
 
-  // this is used in the innermost force-loop
-  Potential &getPotential(int type1, int type2) {
-    return potentialArray.at(type1, type2);
-  }
+    virtual ~VerletListHybridInteractionTemplate(){};
 
-  // this is mainly used to access the potential from Python (e.g. to change parameters of the potential)
-  std::shared_ptr<Potential> getPotentialPtr(int type1, int type2) {
-    return make_shared<Potential>(potentialArray.at(type1, type2));
-  }
+    void setVerletList(std::shared_ptr<VerletList> _verletList) { verletList = _verletList; }
 
-  void setScaleFactor(real s) {
-    scaleFactor_ = s;
-    if (scaleFactor_ >= 1.0)
-      scaleFactor_ = 1.0;
-    else if (scaleFactor_ <= 0.0)
-      scaleFactor_ = 0.0;
-  }
+    std::shared_ptr<VerletList> getVerletList() { return verletList; }
 
-  real scaleFactor() { return scaleFactor_; }
+    void setPotential(int type1, int type2, const Potential &potential)
+    {
+        // typeX+1 because i<ntypes
+        ntypes = std::max(ntypes, std::max(type1 + 1, type2 + 1));
+        potentialArray.at(type1, type2) = potential;
+        LOG4ESPP_INFO(_Potential::theLogger,
+                      "added potential for type1=" << type1 << " type2=" << type2);
+        if (type1 != type2)
+        {  // add potential in the other direction
+            potentialArray.at(type2, type1) = potential;
+            LOG4ESPP_INFO(_Potential::theLogger, "automatically added the same potential for type1="
+                                                     << type2 << " type2=" << type1);
+        }
+    }
 
-  void setMaxForce(real s) {
-      maxForce_ = s;
-      hasMaxForce_ = s > 0.0;
-  }
+    // this is used in the innermost force-loop
+    Potential &getPotential(int type1, int type2) { return potentialArray.at(type1, type2); }
 
-  real maxForce() { return maxForce_; }
+    // this is mainly used to access the potential from Python (e.g. to change parameters of the
+    // potential)
+    std::shared_ptr<Potential> getPotentialPtr(int type1, int type2)
+    {
+        return make_shared<Potential>(potentialArray.at(type1, type2));
+    }
 
-  virtual void addForces();
-  virtual real computeEnergy();
-  virtual real computeEnergyDeriv();
-  virtual real computeEnergyAA();
-  virtual real computeEnergyCG();
-  virtual real computeEnergyAA(int atomtype);
-  virtual real computeEnergyCG(int atomtype);
-  virtual void computeVirialX(std::vector<real> &p_xx_total, int bins);
-  virtual real computeVirial();
-  virtual void computeVirialTensor(Tensor &w);
-  virtual void computeVirialTensor(Tensor &w, real z);
-  virtual void computeVirialTensor(Tensor *w, int n);
-  virtual real getMaxCutoff();
-  virtual int bondType() { return Nonbonded; }
+    void setScaleFactor(real s)
+    {
+        scaleFactor_ = s;
+        if (scaleFactor_ >= 1.0)
+            scaleFactor_ = 1.0;
+        else if (scaleFactor_ <= 0.0)
+            scaleFactor_ = 0.0;
+    }
 
- protected:
-  int ntypes;
-  std::shared_ptr<VerletList> verletList;
-  esutil::Array2D<Potential, esutil::enlarge> potentialArray;
+    real scaleFactor() { return scaleFactor_; }
 
-  bool cgPotential;
-  real scaleFactor_;
-  real maxForce_;
-  bool hasMaxForce_;
-  // not needed esutil::Array2D<std::shared_ptr<Potential>, esutil::enlarge> potentialArrayPtr;
+    void setMaxForce(real s)
+    {
+        maxForce_ = s;
+        hasMaxForce_ = s > 0.0;
+    }
+
+    real maxForce() { return maxForce_; }
+
+    virtual void addForces();
+    virtual real computeEnergy();
+    virtual real computeEnergyDeriv();
+    virtual real computeEnergyAA();
+    virtual real computeEnergyCG();
+    virtual real computeEnergyAA(int atomtype);
+    virtual real computeEnergyCG(int atomtype);
+    virtual void computeVirialX(std::vector<real> &p_xx_total, int bins);
+    virtual real computeVirial();
+    virtual void computeVirialTensor(Tensor &w);
+    virtual void computeVirialTensor(Tensor &w, real z);
+    virtual void computeVirialTensor(Tensor *w, int n);
+    virtual real getMaxCutoff();
+    virtual int bondType() { return Nonbonded; }
+
+protected:
+    int ntypes;
+    std::shared_ptr<VerletList> verletList;
+    esutil::Array2D<Potential, esutil::enlarge> potentialArray;
+
+    bool cgPotential;
+    real scaleFactor_;
+    real maxForce_;
+    bool hasMaxForce_;
+    // not needed esutil::Array2D<std::shared_ptr<Potential>, esutil::enlarge> potentialArrayPtr;
 };
 
 //////////////////////////////////////////////////
 // INLINE IMPLEMENTATION
 //////////////////////////////////////////////////
-template<typename _Potential>
-inline void
-VerletListHybridInteractionTemplate<_Potential>::
-addForces() {
-  LOG4ESPP_DEBUG(_Potential::theLogger, "loop over verlet list pairs and add forces");
+template <typename _Potential>
+inline void VerletListHybridInteractionTemplate<_Potential>::addForces()
+{
+    LOG4ESPP_DEBUG(_Potential::theLogger, "loop over verlet list pairs and add forces");
 
-  for (PairList::Iterator it(verletList->getPairs()); it.isValid(); ++it) {
-    Particle &p1 = *it->first;
-    Particle &p2 = *it->second;
-    int type1 = p1.type();
-    int type2 = p2.type();
+    for (PairList::Iterator it(verletList->getPairs()); it.isValid(); ++it)
+    {
+        Particle &p1 = *it->first;
+        Particle &p2 = *it->second;
+        int type1 = p1.type();
+        int type2 = p2.type();
 
-    real p1lambda = p1.lambda();
-    real p2lambda = p2.lambda();
-    if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0))
-      continue;
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0)) continue;
 
-    real w12 = p1lambda * p2lambda;
-    if (w12 < 0.0)
-      w12 = 0.0;
-    real forcescale12 = w12;
-    if (cgPotential) {
-      forcescale12 = (1 - w12);
-    }
-
-    forcescale12 *= scaleFactor_;
-
-    if (forcescale12 > 0.0) {
-      const Potential &potential = getPotential(type1, type2);
-      Real3D force(0.0);
-      if (potential._computeForce(force, p1, p2)) {
-        if (hasMaxForce_) {
-          if (force.isNaNInf()) {
-            force = 0.0;
-          } else {
-            real abs_force = force.abs();
-            if (abs_force > maxForce_) {
-              force = (force / abs_force) * maxForce_;
-            }
-          }
+        real w12 = p1lambda * p2lambda;
+        if (w12 < 0.0) w12 = 0.0;
+        real forcescale12 = w12;
+        if (cgPotential)
+        {
+            forcescale12 = (1 - w12);
         }
-        p1.force() += forcescale12 * force;
-        p2.force() -= forcescale12 * force;
-        LOG4ESPP_TRACE(_Potential::theLogger, "id1=" << p1.id() << " id2=" << p2.id() << " force=" << force);
-      }
+
+        forcescale12 *= scaleFactor_;
+
+        if (forcescale12 > 0.0)
+        {
+            const Potential &potential = getPotential(type1, type2);
+            Real3D force(0.0);
+            if (potential._computeForce(force, p1, p2))
+            {
+                if (hasMaxForce_)
+                {
+                    if (force.isNaNInf())
+                    {
+                        force = 0.0;
+                    }
+                    else
+                    {
+                        real abs_force = force.abs();
+                        if (abs_force > maxForce_)
+                        {
+                            force = (force / abs_force) * maxForce_;
+                        }
+                    }
+                }
+                p1.force() += forcescale12 * force;
+                p2.force() -= forcescale12 * force;
+                LOG4ESPP_TRACE(_Potential::theLogger,
+                               "id1=" << p1.id() << " id2=" << p2.id() << " force=" << force);
+            }
+        }
     }
-  }
 }
 
-template<typename _Potential>
-inline real
-VerletListHybridInteractionTemplate<_Potential>::
-computeEnergy() {
-  LOG4ESPP_DEBUG(_Potential::theLogger, "loop over verlet list pairs and sum up potential energies");
+template <typename _Potential>
+inline real VerletListHybridInteractionTemplate<_Potential>::computeEnergy()
+{
+    LOG4ESPP_DEBUG(_Potential::theLogger,
+                   "loop over verlet list pairs and sum up potential energies");
 
-  real es = 0.0;
-  for (PairList::Iterator it(verletList->getPairs()); it.isValid(); ++it) {
-    Particle &p1 = *it->first;
-    Particle &p2 = *it->second;
-    int type1 = p1.type();
-    int type2 = p2.type();
+    real es = 0.0;
+    for (PairList::Iterator it(verletList->getPairs()); it.isValid(); ++it)
+    {
+        Particle &p1 = *it->first;
+        Particle &p2 = *it->second;
+        int type1 = p1.type();
+        int type2 = p2.type();
 
-    real p1lambda = p1.lambda();
-    real p2lambda = p2.lambda();
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
 
-    if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0))
-      continue;
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0)) continue;
 
-    real w12 = p1lambda * p2lambda;
-    if (w12 < 0.0)
-      w12 = 0.0;
+        real w12 = p1lambda * p2lambda;
+        if (w12 < 0.0) w12 = 0.0;
 
-    real forcescale12 = w12;
-    if (cgPotential) {
-      forcescale12 = (1 - w12);
+        real forcescale12 = w12;
+        if (cgPotential)
+        {
+            forcescale12 = (1 - w12);
+        }
+
+        forcescale12 *= scaleFactor_;
+
+        if (forcescale12 > 0.0)
+        {
+            const Potential &potential = getPotential(type1, type2);
+            real e1 = forcescale12 * potential._computeEnergy(p1, p2);
+            if (std::isnan(e1)) e1 = 0.0;
+            es += e1;
+            LOG4ESPP_TRACE(_Potential::theLogger,
+                           "id1=" << p1.id() << " id2=" << p2.id() << " potential energy=" << es);
+        }
     }
 
-    forcescale12 *= scaleFactor_;
-
-    if (forcescale12 > 0.0) {
-      const Potential &potential = getPotential(type1, type2);
-      real e1 = forcescale12*potential._computeEnergy(p1, p2);
-      if (std::isnan(e1))
-        e1 = 0.0;
-      es += e1;
-      LOG4ESPP_TRACE(_Potential::theLogger, "id1=" << p1.id() << " id2=" << p2.id() << " potential energy=" << es);
-    }
-  }
-
-  // reduce over all CPUs
-  real esum = 0.0;
-  boost::mpi::all_reduce(*getVerletList()->getSystem()->comm, es, esum, std::plus<real>());
-  return esum;
+    // reduce over all CPUs
+    real esum = 0.0;
+    boost::mpi::all_reduce(*getVerletList()->getSystem()->comm, es, esum, std::plus<real>());
+    return esum;
 }
 
-template<typename _Potential>
-inline real
-VerletListHybridInteractionTemplate<_Potential>::
-computeEnergyAA() {
-  return computeEnergy();
+template <typename _Potential>
+inline real VerletListHybridInteractionTemplate<_Potential>::computeEnergyAA()
+{
+    return computeEnergy();
 }
 
-template<typename _Potential>
-inline real
-VerletListHybridInteractionTemplate<_Potential>::
-computeEnergyCG() {
-  return computeEnergy();
+template <typename _Potential>
+inline real VerletListHybridInteractionTemplate<_Potential>::computeEnergyCG()
+{
+    return computeEnergy();
 }
 
 template <typename _Potential>
 inline real VerletListHybridInteractionTemplate<_Potential>::computeEnergyDeriv()
 {
-    std::cout << "Warning! At the moment computeEnergyDeriv() in VerletListHybridInteractionTemplate "
-                 "does not work."
-              << std::endl;
+    std::cout
+        << "Warning! At the moment computeEnergyDeriv() in VerletListHybridInteractionTemplate "
+           "does not work."
+        << std::endl;
     return 0.0;
 }
 
@@ -267,139 +278,140 @@ inline real VerletListHybridInteractionTemplate<_Potential>::computeEnergyCG(int
     return 0.0;
 }
 
-template<typename _Potential>
-inline void
-VerletListHybridInteractionTemplate<_Potential>::
-computeVirialX(std::vector<real> &p_xx_total, int bins) {
-  LOG4ESPP_WARN(_Potential::theLogger, "Warning! computeVirialX() is not yet implemented.");
+template <typename _Potential>
+inline void VerletListHybridInteractionTemplate<_Potential>::computeVirialX(
+    std::vector<real> &p_xx_total, int bins)
+{
+    LOG4ESPP_WARN(_Potential::theLogger, "Warning! computeVirialX() is not yet implemented.");
 }
 
-template<typename _Potential>
-inline real
-VerletListHybridInteractionTemplate<_Potential>::
-computeVirial() {
-  LOG4ESPP_DEBUG(_Potential::theLogger, "loop over verlet list pairs and sum up virial");
+template <typename _Potential>
+inline real VerletListHybridInteractionTemplate<_Potential>::computeVirial()
+{
+    LOG4ESPP_DEBUG(_Potential::theLogger, "loop over verlet list pairs and sum up virial");
 
-  real w = 0.0;
-  for (PairList::Iterator it(verletList->getPairs());
-       it.isValid(); ++it) {
-    Particle &p1 = *it->first;
-    Particle &p2 = *it->second;
-    int type1 = p1.type();
-    int type2 = p2.type();
+    real w = 0.0;
+    for (PairList::Iterator it(verletList->getPairs()); it.isValid(); ++it)
+    {
+        Particle &p1 = *it->first;
+        Particle &p2 = *it->second;
+        int type1 = p1.type();
+        int type2 = p2.type();
 
-    real p1lambda = p1.lambda();
-    real p2lambda = p2.lambda();
-    if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0))
-      continue;
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0)) continue;
 
-    real w12 = p1lambda * p2lambda;
-    if (w12 < 0.0)
-      w12 = 0.0;
-    real forcescale12 = w12;
-    if (cgPotential) {
-      forcescale12 = (1 - w12);
+        real w12 = p1lambda * p2lambda;
+        if (w12 < 0.0) w12 = 0.0;
+        real forcescale12 = w12;
+        if (cgPotential)
+        {
+            forcescale12 = (1 - w12);
+        }
+
+        forcescale12 *= scaleFactor_;
+
+        if (forcescale12 > 0.0)
+        {
+            const Potential &potential = getPotential(type1, type2);
+            // std::shared_ptr<Potential> potential = getPotential(type1, type2);
+
+            Real3D force(0.0, 0.0, 0.0);
+            if (potential._computeForce(force, p1, p2))
+            {
+                // if(potential->_computeForce(force, p1, p2)) {
+                Real3D r21 = p1.position() - p2.position();
+                w = w + r21 * forcescale12 * force;
+            }
+        }
     }
 
-    forcescale12 *= scaleFactor_;
-
-    if (forcescale12 > 0.0) {
-      const Potential &potential = getPotential(type1, type2);
-      // std::shared_ptr<Potential> potential = getPotential(type1, type2);
-
-      Real3D force(0.0, 0.0, 0.0);
-      if (potential._computeForce(force, p1, p2)) {
-        // if(potential->_computeForce(force, p1, p2)) {
-        Real3D r21 = p1.position() - p2.position();
-        w = w + r21 * forcescale12*force;
-      }
-    }
-  }
-
-  // reduce over all CPUs
-  real wsum;
-  boost::mpi::all_reduce(*mpiWorld, w, wsum, std::plus<real>());
-  return wsum;
+    // reduce over all CPUs
+    real wsum;
+    boost::mpi::all_reduce(*mpiWorld, w, wsum, std::plus<real>());
+    return wsum;
 }
 
-template<typename _Potential>
-inline void
-VerletListHybridInteractionTemplate<_Potential>::
-computeVirialTensor(Tensor &w) {
-  LOG4ESPP_DEBUG(_Potential::theLogger, "loop over verlet list pairs and sum up virial tensor");
+template <typename _Potential>
+inline void VerletListHybridInteractionTemplate<_Potential>::computeVirialTensor(Tensor &w)
+{
+    LOG4ESPP_DEBUG(_Potential::theLogger, "loop over verlet list pairs and sum up virial tensor");
 
-  Tensor wlocal(0.0);
-  for (PairList::Iterator it(verletList->getPairs());
-       it.isValid(); ++it) {
-    Particle &p1 = *it->first;
-    Particle &p2 = *it->second;
-    int type1 = p1.type();
-    int type2 = p2.type();
+    Tensor wlocal(0.0);
+    for (PairList::Iterator it(verletList->getPairs()); it.isValid(); ++it)
+    {
+        Particle &p1 = *it->first;
+        Particle &p2 = *it->second;
+        int type1 = p1.type();
+        int type2 = p2.type();
 
-    real p1lambda = p1.lambda();
-    real p2lambda = p2.lambda();
-    if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0))
-      continue;
+        real p1lambda = p1.lambda();
+        real p2lambda = p2.lambda();
+        if (!cgPotential && (p1lambda < 0.0 || p2lambda < 0.0)) continue;
 
-    real w12 = p1lambda * p2lambda;
-    if (w12 < 0.0)
-      w12 = 0.0;
-    real forcescale12 = w12;
-    if (cgPotential) {
-      forcescale12 = (1 - w12);
+        real w12 = p1lambda * p2lambda;
+        if (w12 < 0.0) w12 = 0.0;
+        real forcescale12 = w12;
+        if (cgPotential)
+        {
+            forcescale12 = (1 - w12);
+        }
+
+        forcescale12 *= scaleFactor_;
+
+        if (forcescale12 > 0.0)
+        {
+            const Potential &potential = getPotential(type1, type2);
+            // std::shared_ptr<Potential> potential = getPotential(type1, type2);
+
+            Real3D force(0.0, 0.0, 0.0);
+            if (potential._computeForce(force, p1, p2))
+            {
+                // if(potential->_computeForce(force, p1, p2)) {
+                Real3D r21 = p1.position() - p2.position();
+                wlocal += Tensor(r21, forcescale12 * force);
+            }
+        }
     }
 
-    forcescale12 *= scaleFactor_;
-
-    if (forcescale12 > 0.0) {
-      const Potential &potential = getPotential(type1, type2);
-      // std::shared_ptr<Potential> potential = getPotential(type1, type2);
-
-      Real3D force(0.0, 0.0, 0.0);
-      if (potential._computeForce(force, p1, p2)) {
-        // if(potential->_computeForce(force, p1, p2)) {
-        Real3D r21 = p1.position() - p2.position();
-        wlocal += Tensor(r21, forcescale12*force);
-      }
-    }
-  }
-
-  // reduce over all CPUs
-  Tensor wsum(0.0);
-  boost::mpi::all_reduce(*mpiWorld, (double *) &wlocal, 6, (double *) &wsum, std::plus<double>());
-  w += wsum;
+    // reduce over all CPUs
+    Tensor wsum(0.0);
+    boost::mpi::all_reduce(*mpiWorld, (double *)&wlocal, 6, (double *)&wsum, std::plus<double>());
+    w += wsum;
 }
 
 // local pressure tensor for layer, plane is defined by z coordinate
-template<typename _Potential>
-inline void
-VerletListHybridInteractionTemplate<_Potential>::
-computeVirialTensor(Tensor &w, real z) {
-  LOG4ESPP_ERROR(_Potential::theLogger, "computeVirialTensor not implemented for VerletListHybridInteraction");
+template <typename _Potential>
+inline void VerletListHybridInteractionTemplate<_Potential>::computeVirialTensor(Tensor &w, real z)
+{
+    LOG4ESPP_ERROR(_Potential::theLogger,
+                   "computeVirialTensor not implemented for VerletListHybridInteraction");
 }
 
 // it will calculate the pressure in 'n' layers along Z axis
 // the first layer has coordinate 0.0 the last - (Lz - Lz/n)
-template<typename _Potential>
-inline void
-VerletListHybridInteractionTemplate<_Potential>::
-computeVirialTensor(Tensor *w, int n) {
-  LOG4ESPP_ERROR(_Potential::theLogger, "computeVirialTensor not implemented for VerletListHybridInteraction");
+template <typename _Potential>
+inline void VerletListHybridInteractionTemplate<_Potential>::computeVirialTensor(Tensor *w, int n)
+{
+    LOG4ESPP_ERROR(_Potential::theLogger,
+                   "computeVirialTensor not implemented for VerletListHybridInteraction");
 }
 
-template<typename _Potential>
-inline real
-VerletListHybridInteractionTemplate<_Potential>::
-getMaxCutoff() {
-  real cutoff = 0.0;
-  for (int i = 0; i < ntypes; i++) {
-    for (int j = 0; j < ntypes; j++) {
-      cutoff = std::max(cutoff, getPotential(i, j).getCutoff());
+template <typename _Potential>
+inline real VerletListHybridInteractionTemplate<_Potential>::getMaxCutoff()
+{
+    real cutoff = 0.0;
+    for (int i = 0; i < ntypes; i++)
+    {
+        for (int j = 0; j < ntypes; j++)
+        {
+            cutoff = std::max(cutoff, getPotential(i, j).getCutoff());
+        }
     }
-  }
-  return cutoff;
+    return cutoff;
 }
 
-}
-}
+}  // namespace interaction
+}  // namespace espressopp
 #endif

--- a/src/io/DumpH5MD.py
+++ b/src/io/DumpH5MD.py
@@ -60,6 +60,19 @@ This module provides a writer for H5MD_ file format.
 
     :rtype: The DumpH5MD writer.
 
+Flags
+++++++++++++++++++
+
+- store_position: saves position of particles.
+- store_species: saves the type of particles.
+- store_state: saves chemical state of particles.
+- store_velocity: saves velocity
+- store_force: saves force
+- store_charge: saves charge
+- store_lambda: saves the value of lambda parameter (useful in AdResS simulations)
+- store_res_id: saves residue id
+- do_sort: sort the file (see :ref:`sorting-file-label`)
+
 Example
 +++++++
 
@@ -196,7 +209,7 @@ class DumpH5MDLocal(io_DumpH5MD):
                 author_email=email,
                 driver='mpio',
                 comm=MPI.COMM_WORLD)
-        except (NameError, AttributeError):
+        except (NameError, AttributeError, ValueError):
             # h5py in serial mode.
             self.file = pyh5md.File(
                 filename, 'w',
@@ -257,6 +270,7 @@ class DumpH5MDLocal(io_DumpH5MD):
         if self.store_res_id:
             self.res_id = pyh5md.element(part, 'res_id', store='time', time=True, maxshape=(None, ),
                                          shape=(self.chunk_size, ), dtype=self.int_type,  fillvalue=-1)
+        self._system_data()
 
         self.commTimer = 0.0
         self.updateTimer = 0.0
@@ -440,7 +454,7 @@ class DumpH5MDLocal(io_DumpH5MD):
 
         # Store species.
         if self.store_species:
-            species = np.asarray(self.getSpecies())
+            species = np.asarray(self.getSpecies(), dtype=self.int_type)
             if total_size > self.species.value.shape[1]:
                 isResized = True
                 self.species.value.resize(total_size, axis=1)
@@ -448,7 +462,7 @@ class DumpH5MDLocal(io_DumpH5MD):
 
         # Store state.
         if self.store_state:
-            state = np.asarray(self.getState())
+            state = np.asarray(self.getState(), dtype=self.int_type)
             if total_size > self.state.value.shape[1]:
                 isResized = True
                 self.state.value.resize(total_size, axis=1)
@@ -456,7 +470,7 @@ class DumpH5MDLocal(io_DumpH5MD):
 
         # Store lambda_adr
         if self.store_lambda:
-            lambda_adr = np.asarray(self.getLambda())
+            lambda_adr = np.asarray(self.getLambda(), dtype=self.float_type)
             if total_size > self.lambda_adr.value.shape[1]:
                 isResized = True
                 self.lambda_adr.value.resize(total_size, axis=1)
@@ -464,7 +478,7 @@ class DumpH5MDLocal(io_DumpH5MD):
 
         # Store res_id
         if self.store_res_id:
-            res_id = np.asarray(self.getResId())
+            res_id = np.asarray(self.getResId(), dtype=self.int_type)
             if total_size > self.res_id.value.shape[1]:
                 isResized = True
                 self.res_id.value.resize(total_size, axis=1)

--- a/src/io/DumpH5MD.py
+++ b/src/io/DumpH5MD.py
@@ -197,7 +197,8 @@ class DumpH5MDLocal(io_DumpH5MD):
             if os.path.exists(filename):
                 basename = os.path.basename(filename)
                 dirname = os.path.dirname(filename)
-                new_filename = '{}/{}_{}'.format(dirname, int(py_time.time()), os.path.basename(filename))
+                new_filename = '{}/{}_{}'.format(dirname, int(
+                    py_time.time()), os.path.basename(filename))
                 os.rename(filename, new_filename)
                 print(('File {} exists, moved to {}'.format(filename, new_filename)))
         try:
@@ -298,7 +299,7 @@ class DumpH5MDLocal(io_DumpH5MD):
                     'flushTimer': self.flushTimer,
                     'closeTimer': self.closeTimer,
                     'resizeCounter': self.resizeCounter
-                   }
+                    }
 
     def set_parameters(self, paramters):
         if pmi.workerIsActive():
@@ -395,12 +396,14 @@ class DumpH5MDLocal(io_DumpH5MD):
         if total_size > self.id_e.value.shape[1]:
             isResized = True
             self.id_e.value.resize(total_size, axis=1)
-        self.id_e.append(id_ar, step, time, region=(idx_0, idx_1), collective=collective_write)
+        self.id_e.append(id_ar, step, time, region=(
+            idx_0, idx_1), collective=collective_write)
 
         # Store box values at every time step
         if not self.static_box:
             self.particle_group.box.edges.append(
-                np.array([edge_i for edge_i in self.system.bc.boxL], dtype=self.float_type),
+                np.array([edge_i for edge_i in self.system.bc.boxL],
+                         dtype=self.float_type),
                 step,
                 time, collective=collective_write)
 
@@ -410,7 +413,8 @@ class DumpH5MDLocal(io_DumpH5MD):
             if total_size > self.position.value.shape[1]:
                 isResized = True
                 self.position.value.resize(total_size, axis=1)
-            self.position.append(pos, step, time, region=(idx_0, idx_1), collective=collective_write)
+            self.position.append(pos, step, time, region=(
+                idx_0, idx_1), collective=collective_write)
             # Store image.
             data_image = self.getImage()
             if data_image is None:
@@ -420,7 +424,8 @@ class DumpH5MDLocal(io_DumpH5MD):
             if total_size > self.image.value.shape[1]:
                 isResized = True
                 self.image.value.resize(total_size, axis=1)
-            self.image.append(image, step, time, region=(idx_0, idx_1), collective=collective_write)
+            self.image.append(image, step, time, region=(
+                idx_0, idx_1), collective=collective_write)
 
         # Store velocity.
         if self.store_velocity:
@@ -428,21 +433,24 @@ class DumpH5MDLocal(io_DumpH5MD):
             if total_size > self.velocity.value.shape[1]:
                 isResized = True
                 self.velocity.value.resize(total_size, axis=1)
-            self.velocity.append(vel, step, time, region=(idx_0, idx_1), collective=collective_write)
+            self.velocity.append(vel, step, time, region=(
+                idx_0, idx_1), collective=collective_write)
 
         if self.store_force:
             force = np.asarray(self.getForce(), dtype=self.float_type)
             if total_size > self.force.value.shape[1]:
                 isResized = True
                 self.force.value.resize(total_size, axis=1)
-            self.force.append(force, step, time, region=(idx_0, idx_1), collective=collective_write)
+            self.force.append(force, step, time, region=(
+                idx_0, idx_1), collective=collective_write)
 
         if self.store_charge:
             charge = np.asarray(self.getCharge(), dtype=self.float_type)
             if total_size > self.charge.value.shape[1]:
                 isResized = True
                 self.charge.value.resize(total_size, axis=1)
-            self.charge.append(charge, step, time, region=(idx_0, idx_1), collective=collective_write)
+            self.charge.append(charge, step, time, region=(
+                idx_0, idx_1), collective=collective_write)
 
         # Store mass.
         if self.store_mass:
@@ -450,7 +458,8 @@ class DumpH5MDLocal(io_DumpH5MD):
             if total_size > self.mass.value.shape[1]:
                 isResized = True
                 self.mass.value.resize(total_size, axis=1)
-            self.mass.append(mass, step, time, region=(idx_0, idx_1), collective=collective_write)
+            self.mass.append(mass, step, time, region=(
+                idx_0, idx_1), collective=collective_write)
 
         # Store species.
         if self.store_species:
@@ -458,7 +467,8 @@ class DumpH5MDLocal(io_DumpH5MD):
             if total_size > self.species.value.shape[1]:
                 isResized = True
                 self.species.value.resize(total_size, axis=1)
-            self.species.append(species, step, time, region=(idx_0, idx_1), collective=collective_write)
+            self.species.append(species, step, time, region=(
+                idx_0, idx_1), collective=collective_write)
 
         # Store state.
         if self.store_state:
@@ -466,7 +476,8 @@ class DumpH5MDLocal(io_DumpH5MD):
             if total_size > self.state.value.shape[1]:
                 isResized = True
                 self.state.value.resize(total_size, axis=1)
-            self.state.append(state, step, time, region=(idx_0, idx_1), collective=collective_write)
+            self.state.append(state, step, time, region=(
+                idx_0, idx_1), collective=collective_write)
 
         # Store lambda_adr
         if self.store_lambda:
@@ -474,7 +485,8 @@ class DumpH5MDLocal(io_DumpH5MD):
             if total_size > self.lambda_adr.value.shape[1]:
                 isResized = True
                 self.lambda_adr.value.resize(total_size, axis=1)
-            self.lambda_adr.append(lambda_adr, step, time, region=(idx_0, idx_1), collective=collective_write)
+            self.lambda_adr.append(lambda_adr, step, time, region=(
+                idx_0, idx_1), collective=collective_write)
 
         # Store res_id
         if self.store_res_id:
@@ -482,7 +494,8 @@ class DumpH5MDLocal(io_DumpH5MD):
             if total_size > self.res_id.value.shape[1]:
                 isResized = True
                 self.res_id.value.resize(total_size, axis=1)
-            self.res_id.append(res_id, step, time, region=(idx_0, idx_1), collective=collective_write)
+            self.res_id.append(res_id, step, time, region=(
+                idx_0, idx_1), collective=collective_write)
         self.writeTimer += (py_time.time() - time0)
 
         if isResized:
@@ -504,7 +517,8 @@ class DumpH5MDLocal(io_DumpH5MD):
 if pmi.isController:
     def sort_file(h5):
         """Sort data file."""
-        atom_groups = [ag for ag in h5['/particles'] if 'id' in h5['/particles/{}/'.format(ag)]]
+        atom_groups = [ag for ag in h5['/particles']
+                       if 'id' in h5['/particles/{}/'.format(ag)]]
         T = len(h5['/particles/{}/id/value'.format(atom_groups[0])])
         # Iterate over time frames.
         for t in range(T):
@@ -514,7 +528,7 @@ if pmi.isController:
                     x[1] for x in sorted(
                         [(p_id, col_id) for col_id, p_id in enumerate(ids[t])],
                         key=lambda y: (True, y[0]) if y[0] == -1 else (False, y[0]))
-                    ]
+                ]
                 for k in list(h5['/particles/{}/'.format(ag)].keys()):
                     if 'value' in list(h5['/particles/{}/{}'.format(ag, k)].keys()):
                         path = '/particles/{}/{}/value'.format(ag, k)

--- a/src/storage/Storage.py
+++ b/src/storage/Storage.py
@@ -252,6 +252,8 @@ class StorageLocal(object):
             index_lambda_adrd = -1
             index_state       = -1
             index_pib         = -1
+            index_res_id      = -1
+            index_vp          = -1
 
             last_pos = toReal3DFromVector([-99,-99,-99])
 
@@ -282,6 +284,8 @@ class StorageLocal(object):
                     elif val.lower() == "lambda_adrd": index_lambda_adrd = nindex
                     elif val.lower() == "state": index_state = nindex
                     elif val.lower() == "pib": index_pib = nindex
+                    elif val.lower() == "res_id": index_res_id = nindex
+                    elif val.lower() == "vp": index_vp = nindex
                     else: raise SyntaxError("unknown particle property: %s"%val)
                     nindex += 1
 
@@ -371,6 +375,12 @@ class StorageLocal(object):
 
                     if index_state >= 0:
                         storedParticle.state = particle[index_state]
+
+                    if index_res_id >= 0:
+                        storedParticle.res_id = particle[index_res_id]
+
+                    if index_vp >= 0:
+                        storedParticle.vp = particle[index_vp]
 
     def modifyParticle(self, pid, property, value):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
@@ -464,6 +474,8 @@ class StorageLocal(object):
             index_lambda_adrd = -1
             index_state       = -1
             index_pib         = -1
+            index_res_id      = -1
+            index_vp          = -1
 
             last_pos = toReal3DFromVector([-99,-99,-99])
 
@@ -507,6 +519,8 @@ class StorageLocal(object):
                     elif val.lower() == "lambda_adrd": index_lambda_adrd = nindex
                     elif val.lower() == "state": index_state = nindex
                     elif val.lower() == "pib": index_pib = nindex
+                    elif val.lower() == "res_id": index_res_id = nindex
+                    elif val.lower() == "vp": index_vp = nindex
                     else: raise SyntaxError("unknown particle property: %s"%val)
 
             assert index_id >= 0, "particle property id is mandatory"
@@ -530,7 +544,8 @@ class StorageLocal(object):
                 index_vx, index_vy, index_vz, index_modemomx, index_modemomy, index_modemomz,
                 index_fx, index_fy, index_fz, index_fmx, index_fmy, index_fmz,
                 index_q, index_radius, index_fradius, index_vradius, index_type, index_mass,
-                index_varmass, index_adrAT, index_lambda_adr, index_lambda_adrd, index_state, index_pib
+                index_varmass, index_adrAT, index_lambda_adr, index_lambda_adrd, index_state, index_pib, index_res_id,
+                index_vp
                 ], dtype=np.int32)
             self.cxxclass.addParticlesFromArray(self, particleList, indices)
 

--- a/src/storage/Storage.py
+++ b/src/storage/Storage.py
@@ -191,6 +191,7 @@ from espressopp import toReal3DFromVector, ParticleLocal, Particle
 from espressopp.Exceptions import ParticleDoesNotExistHere
 import numpy as np
 
+
 class StorageLocal(object):
 
     logger = logging.getLogger("Storage")
@@ -220,7 +221,7 @@ class StorageLocal(object):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             self.cxxclass.addAdrATParticle(
                 self, pid, toReal3DFromVector(*args)
-                )
+            )
 
     def setFixedTuplesAdress(self, fixedtuples):
         if pmi.workerIsActive():
@@ -233,29 +234,29 @@ class StorageLocal(object):
     def addParticles(self, particleList, *properties):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
 
-            index_id          = -1
-            index_pos         = -1
-            index_modepos     = -1
-            index_v           = -1
-            index_modemom     = -1
-            index_f           = -1
-            index_fm          = -1
-            index_q           = -1
-            index_radius      = -1
-            index_fradius     = -1
-            index_vradius     = -1
-            index_type        = -1
-            index_mass        = -1
-            index_varmass     = -1
-            index_adrAT       = -1 # adress AT particle if 1
-            index_lambda_adr  = -1
+            index_id = -1
+            index_pos = -1
+            index_modepos = -1
+            index_v = -1
+            index_modemom = -1
+            index_f = -1
+            index_fm = -1
+            index_q = -1
+            index_radius = -1
+            index_fradius = -1
+            index_vradius = -1
+            index_type = -1
+            index_mass = -1
+            index_varmass = -1
+            index_adrAT = -1  # adress AT particle if 1
+            index_lambda_adr = -1
             index_lambda_adrd = -1
-            index_state       = -1
-            index_pib         = -1
-            index_res_id      = -1
-            index_vp          = -1
+            index_state = -1
+            index_pib = -1
+            index_res_id = -1
+            index_vp = -1
 
-            last_pos = toReal3DFromVector([-99,-99,-99])
+            last_pos = toReal3DFromVector([-99, -99, -99])
 
             if properties == None:
                 # default properities = (id, pos)
@@ -265,32 +266,57 @@ class StorageLocal(object):
             else:
                 nindex = 0
                 for val in properties:
-                    if val.lower() == "id": index_id = nindex
-                    elif val.lower() == "pos": index_pos = nindex
-                    elif val.lower() == "modepos": index_modepos = nindex
-                    elif val.lower() == "type": index_type = nindex
-                    elif val.lower() == "mass": index_mass = nindex
-                    elif val.lower() == "varmass": index_varmass = nindex
-                    elif val.lower() == "v": index_v = nindex
-                    elif val.lower() == "modemom": index_modemom = nindex
-                    elif val.lower() == "f": index_f = nindex
-                    elif val.lower() == "fm": index_fm = nindex
-                    elif val.lower() == "q": index_q = nindex
-                    elif val.lower() == "radius": index_radius = nindex
-                    elif val.lower() == "fradius": index_fradius = nindex
-                    elif val.lower() == "vradius": index_vradius = nindex
-                    elif val.lower() == "adrat": index_adrAT = nindex
-                    elif val.lower() == "lambda_adr": index_lambda_adr = nindex
-                    elif val.lower() == "lambda_adrd": index_lambda_adrd = nindex
-                    elif val.lower() == "state": index_state = nindex
-                    elif val.lower() == "pib": index_pib = nindex
-                    elif val.lower() == "res_id": index_res_id = nindex
-                    elif val.lower() == "vp": index_vp = nindex
-                    else: raise SyntaxError("unknown particle property: %s"%val)
+                    if val.lower() == "id":
+                        index_id = nindex
+                    elif val.lower() == "pos":
+                        index_pos = nindex
+                    elif val.lower() == "modepos":
+                        index_modepos = nindex
+                    elif val.lower() == "type":
+                        index_type = nindex
+                    elif val.lower() == "mass":
+                        index_mass = nindex
+                    elif val.lower() == "varmass":
+                        index_varmass = nindex
+                    elif val.lower() == "v":
+                        index_v = nindex
+                    elif val.lower() == "modemom":
+                        index_modemom = nindex
+                    elif val.lower() == "f":
+                        index_f = nindex
+                    elif val.lower() == "fm":
+                        index_fm = nindex
+                    elif val.lower() == "q":
+                        index_q = nindex
+                    elif val.lower() == "radius":
+                        index_radius = nindex
+                    elif val.lower() == "fradius":
+                        index_fradius = nindex
+                    elif val.lower() == "vradius":
+                        index_vradius = nindex
+                    elif val.lower() == "adrat":
+                        index_adrAT = nindex
+                    elif val.lower() == "lambda_adr":
+                        index_lambda_adr = nindex
+                    elif val.lower() == "lambda_adrd":
+                        index_lambda_adrd = nindex
+                    elif val.lower() == "state":
+                        index_state = nindex
+                    elif val.lower() == "pib":
+                        index_pib = nindex
+                    elif val.lower() == "res_id":
+                        index_res_id = nindex
+                    elif val.lower() == "vp":
+                        index_vp = nindex
+                    else:
+                        raise SyntaxError(
+                            "unknown particle property: %s" % val)
                     nindex += 1
 
-            if index_id < 0  : raise Exception("particle property id is mandatory")
-            if index_pos < 0 : raise Exception("particle property pos is mandatory")
+            if index_id < 0:
+                raise Exception("particle property id is mandatory")
+            if index_pos < 0:
+                raise Exception("particle property pos is mandatory")
 
             # we should check at the begin whether all the particles do not exist.
             doWeAddParticles = True
@@ -301,30 +327,37 @@ class StorageLocal(object):
                     print("WARNING: Particle ", pid, " already exists")
 
             if not doWeAddParticles:
-                print('WARNING: Some particles already exist. The list of particles was not added.')
+                print(
+                    'WARNING: Some particles already exist. The list of particles was not added.')
                 return
 
             for particle in particleList:
                 # verify that each particle has enough entries, avoids index errors
                 if len(particle) != nindex:
-                    raise SyntaxError("particle has %d entries, but %d expected"%(len(particle), nindex))
+                    raise SyntaxError(
+                        "particle has %d entries, but %d expected" % (len(particle), nindex))
 
                 id = particle[index_id]
                 pos = particle[index_pos]
 
                 if index_adrAT >= 0:
                     if particle[index_adrAT] == 0:
-                        storedParticle = self.cxxclass.addParticle(self, id, pos, True)
+                        storedParticle = self.cxxclass.addParticle(
+                            self, id, pos, True)
                         last_pos = pos
                     else:
-                        storedParticle = self.cxxclass.addAdrATParticle(self, id, pos, last_pos)
+                        storedParticle = self.cxxclass.addAdrATParticle(
+                            self, id, pos, last_pos)
                 else:
-                    #print "%d:  addParticle %d, last_pos=pos %f, %f, %f"%(pmi._MPIcomm.rank,id,pos[0], pos[1], pos[2])
-                    storedParticle = self.cxxclass.addParticle(self, id, pos, True)
+                    # print "%d:  addParticle %d, last_pos=pos %f, %f, %f"%(pmi._MPIcomm.rank,id,pos[0], pos[1], pos[2])
+                    storedParticle = self.cxxclass.addParticle(
+                        self, id, pos, True)
 
                 if storedParticle is not None:
-                    self.logger.debug("Processor %d stores particle id = %d"%(pmi.rank, id))
-                    self.logger.debug("particle property indexes: id=%i pos=%i type=%i mass=%i v=%i f=%i q=%i radius=%i lambda_adr=%i lambda_adrd=%i state=%i"%(index_id,index_pos,index_type,index_mass,index_v,index_f,index_q,index_radius,index_lambda_adr,index_lambda_adrd,index_state))
+                    self.logger.debug(
+                        "Processor %d stores particle id = %d" % (pmi.rank, id))
+                    self.logger.debug("particle property indexes: id=%i pos=%i type=%i mass=%i v=%i f=%i q=%i radius=%i lambda_adr=%i lambda_adrd=%i state=%i" % (
+                        index_id, index_pos, index_type, index_mass, index_v, index_f, index_q, index_radius, index_lambda_adr, index_lambda_adrd, index_state))
 
                     # only the owner processor writes other properties
 
@@ -387,33 +420,52 @@ class StorageLocal(object):
             if self.particleExists(pid):
                 particle = self.getParticle(pid)
                 self.logger.info("particle pid=%i rank=%i" % (pid, pmi.rank))
-                if   property.lower() == "id"   : raise "particles pid cannot be modified !"
-                elif property.lower() == "pos"  : # alway assume unfolded coordinates
-                    particle.pos       = value
-                    particle.imageBox  = Int3D(0, 0, 0)
-                elif property.lower() == "modepos"  : particle.modepos = value
-                elif property.lower() == "img"  : particle.imageBox = value
-                elif property.lower() == "type" : particle.type = value
-                elif property.lower() == "pib" : particle.pib = value
-                elif property.lower() == "mass" : particle.mass = value
-                elif property.lower() == "varmass" : particle.varmass = value
-                elif property.lower() == "v"    : particle.v    = value
-                elif property.lower() == "modemom"  : particle.modemom = value
-                elif property.lower() == "f"    : particle.f    = value
-                elif property.lower() == "q"    : particle.q    = value
-                elif property.lower() == "radius" : particle.radius = value
-                elif property.lower() == "fradius" : particle.fradius = value
-                elif property.lower() == "vradius" : particle.vradius = value
-                elif property.lower() == "lambda_adr" : particle.lambda_adr = value
-                elif property.lower() == "lambda_adrd" : particle.lambda_adrd = value
-                elif property.lower() == "state" : particle.state = value
-                else: raise SyntaxError( 'unknown particle property: %s' % property) # UnknownParticleProperty exception is not implemented
-                #except ParticleDoesNotExistHere:
+                if property.lower() == "id":
+                    raise "particles pid cannot be modified !"
+                elif property.lower() == "pos":  # alway assume unfolded coordinates
+                    particle.pos = value
+                    particle.imageBox = Int3D(0, 0, 0)
+                elif property.lower() == "modepos":
+                    particle.modepos = value
+                elif property.lower() == "img":
+                    particle.imageBox = value
+                elif property.lower() == "type":
+                    particle.type = value
+                elif property.lower() == "pib":
+                    particle.pib = value
+                elif property.lower() == "mass":
+                    particle.mass = value
+                elif property.lower() == "varmass":
+                    particle.varmass = value
+                elif property.lower() == "v":
+                    particle.v = value
+                elif property.lower() == "modemom":
+                    particle.modemom = value
+                elif property.lower() == "f":
+                    particle.f = value
+                elif property.lower() == "q":
+                    particle.q = value
+                elif property.lower() == "radius":
+                    particle.radius = value
+                elif property.lower() == "fradius":
+                    particle.fradius = value
+                elif property.lower() == "vradius":
+                    particle.vradius = value
+                elif property.lower() == "lambda_adr":
+                    particle.lambda_adr = value
+                elif property.lower() == "lambda_adrd":
+                    particle.lambda_adrd = value
+                elif property.lower() == "state":
+                    particle.state = value
+                else:
+                    # UnknownParticleProperty exception is not implemented
+                    raise SyntaxError(
+                        'unknown particle property: %s' % property)
+                # except ParticleDoesNotExistHere:
              # self.logger.debug("ParticleDoesNotExistHere pid=% rank=%i" % (pid, pmi.rank))
              # pass
-            #else:
+            # else:
          # print "WARNING: Particle ", pid, " does not exist and was not modified"
-
 
     def savePositions(self, idList):
 
@@ -436,48 +488,49 @@ class StorageLocal(object):
     def printRealParticles(self):
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
             for pid in self.getRealParticleIDs():
-                p = ParticleLocal(pid,self)
-                print("CPU %-3i ID %-5i TYPE %-3i POS(%8.3f, %8.3f, %8.3f)" % (pmi._MPIcomm.rank, p.id, p.type, p.pos[0], p.pos[1], p.pos[2]))
+                p = ParticleLocal(pid, self)
+                print("CPU %-3i ID %-5i TYPE %-3i POS(%8.3f, %8.3f, %8.3f)" %
+                      (pmi._MPIcomm.rank, p.id, p.type, p.pos[0], p.pos[1], p.pos[2]))
 
     def addParticlesArray(self, particleList, *properties):
 
         if not (pmi._PMIComm and pmi._PMIComm.isActive()) or pmi._MPIcomm.rank in pmi._PMIComm.getMPIcpugroup():
 
-            index_id          = -1
-            index_posx        = -1 ### Real3D
-            index_posy        = -1
-            index_posz        = -1
-            index_modeposx    = -1 ### Real3D
-            index_modeposy    = -1
-            index_modeposz    = -1
-            index_vx          = -1 ### Real3D
-            index_vy          = -1
-            index_vz          = -1
-            index_modemomx    = -1 ### Real3D
-            index_modemomy    = -1
-            index_modemomz    = -1
-            index_fx          = -1 ### Real3D
-            index_fy          = -1
-            index_fz          = -1
-            index_fmx         = -1 ### Real3D
-            index_fmy         = -1
-            index_fmz         = -1
-            index_q           = -1
-            index_radius      = -1
-            index_fradius     = -1
-            index_vradius     = -1
-            index_type        = -1
-            index_mass        = -1
-            index_varmass     = -1
-            index_adrAT       = -1 # adress AT particle if 1
-            index_lambda_adr  = -1
+            index_id = -1
+            index_posx = -1  # Real3D
+            index_posy = -1
+            index_posz = -1
+            index_modeposx = -1  # Real3D
+            index_modeposy = -1
+            index_modeposz = -1
+            index_vx = -1  # Real3D
+            index_vy = -1
+            index_vz = -1
+            index_modemomx = -1  # Real3D
+            index_modemomy = -1
+            index_modemomz = -1
+            index_fx = -1  # Real3D
+            index_fy = -1
+            index_fz = -1
+            index_fmx = -1  # Real3D
+            index_fmy = -1
+            index_fmz = -1
+            index_q = -1
+            index_radius = -1
+            index_fradius = -1
+            index_vradius = -1
+            index_type = -1
+            index_mass = -1
+            index_varmass = -1
+            index_adrAT = -1  # adress AT particle if 1
+            index_lambda_adr = -1
             index_lambda_adrd = -1
-            index_state       = -1
-            index_pib         = -1
-            index_res_id      = -1
-            index_vp          = -1
+            index_state = -1
+            index_pib = -1
+            index_res_id = -1
+            index_vp = -1
 
-            last_pos = toReal3DFromVector([-99,-99,-99])
+            last_pos = toReal3DFromVector([-99, -99, -99])
 
             if properties == None:
                 # default properties = (id, pos)
@@ -488,40 +541,75 @@ class StorageLocal(object):
                 nindex = 4
             else:
                 for nindex, val in enumerate(properties):
-                    if val.lower() == "id": index_id = nindex
-                    elif val.lower() == "posx": index_posx = nindex
-                    elif val.lower() == "posy": index_posy = nindex
-                    elif val.lower() == "posz": index_posz = nindex
-                    elif val.lower() == "modeposx": index_modeposx = nindex
-                    elif val.lower() == "modeposy": index_modeposy = nindex
-                    elif val.lower() == "modeposz": index_modeposz = nindex
-                    elif val.lower() == "type": index_type = nindex
-                    elif val.lower() == "mass": index_mass = nindex
-                    elif val.lower() == "varmass": index_varmass = nindex
-                    elif val.lower() == "vx": index_vx = nindex
-                    elif val.lower() == "vy": index_vy = nindex
-                    elif val.lower() == "vz": index_vz = nindex
-                    elif val.lower() == "modemomx": index_modemomx = nindex
-                    elif val.lower() == "modemomy": index_modemomy = nindex
-                    elif val.lower() == "modemomz": index_modemomz = nindex
-                    elif val.lower() == "fx": index_fx = nindex
-                    elif val.lower() == "fy": index_fy = nindex
-                    elif val.lower() == "fz": index_fz = nindex
-                    elif val.lower() == "fmx": index_fmx = nindex
-                    elif val.lower() == "fmy": index_fmy = nindex
-                    elif val.lower() == "fmz": index_fmz = nindex
-                    elif val.lower() == "q": index_q = nindex
-                    elif val.lower() == "radius": index_radius = nindex
-                    elif val.lower() == "fradius": index_fradius = nindex
-                    elif val.lower() == "vradius": index_vradius = nindex
-                    elif val.lower() == "adrat": index_adrAT = nindex
-                    elif val.lower() == "lambda_adr": index_lambda_adr = nindex
-                    elif val.lower() == "lambda_adrd": index_lambda_adrd = nindex
-                    elif val.lower() == "state": index_state = nindex
-                    elif val.lower() == "pib": index_pib = nindex
-                    elif val.lower() == "res_id": index_res_id = nindex
-                    elif val.lower() == "vp": index_vp = nindex
-                    else: raise SyntaxError("unknown particle property: %s"%val)
+                    if val.lower() == "id":
+                        index_id = nindex
+                    elif val.lower() == "posx":
+                        index_posx = nindex
+                    elif val.lower() == "posy":
+                        index_posy = nindex
+                    elif val.lower() == "posz":
+                        index_posz = nindex
+                    elif val.lower() == "modeposx":
+                        index_modeposx = nindex
+                    elif val.lower() == "modeposy":
+                        index_modeposy = nindex
+                    elif val.lower() == "modeposz":
+                        index_modeposz = nindex
+                    elif val.lower() == "type":
+                        index_type = nindex
+                    elif val.lower() == "mass":
+                        index_mass = nindex
+                    elif val.lower() == "varmass":
+                        index_varmass = nindex
+                    elif val.lower() == "vx":
+                        index_vx = nindex
+                    elif val.lower() == "vy":
+                        index_vy = nindex
+                    elif val.lower() == "vz":
+                        index_vz = nindex
+                    elif val.lower() == "modemomx":
+                        index_modemomx = nindex
+                    elif val.lower() == "modemomy":
+                        index_modemomy = nindex
+                    elif val.lower() == "modemomz":
+                        index_modemomz = nindex
+                    elif val.lower() == "fx":
+                        index_fx = nindex
+                    elif val.lower() == "fy":
+                        index_fy = nindex
+                    elif val.lower() == "fz":
+                        index_fz = nindex
+                    elif val.lower() == "fmx":
+                        index_fmx = nindex
+                    elif val.lower() == "fmy":
+                        index_fmy = nindex
+                    elif val.lower() == "fmz":
+                        index_fmz = nindex
+                    elif val.lower() == "q":
+                        index_q = nindex
+                    elif val.lower() == "radius":
+                        index_radius = nindex
+                    elif val.lower() == "fradius":
+                        index_fradius = nindex
+                    elif val.lower() == "vradius":
+                        index_vradius = nindex
+                    elif val.lower() == "adrat":
+                        index_adrAT = nindex
+                    elif val.lower() == "lambda_adr":
+                        index_lambda_adr = nindex
+                    elif val.lower() == "lambda_adrd":
+                        index_lambda_adrd = nindex
+                    elif val.lower() == "state":
+                        index_state = nindex
+                    elif val.lower() == "pib":
+                        index_pib = nindex
+                    elif val.lower() == "res_id":
+                        index_res_id = nindex
+                    elif val.lower() == "vp":
+                        index_vp = nindex
+                    else:
+                        raise SyntaxError(
+                            "unknown particle property: %s" % val)
 
             assert index_id >= 0, "particle property id is mandatory"
             assert index_posx >= 0, "particle property posx is mandatory"
@@ -529,33 +617,38 @@ class StorageLocal(object):
             assert index_posz >= 0, "particle property posz is mandatory"
 
             def check3DProperty(prop, ix, iy, iz):
-                assert ((ix>=0)==(iy>=0) and (iy>=0)==(iz>=0)), \
-                    "Missing at least one of the 3d coordinates of property \"{}\"".format(prop)
+                assert ((ix >= 0) == (iy >= 0) and (iy >= 0) == (iz >= 0)), \
+                    "Missing at least one of the 3d coordinates of property \"{}\"".format(
+                        prop)
 
             check3DProperty("pos", index_posx, index_posy, index_posz)
             check3DProperty("v", index_vx, index_vy, index_vz)
             check3DProperty("f", index_fx, index_fy, index_fz)
             check3DProperty("fm", index_fmx, index_fmy, index_fmz)
-            check3DProperty("modepos", index_modeposx, index_modeposy, index_modeposz)
-            check3DProperty("modemom", index_modemomx, index_modemomy, index_modemomz)
+            check3DProperty("modepos", index_modeposx,
+                            index_modeposy, index_modeposz)
+            check3DProperty("modemom", index_modemomx,
+                            index_modemomy, index_modemomz)
 
             indices = np.array([index_id,
-                index_posx, index_posy, index_posz, index_modeposx, index_modeposy, index_modeposz,
-                index_vx, index_vy, index_vz, index_modemomx, index_modemomy, index_modemomz,
-                index_fx, index_fy, index_fz, index_fmx, index_fmy, index_fmz,
-                index_q, index_radius, index_fradius, index_vradius, index_type, index_mass,
-                index_varmass, index_adrAT, index_lambda_adr, index_lambda_adrd, index_state, index_pib, index_res_id,
-                index_vp
-                ], dtype=np.int32)
+                                index_posx, index_posy, index_posz, index_modeposx, index_modeposy, index_modeposz,
+                                index_vx, index_vy, index_vz, index_modemomx, index_modemomy, index_modemomz,
+                                index_fx, index_fy, index_fz, index_fmx, index_fmy, index_fmz,
+                                index_q, index_radius, index_fradius, index_vradius, index_type, index_mass,
+                                index_varmass, index_adrAT, index_lambda_adr, index_lambda_adrd, index_state, index_pib, index_res_id,
+                                index_vp
+                                ], dtype=np.int32)
             self.cxxclass.addParticlesFromArray(self, particleList, indices)
+
 
 if pmi.isController:
     class Storage(metaclass=pmi.Proxy):
         pmiproxydefs = dict(
-            pmicall = [ "decompose", "addParticles", "setFixedTuplesAdress", "removeAllParticles", "addParticlesArray"],
-            pmiproperty = [ "system" ],
-            pmiinvoke = ["getRealParticleIDs", "printRealParticles"]
-            )
+            pmicall=["decompose", "addParticles", "setFixedTuplesAdress",
+                     "removeAllParticles", "addParticlesArray"],
+            pmiproperty=["system"],
+            pmiinvoke=["getRealParticleIDs", "printRealParticles"]
+        )
 
         def particleExists(self, pid):
             return pmi.reduce(pmi.BOR, self.pmiobject, 'particleExists', pid)
@@ -563,7 +656,8 @@ if pmi.isController:
         def addParticle(self, pid, pos, checkexist=True):
             if checkexist:
                 if self.particleExists(pid):
-                    print("WARNING: Particle ", pid, " already exists. Therefore it was not added.")
+                    print("WARNING: Particle ", pid,
+                          " already exists. Therefore it was not added.")
                     return None
                 else:
                     pmi.call(self.pmiobject, 'addParticle', pid, pos)
@@ -576,29 +670,31 @@ if pmi.isController:
             if n == 0:
                 print("WARNING: Particle ", pid, " does not exist")
             elif n > 1:
-                print("ERROR: Particle ",pid, " did exist more than once !")
+                print("ERROR: Particle ", pid, " did exist more than once !")
                 print("       This should never happen !!!")
 
         def modifyParticle(self, pid, property, value):
             if (self.particleExists(pid)):
-                pmi.call(self.pmiobject, 'modifyParticle', pid, property, value)
+                pmi.call(self.pmiobject, 'modifyParticle',
+                         pid, property, value)
             else:
-                print("WARNING: Particle ", pid, " does not exist and was not modified")
-
+                print("WARNING: Particle ", pid,
+                      " does not exist and was not modified")
 
         def addAdrATParticle(self, pid, *args):
-            if( self.particleExists(pid) ):
-                print("WARNING: Particle ", pid, " already exists. Therefore it was not added.")
+            if(self.particleExists(pid)):
+                print("WARNING: Particle ", pid,
+                      " already exists. Therefore it was not added.")
                 return None
             else:
                 pmi.call(self.pmiobject, 'addAdrATParticle', pid, *args)
                 return Particle(pid, self)
 
-        #def setFixedTuples(self, tuples):
+        # def setFixedTuples(self, tuples):
         #    pmi.call(self.pmiobject, 'setFixedTuples', tuples)
 
         def getParticle(self, pid):
-            if( self.particleExists(pid) ):
+            if(self.particleExists(pid)):
                 return Particle(pid, self)
             else:
                 print("WARNING: Particle ", pid, " does not exist")


### PR DESCRIPTION
This PR adds code that was used to perform reverse mapping of different systems presented in:
 - Generic Adaptive Resolution Method for Reverse Mapping of Polymers from Coarse-Grained to Atomistic Descriptions (https://pubs.acs.org/doi/abs/10.1021/acs.jctc.6b00595)
 -  Reverse mapping method for complex polymer systems (https://onlinelibrary.wiley.com/doi/abs/10.1002/jcc.25129)

Although the method uses AdResS, in fact it works a bit different from the implementation that is already in E++. Basically, all particls (both AT and CG) are present in the simulation box. One additional parameter to the Particle was added: vp (virtual particle). The relationship between CG and AT particles is kept in FixedVSList. 