### PR TITLE
trying to remove some sources for nonull warnings

### DIFF
--- a/src/analysis/RDFatomistic.cpp
+++ b/src/analysis/RDFatomistic.cpp
@@ -79,8 +79,7 @@ python::list RDFatomistic::computeArray(int rdfN) const
                 {  // Are there atomistic particles for given CG particle? If yes, use those for
                    // calculation.
                     std::vector<Particle *> atList = it2->second;
-                    for (auto it3 = atList.begin();
-                         it3 != atList.end(); ++it3)
+                    for (auto it3 = atList.begin(); it3 != atList.end(); ++it3)
                     {
                         Particle &at = **it3;
                         int id = at.id();
@@ -251,8 +250,7 @@ python::list RDFatomistic::computeArrayPathIntegral(int rdfN) const
                 if (it2 != fixedtupleList->end())
                 {
                     std::vector<Particle *> atList = it2->second;
-                    for (auto it3 = atList.begin();
-                         it3 != atList.end(); ++it3)
+                    for (auto it3 = atList.begin(); it3 != atList.end(); ++it3)
                     {
                         Particle &at = **it3;
 

--- a/src/analysis/RDFatomistic.cpp
+++ b/src/analysis/RDFatomistic.cpp
@@ -78,9 +78,8 @@ python::list RDFatomistic::computeArray(int rdfN) const
                 if (it2 != fixedtupleList->end())
                 {  // Are there atomistic particles for given CG particle? If yes, use those for
                    // calculation.
-                    std::vector<Particle *> atList;
-                    atList = it2->second;
-                    for (std::vector<Particle *>::iterator it3 = atList.begin();
+                    std::vector<Particle *> atList = it2->second;
+                    for (auto it3 = atList.begin();
                          it3 != atList.end(); ++it3)
                     {
                         Particle &at = **it3;
@@ -101,7 +100,7 @@ python::list RDFatomistic::computeArray(int rdfN) const
         boost::mpi::broadcast(*system.comm, conf, rank_i);
 
         // for simplicity we will number the particles from 0
-        for (map<size_t, data>::iterator itr = conf.begin(); itr != conf.end(); ++itr)
+        for (auto itr = conf.begin(); itr != conf.end(); ++itr)
         {
             data p = itr->second;
             config[num_part] = p;
@@ -127,7 +126,7 @@ python::list RDFatomistic::computeArray(int rdfN) const
         int molP1 = config[i].molecule;
         real resolutionP1 = config[i].resolution;
 
-        if (spanbased == true)
+        if (spanbased)
         {
             if ((coordP1[0] < Li_half[0] + span) && (coordP1[0] > Li_half[0] - span))
             {
@@ -251,9 +250,8 @@ python::list RDFatomistic::computeArrayPathIntegral(int rdfN) const
 
                 if (it2 != fixedtupleList->end())
                 {
-                    std::vector<Particle *> atList;
-                    atList = it2->second;
-                    for (std::vector<Particle *>::iterator it3 = atList.begin();
+                    std::vector<Particle *> atList = it2->second;
+                    for (auto it3 = atList.begin();
                          it3 != atList.end(); ++it3)
                     {
                         Particle &at = **it3;
@@ -279,7 +277,7 @@ python::list RDFatomistic::computeArrayPathIntegral(int rdfN) const
         boost::mpi::broadcast(*system.comm, conf, rank_i);
 
         // for simplicity we will number the particles from 0
-        for (map<size_t, dataPathIntegral>::iterator itr = conf.begin(); itr != conf.end(); ++itr)
+        for (auto itr = conf.begin(); itr != conf.end(); ++itr)
         {
             dataPathIntegral p = itr->second;
             config[num_part] = p;

--- a/src/integrator/Adress.cpp
+++ b/src/integrator/Adress.cpp
@@ -403,8 +403,7 @@ void Adress::integrate2()
 
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Particle*> atList;
-            atList = it3->second;
+            std::vector<Particle*> atList = it3->second;
 
             Real3D cmv(0.0, 0.0, 0.0);  // center of mass velocity
             for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
@@ -452,8 +451,7 @@ void Adress::integrateSlow()
 
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Particle*> atList;
-            atList = it3->second;
+            std::vector<Particle*> atList = it3->second;
 
             Real3D cmv(0.0, 0.0, 0.0);  // center of mass velocity
             for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)

--- a/src/integrator/Adress.cpp
+++ b/src/integrator/Adress.cpp
@@ -149,13 +149,12 @@ void Adress::SetPosVel()
 
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Particle*> atList;
-            atList = it3->second;
+            std::vector<Particle*> atList = it3->second;
 
             // Compute center of mass
             Real3D cmp(0.0, 0.0, 0.0);  // center of mass position
             Real3D cmv(0.0, 0.0, 0.0);  // center of mass velocity
-            for (std::vector<Particle*>::iterator it2 = atList.begin(); it2 != atList.end(); ++it2)
+            for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
             {
                 Particle& at = **it2;
                 cmp += at.mass() * at.position();
@@ -224,7 +223,7 @@ void Adress::initForces()
 
     // AT reals
     ParticleList& adrATparticles = system.storage->getAdrATParticles();
-    for (std::vector<Particle>::iterator it = adrATparticles.begin(); it != adrATparticles.end();
+    for (auto it = adrATparticles.begin(); it != adrATparticles.end();
          ++it)
     {
         it->force() = 0.0;
@@ -233,9 +232,9 @@ void Adress::initForces()
     // AT ghosts
     typedef std::list<ParticleList> ParticleListAdr;
     ParticleListAdr& adrATparticlesG = system.storage->getAdrATParticlesG();
-    for (ParticleListAdr::iterator it = adrATparticlesG.begin(); it != adrATparticlesG.end(); ++it)
+    for (auto it = adrATparticlesG.begin(); it != adrATparticlesG.end(); ++it)
     {
-        for (ParticleList::iterator it2 = it->begin(); it2 != it->end(); ++it2)
+        for (auto it2 = it->begin(); it2 != it->end(); ++it2)
         {
             it2->force() = 0.0;
             it2->drift() = 0.0;
@@ -249,7 +248,7 @@ void Adress::integrate1(real& maxSqDist)
     real dt = integrator->getTimeStep();
 
     ParticleList& adrATparticles = system.storage->getAdrATParticles();
-    for (std::vector<Particle>::iterator it = adrATparticles.begin(); it != adrATparticles.end();
+    for (auto it = adrATparticles.begin(); it != adrATparticles.end();
          it++)
     {
         real sqDist = 0.0;
@@ -277,13 +276,12 @@ void Adress::integrate1(real& maxSqDist)
 
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Particle*> atList;
-            atList = it3->second;
+            std::vector<Particle*> atList = it3->second;
 
             // Compute center of mass
             Real3D cmp(0.0, 0.0, 0.0);  // center of mass position
             Real3D cmv(0.0, 0.0, 0.0);  // center of mass velocity
-            for (std::vector<Particle*>::iterator it2 = atList.begin(); it2 != atList.end(); ++it2)
+            for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
             {
                 Particle& at = **it2;
                 cmp += at.mass() * at.position();
@@ -385,7 +383,7 @@ void Adress::integrate2()
 
     // propagete real AT particles
     ParticleList& adrATparticles = system.storage->getAdrATParticles();
-    for (std::vector<Particle>::iterator it = adrATparticles.begin(); it != adrATparticles.end();
+    for (auto it = adrATparticles.begin(); it != adrATparticles.end();
          ++it)
     {
         real dtfm = 0.5 * dt / it->mass();
@@ -409,7 +407,7 @@ void Adress::integrate2()
             atList = it3->second;
 
             Real3D cmv(0.0, 0.0, 0.0);  // center of mass velocity
-            for (std::vector<Particle*>::iterator it2 = atList.begin(); it2 != atList.end(); ++it2)
+            for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
             {
                 Particle& at = **it2;
                 cmv += at.mass() * at.velocity();
@@ -434,7 +432,7 @@ void Adress::integrateSlow()
 
     // propagete real AT particles
     ParticleList& adrATparticles = system.storage->getAdrATParticles();
-    for (std::vector<Particle>::iterator it = adrATparticles.begin(); it != adrATparticles.end();
+    for (auto it = adrATparticles.begin(); it != adrATparticles.end();
          ++it)
     {
         real dtfm = 0.5 * multistep * dt / it->mass();
@@ -458,7 +456,7 @@ void Adress::integrateSlow()
             atList = it3->second;
 
             Real3D cmv(0.0, 0.0, 0.0);  // center of mass velocity
-            for (std::vector<Particle*>::iterator it2 = atList.begin(); it2 != atList.end(); ++it2)
+            for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
             {
                 Particle& at = **it2;
                 cmv += at.mass() * at.velocity();
@@ -628,12 +626,11 @@ void Adress::aftCalcF()
 
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Particle*> atList;
-            atList = it3->second;
+            std::vector<Particle*> atList = it3->second;
 
             // update force of AT particles belonging to a VP
             Real3D vpfm = vp.force() / vp.getMass();
-            for (std::vector<Particle*>::iterator it2 = atList.begin(); it2 != atList.end(); ++it2)
+            for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
             {
                 Particle& at = **it2;
 

--- a/src/integrator/Adress.cpp
+++ b/src/integrator/Adress.cpp
@@ -223,8 +223,7 @@ void Adress::initForces()
 
     // AT reals
     ParticleList& adrATparticles = system.storage->getAdrATParticles();
-    for (auto it = adrATparticles.begin(); it != adrATparticles.end();
-         ++it)
+    for (auto it = adrATparticles.begin(); it != adrATparticles.end(); ++it)
     {
         it->force() = 0.0;
     }
@@ -248,8 +247,7 @@ void Adress::integrate1(real& maxSqDist)
     real dt = integrator->getTimeStep();
 
     ParticleList& adrATparticles = system.storage->getAdrATParticles();
-    for (auto it = adrATparticles.begin(); it != adrATparticles.end();
-         it++)
+    for (auto it = adrATparticles.begin(); it != adrATparticles.end(); it++)
     {
         real sqDist = 0.0;
         real dtfm = 0.5 * dt / it->mass();
@@ -383,8 +381,7 @@ void Adress::integrate2()
 
     // propagete real AT particles
     ParticleList& adrATparticles = system.storage->getAdrATParticles();
-    for (auto it = adrATparticles.begin(); it != adrATparticles.end();
-         ++it)
+    for (auto it = adrATparticles.begin(); it != adrATparticles.end(); ++it)
     {
         real dtfm = 0.5 * dt / it->mass();
 
@@ -431,8 +428,7 @@ void Adress::integrateSlow()
 
     // propagete real AT particles
     ParticleList& adrATparticles = system.storage->getAdrATParticles();
-    for (auto it = adrATparticles.begin(); it != adrATparticles.end();
-         ++it)
+    for (auto it = adrATparticles.begin(); it != adrATparticles.end(); ++it)
     {
         real dtfm = 0.5 * multistep * dt / it->mass();
 

--- a/src/integrator/PIAdressIntegrator.cpp
+++ b/src/integrator/PIAdressIntegrator.cpp
@@ -212,12 +212,11 @@ void PIAdressIntegrator::initializeSetup()
 
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it3->second;
+            std::vector<Particle *> atList = it3->second;
 
             Real3D cmp(0.0, 0.0, 0.0);
             Real3D cmv(0.0, 0.0, 0.0);
-            for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end(); ++it2)
+            for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
             {
                 Particle &at = **it2;
                 cmp += at.position();
@@ -232,7 +231,7 @@ void PIAdressIntegrator::initializeSetup()
 
             if (KTI == false)
             {
-                std::vector<Real3D *>::iterator it2 = verletList->getAdrPositions().begin();
+                auto it2 = verletList->getAdrPositions().begin();
                 Real3D pa = **it2;  // position of adress particle
                 Real3D d1(0.0, 0.0, 0.0);
                 verletList->getSystem()->bc->getMinimumImageVector(d1, vp.position(), pa);
@@ -320,10 +319,9 @@ void PIAdressIntegrator::integrateV1(int t, bool doubletime)
         it3 = fixedtupleList->find(&vp);
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it3->second;
+            std::vector<Particle *> atList = it3->second;
 
-            for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end(); ++it2)
+            for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
             {
                 Particle &at = **it2;
                 if ((at.pib() != 1) && (speedup == true) && (vp.lambda() < 0.000000001))
@@ -365,8 +363,7 @@ void PIAdressIntegrator::integrateV2()
         it3 = fixedtupleList->find(&vp);
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it3->second;
+            std::vector<Particle *> atList = it3->second;
 
             if (constkinmass == false)
             {  // kinetic mass also changes - hence, second decomposition level required
@@ -374,7 +371,7 @@ void PIAdressIntegrator::integrateV2()
                 // First half_dt4 loop without centroid mode
                 if ((speedup == false) || (vp.lambda() > 0.000000001))
                 {  // do not propagate the higher modes in the CL region when using speedup
-                    for (std::vector<Particle *>::iterator it2 = atList.begin();
+                    for (auto it2 = atList.begin();
                          it2 != atList.end(); ++it2)
                     {
                         Particle &at = **it2;
@@ -396,7 +393,7 @@ void PIAdressIntegrator::integrateV2()
                 }
 
                 // half_dt2, only centroid mode
-                for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end();
+                for (auto it2 = atList.begin(); it2 != atList.end();
                      ++it2)
                 {
                     Particle &at = **it2;
@@ -408,7 +405,7 @@ void PIAdressIntegrator::integrateV2()
                         {
                             // Get the inner factor
                             real xi = 0.0;
-                            for (std::vector<Particle *>::iterator it5 = atList.begin();
+                            for (auto it5 = atList.begin();
                                  it5 != atList.end(); ++it5)
                             {
                                 Particle &at2 = **it5;
@@ -425,7 +422,7 @@ void PIAdressIntegrator::integrateV2()
                                 }
                             }
 
-                            std::vector<Real3D *>::iterator it2 =
+                            auto it2 =
                                 verletList->getAdrPositions().begin();
                             Real3D pa = **it2;
                             Real3D mindriftforce(0.0, 0.0, 0.0);
@@ -504,7 +501,7 @@ void PIAdressIntegrator::integrateV2()
                 if ((speedup == false) || (vp.lambda() > 0.000000001))
                 {  // do not propagate the higher modes in the CL region when using speedup
 
-                    for (std::vector<Particle *>::iterator it2 = atList.begin();
+                    for (auto it2 = atList.begin();
                          it2 != atList.end(); ++it2)
                     {
                         Particle &at = **it2;
@@ -528,7 +525,7 @@ void PIAdressIntegrator::integrateV2()
             }
             else
             {  // constant kinetic mass - hence, no second decomposition level required
-                for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end();
+                for (auto it2 = atList.begin(); it2 != atList.end();
                      ++it2)
                 {
                     Particle &at = **it2;
@@ -574,11 +571,10 @@ void PIAdressIntegrator::integrateModePos()
             it3 = fixedtupleList->find(&vp);
             if (it3 != fixedtupleList->end())
             {
-                std::vector<Particle *> atList;
-                atList = it3->second;
+                std::vector<Particle *> atList = it3->second;
 
                 // First half_dt4 loop with only centroid mode
-                for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end();
+                for (auto it2 = atList.begin(); it2 != atList.end();
                      ++it2)
                 {
                     Particle &at = **it2;
@@ -589,7 +585,7 @@ void PIAdressIntegrator::integrateModePos()
                         if (KTI == false)
                         {
                             // Update resolution and variable masses
-                            std::vector<Real3D *>::iterator it2 =
+                            auto it2 =
                                 verletList->getAdrPositions().begin();
                             Real3D pa = **it2;
                             Real3D d1(0.0, 0.0, 0.0);
@@ -640,7 +636,7 @@ void PIAdressIntegrator::integrateModePos()
 
                 // half_dt2 loop without centroid mode
                 real half_dt = 0.5 * ntrotter * dt / (CMDparameter * vp.varmass());
-                for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end();
+                for (auto it2 = atList.begin(); it2 != atList.end();
                      ++it2)
                 {
                     Particle &at = **it2;
@@ -664,7 +660,7 @@ void PIAdressIntegrator::integrateModePos()
                 }
 
                 // Second half_dt4 loop with only centroid mode
-                for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end();
+                for (auto it2 = atList.begin(); it2 != atList.end();
                      ++it2)
                 {
                     Particle &at = **it2;
@@ -676,7 +672,7 @@ void PIAdressIntegrator::integrateModePos()
                         if (KTI == false)
                         {
                             // Update resolution and variable masses
-                            std::vector<Real3D *>::iterator it2 =
+                            auto it2 =
                                 verletList->getAdrPositions().begin();
                             Real3D pa = **it2;
                             Real3D d1(0.0, 0.0, 0.0);
@@ -741,10 +737,9 @@ void PIAdressIntegrator::integrateModePos()
             it3 = fixedtupleList->find(&vp);
             if (it3 != fixedtupleList->end())
             {
-                std::vector<Particle *> atList;
-                atList = it3->second;
+                std::vector<Particle *> atList = it3->second;
 
-                for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end();
+                for (auto it2 = atList.begin(); it2 != atList.end();
                      ++it2)
                 {
                     Particle &at = **it2;
@@ -756,7 +751,7 @@ void PIAdressIntegrator::integrateModePos()
                         if (KTI == false)
                         {
                             // Update resolution and variable masses
-                            std::vector<Real3D *>::iterator it2 =
+                            auto it2 =
                                 verletList->getAdrPositions().begin();
                             Real3D pa = **it2;
                             Real3D d1(0.0, 0.0, 0.0);
@@ -854,10 +849,9 @@ void PIAdressIntegrator::OUintegrate()
         it3 = fixedtupleList->find(&vp);
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it3->second;
+            auto atList = it3->second;
 
-            for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end(); ++it2)
+            for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
             {
                 Particle &at = **it2;
                 if (at.pib() == 1)
@@ -964,17 +958,16 @@ void PIAdressIntegrator::transPos1()
 
         if (it2 != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it2->second;
+            std::vector<Particle *> atList = it2->second;
             Real3D oldpos = vp.position();
 
-            for (std::vector<Particle *>::iterator it3 = atList.begin(); it3 != atList.end(); ++it3)
+            for (auto it3 = atList.begin(); it3 != atList.end(); ++it3)
             {
                 Particle &at = **it3;
                 Real3D zero(0.0, 0.0, 0.0);
                 at.position() = zero;
 
-                for (std::vector<Particle *>::iterator it5 = atList.begin(); it5 != atList.end();
+                for (auto it5 = atList.begin(); it5 != atList.end();
                      ++it5)
                 {
                     Particle &at2 = **it5;
@@ -1027,16 +1020,15 @@ void PIAdressIntegrator::transPos2()
 
         if (it2 != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it2->second;
+            std::vector<Particle *> atList = it2->second;
 
-            for (std::vector<Particle *>::iterator it3 = atList.begin(); it3 != atList.end(); ++it3)
+            for (auto it3 = atList.begin(); it3 != atList.end(); ++it3)
             {
                 Particle &at = **it3;
                 Real3D zero(0.0, 0.0, 0.0);
                 at.modepos() = zero;
 
-                for (std::vector<Particle *>::iterator it5 = atList.begin(); it5 != atList.end();
+                for (auto it5 = atList.begin(); it5 != atList.end();
                      ++it5)
                 {
                     Particle &at2 = **it5;
@@ -1079,15 +1071,14 @@ void PIAdressIntegrator::transMom1()
 
         if (it2 != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it2->second;
-            for (std::vector<Particle *>::iterator it3 = atList.begin(); it3 != atList.end(); ++it3)
+            std::vector<Particle *> atList = it2->second;
+            for (auto it3 = atList.begin(); it3 != atList.end(); ++it3)
             {
                 Particle &at = **it3;
                 Real3D zero(0.0, 0.0, 0.0);
                 at.velocity() = zero;
 
-                for (std::vector<Particle *>::iterator it5 = atList.begin(); it5 != atList.end();
+                for (auto it5 = atList.begin(); it5 != atList.end();
                      ++it5)
                 {
                     Particle &at2 = **it5;
@@ -1182,15 +1173,14 @@ void PIAdressIntegrator::transMom2()
 
         if (it2 != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it2->second;
-            for (std::vector<Particle *>::iterator it3 = atList.begin(); it3 != atList.end(); ++it3)
+            std::vector<Particle *> atList = it2->second;
+            for (auto it3 = atList.begin(); it3 != atList.end(); ++it3)
             {
                 Particle &at = **it3;
                 Real3D zero(0.0, 0.0, 0.0);
                 at.modemom() = zero;
 
-                for (std::vector<Particle *>::iterator it5 = atList.begin(); it5 != atList.end();
+                for (auto it5 = atList.begin(); it5 != atList.end();
                      ++it5)
                 {
                     Particle &at2 = **it5;
@@ -1269,13 +1259,12 @@ void PIAdressIntegrator::transForces()
 
         if (it2 != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it2->second;
-            for (std::vector<Particle *>::iterator it3 = atList.begin(); it3 != atList.end(); ++it3)
+            std::vector<Particle *> atList = it2->second;
+            for (auto it3 = atList.begin(); it3 != atList.end(); ++it3)
             {
                 Particle &at = **it3;
 
-                for (std::vector<Particle *>::iterator it5 = atList.begin(); it5 != atList.end();
+                for (auto it5 = atList.begin(); it5 != atList.end();
                      ++it5)
                 {
                     Particle &at2 = **it5;
@@ -1358,9 +1347,8 @@ void PIAdressIntegrator::calcForcesF()
             {
                 if (it2 != fixedtupleList->end())
                 {
-                    std::vector<Particle *> atList;
-                    atList = it2->second;
-                    for (std::vector<Particle *>::iterator it3 = atList.begin();
+                    std::vector<Particle *> atList = it2->second;
+                    for (auto it3 = atList.begin();
                          it3 != atList.end(); ++it3)
                     {
                         Particle &at = **it3;
@@ -1375,7 +1363,7 @@ void PIAdressIntegrator::calcForcesF()
                             if (vp.lambda() < 1.0 && vp.lambda() > 0.0)
                             {
                                 real xi = 0.0;
-                                for (std::vector<Particle *>::iterator it5 = atList.begin();
+                                for (auto it5 = atList.begin();
                                      it5 != atList.end(); ++it5)
                                 {
                                     Particle &at2 = **it5;
@@ -1384,7 +1372,7 @@ void PIAdressIntegrator::calcForcesF()
                                         xi += at2.modepos().sqr() * Eigenvalues[at2.pib() - 1];
                                     }
                                 }
-                                std::vector<Real3D *>::iterator it2 =
+                                auto it2 =
                                     verletList->getAdrPositions().begin();
                                 Real3D pa = **it2;
                                 Real3D mindriftforce(0.0, 0.0, 0.0);
@@ -1462,9 +1450,8 @@ void PIAdressIntegrator::calcForcesF()
         {
             if (it2 != fixedtupleList->end())
             {
-                std::vector<Particle *> atList;
-                atList = it2->second;
-                for (std::vector<Particle *>::iterator it3 = atList.begin(); it3 != atList.end();
+                std::vector<Particle *> atList = it2->second;
+                for (auto it3 = atList.begin(); it3 != atList.end();
                      ++it3)
                 {
                     Particle &at = **it3;
@@ -1479,7 +1466,7 @@ void PIAdressIntegrator::calcForcesF()
                         if (vp.lambda() < 1.0 && vp.lambda() > 0.0)
                         {
                             real xi = 0.0;
-                            for (std::vector<Particle *>::iterator it5 = atList.begin();
+                            for (auto it5 = atList.begin();
                                  it5 != atList.end(); ++it5)
                             {
                                 Particle &at2 = **it5;
@@ -1488,7 +1475,7 @@ void PIAdressIntegrator::calcForcesF()
                                     xi += at2.modepos().sqr() * Eigenvalues[at2.pib() - 1];
                                 }
                             }
-                            std::vector<Real3D *>::iterator it2 =
+                            auto it2 =
                                 verletList->getAdrPositions().begin();
                             Real3D pa = **it2;
                             Real3D mindriftforce(0.0, 0.0, 0.0);
@@ -1618,10 +1605,9 @@ void PIAdressIntegrator::distributeForces()
 
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it3->second;
+            std::vector<Particle *> atList = it3->second;
             Real3D vpfm = vp.force();
-            for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end(); ++it2)
+            for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
             {
                 Particle &at = **it2;
                 at.force() += (1.0 / ntrotter) * vpfm;
@@ -1646,7 +1632,7 @@ void PIAdressIntegrator::initForces(int f)
         // real atomistic particles
         CellList localCells = system.storage->getLocalCells();
         ParticleList &adrATparticles = system.storage->getAdrATParticles();
-        for (std::vector<Particle>::iterator it = adrATparticles.begin();
+        for (auto it = adrATparticles.begin();
              it != adrATparticles.end(); ++it)
         {
             it->forcem() = 0.0;
@@ -1664,7 +1650,7 @@ void PIAdressIntegrator::initForces(int f)
         }
         // real atomistic particles
         ParticleList &adrATparticles = system.storage->getAdrATParticles();
-        for (std::vector<Particle>::iterator it = adrATparticles.begin();
+        for (auto it = adrATparticles.begin();
              it != adrATparticles.end(); ++it)
         {
             it->force() = 0.0;
@@ -1673,10 +1659,10 @@ void PIAdressIntegrator::initForces(int f)
         // atomistic ghost particles
         typedef std::list<ParticleList> ParticleListAdr;
         ParticleListAdr &adrATparticlesG = system.storage->getAdrATParticlesG();
-        for (ParticleListAdr::iterator it = adrATparticlesG.begin(); it != adrATparticlesG.end();
+        for (auto it = adrATparticlesG.begin(); it != adrATparticlesG.end();
              ++it)
         {
-            for (ParticleList::iterator it2 = it->begin(); it2 != it->end(); ++it2)
+            for (auto it2 = it->begin(); it2 != it->end(); ++it2)
             {
                 it2->force() = 0.0;
                 it2->forcem() = 0.0;
@@ -1704,9 +1690,8 @@ real PIAdressIntegrator::computeKineticEnergy()
         it3 = fixedtupleList->find(&vp);
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it3->second;
-            for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end(); ++it2)
+            std::vector<Particle *> atList = it3->second;
+            for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
             {
                 Particle &at = **it2;
                 if (at.pib() == 1)
@@ -1783,9 +1768,8 @@ real PIAdressIntegrator::computeRingEnergy()
         it3 = fixedtupleList->find(&vp);
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it3->second;
-            for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end(); ++it2)
+            std::vector<Particle *> atList = it3->second;
+            for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
             {
                 Particle &at = **it2;
                 if (at.pib() == 1)
@@ -1832,11 +1816,10 @@ real PIAdressIntegrator::computeRingEnergyRaw()
         it3 = fixedtupleList->find(&vp);
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it3->second;
+            std::vector<Particle *> atList = it3->second;
             Real3D pos1(0.0, 0.0, 0.0);
             Real3D posN(0.0, 0.0, 0.0);
-            for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end(); ++it2)
+            for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
             {
                 Particle &at = **it2;
                 if (at.pib() == 1)
@@ -1891,9 +1874,8 @@ real PIAdressIntegrator::computeMomentumDrift(int parttype)
             it3 = fixedtupleList->find(&vp);
             if (it3 != fixedtupleList->end())
             {
-                std::vector<Particle *> atList;
-                atList = it3->second;
-                for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end();
+                std::vector<Particle *> atList = it3->second;
+                for (auto it2 = atList.begin(); it2 != atList.end();
                      ++it2)
                 {
                     Particle &at = **it2;
@@ -1954,9 +1936,8 @@ real PIAdressIntegrator::computePositionDrift(int parttype)
             it3 = fixedtupleList->find(&vp);
             if (it3 != fixedtupleList->end())
             {
-                std::vector<Particle *> atList;
-                atList = it3->second;
-                for (std::vector<Particle *>::iterator it2 = atList.begin(); it2 != atList.end();
+                std::vector<Particle *> atList = it3->second;
+                for (auto it2 = atList.begin(); it2 != atList.end();
                      ++it2)
                 {
                     Particle &at = **it2;
@@ -2004,7 +1985,7 @@ void PIAdressIntegrator::setWeights()
         it3 = fixedtupleList->find(&vp);
         if (it3 != fixedtupleList->end())
         {
-            std::vector<Real3D *>::iterator it2 = verletList->getAdrPositions().begin();
+            auto it2 = verletList->getAdrPositions().begin();
             Real3D pa = **it2;
             Real3D d1(0.0, 0.0, 0.0);
             real min1sq;

--- a/src/integrator/PIAdressIntegrator.cpp
+++ b/src/integrator/PIAdressIntegrator.cpp
@@ -371,8 +371,7 @@ void PIAdressIntegrator::integrateV2()
                 // First half_dt4 loop without centroid mode
                 if ((speedup == false) || (vp.lambda() > 0.000000001))
                 {  // do not propagate the higher modes in the CL region when using speedup
-                    for (auto it2 = atList.begin();
-                         it2 != atList.end(); ++it2)
+                    for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
                     {
                         Particle &at = **it2;
                         if (at.pib() == 1)
@@ -393,8 +392,7 @@ void PIAdressIntegrator::integrateV2()
                 }
 
                 // half_dt2, only centroid mode
-                for (auto it2 = atList.begin(); it2 != atList.end();
-                     ++it2)
+                for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
                 {
                     Particle &at = **it2;
                     if (at.pib() == 1)
@@ -405,8 +403,7 @@ void PIAdressIntegrator::integrateV2()
                         {
                             // Get the inner factor
                             real xi = 0.0;
-                            for (auto it5 = atList.begin();
-                                 it5 != atList.end(); ++it5)
+                            for (auto it5 = atList.begin(); it5 != atList.end(); ++it5)
                             {
                                 Particle &at2 = **it5;
                                 if (at2.pib() != 1)
@@ -422,8 +419,7 @@ void PIAdressIntegrator::integrateV2()
                                 }
                             }
 
-                            auto it2 =
-                                verletList->getAdrPositions().begin();
+                            auto it2 = verletList->getAdrPositions().begin();
                             Real3D pa = **it2;
                             Real3D mindriftforce(0.0, 0.0, 0.0);
                             verletList->getSystem()->bc->getMinimumImageVector(
@@ -501,8 +497,7 @@ void PIAdressIntegrator::integrateV2()
                 if ((speedup == false) || (vp.lambda() > 0.000000001))
                 {  // do not propagate the higher modes in the CL region when using speedup
 
-                    for (auto it2 = atList.begin();
-                         it2 != atList.end(); ++it2)
+                    for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
                     {
                         Particle &at = **it2;
 
@@ -525,8 +520,7 @@ void PIAdressIntegrator::integrateV2()
             }
             else
             {  // constant kinetic mass - hence, no second decomposition level required
-                for (auto it2 = atList.begin(); it2 != atList.end();
-                     ++it2)
+                for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
                 {
                     Particle &at = **it2;
                     if ((at.pib() != 1) && (speedup == true) && (vp.lambda() < 0.000000001))
@@ -574,8 +568,7 @@ void PIAdressIntegrator::integrateModePos()
                 std::vector<Particle *> atList = it3->second;
 
                 // First half_dt4 loop with only centroid mode
-                for (auto it2 = atList.begin(); it2 != atList.end();
-                     ++it2)
+                for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
                 {
                     Particle &at = **it2;
                     if (at.pib() == 1)
@@ -585,8 +578,7 @@ void PIAdressIntegrator::integrateModePos()
                         if (KTI == false)
                         {
                             // Update resolution and variable masses
-                            auto it2 =
-                                verletList->getAdrPositions().begin();
+                            auto it2 = verletList->getAdrPositions().begin();
                             Real3D pa = **it2;
                             Real3D d1(0.0, 0.0, 0.0);
                             real min1sq;
@@ -636,8 +628,7 @@ void PIAdressIntegrator::integrateModePos()
 
                 // half_dt2 loop without centroid mode
                 real half_dt = 0.5 * ntrotter * dt / (CMDparameter * vp.varmass());
-                for (auto it2 = atList.begin(); it2 != atList.end();
-                     ++it2)
+                for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
                 {
                     Particle &at = **it2;
                     if ((at.pib() == 1) ||
@@ -660,8 +651,7 @@ void PIAdressIntegrator::integrateModePos()
                 }
 
                 // Second half_dt4 loop with only centroid mode
-                for (auto it2 = atList.begin(); it2 != atList.end();
-                     ++it2)
+                for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
                 {
                     Particle &at = **it2;
 
@@ -672,8 +662,7 @@ void PIAdressIntegrator::integrateModePos()
                         if (KTI == false)
                         {
                             // Update resolution and variable masses
-                            auto it2 =
-                                verletList->getAdrPositions().begin();
+                            auto it2 = verletList->getAdrPositions().begin();
                             Real3D pa = **it2;
                             Real3D d1(0.0, 0.0, 0.0);
                             real min1sq;
@@ -739,8 +728,7 @@ void PIAdressIntegrator::integrateModePos()
             {
                 std::vector<Particle *> atList = it3->second;
 
-                for (auto it2 = atList.begin(); it2 != atList.end();
-                     ++it2)
+                for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
                 {
                     Particle &at = **it2;
 
@@ -751,8 +739,7 @@ void PIAdressIntegrator::integrateModePos()
                         if (KTI == false)
                         {
                             // Update resolution and variable masses
-                            auto it2 =
-                                verletList->getAdrPositions().begin();
+                            auto it2 = verletList->getAdrPositions().begin();
                             Real3D pa = **it2;
                             Real3D d1(0.0, 0.0, 0.0);
                             real min1sq;
@@ -967,8 +954,7 @@ void PIAdressIntegrator::transPos1()
                 Real3D zero(0.0, 0.0, 0.0);
                 at.position() = zero;
 
-                for (auto it5 = atList.begin(); it5 != atList.end();
-                     ++it5)
+                for (auto it5 = atList.begin(); it5 != atList.end(); ++it5)
                 {
                     Particle &at2 = **it5;
                     if (int_c(at.pib()) <= ntrotter)
@@ -1028,8 +1014,7 @@ void PIAdressIntegrator::transPos2()
                 Real3D zero(0.0, 0.0, 0.0);
                 at.modepos() = zero;
 
-                for (auto it5 = atList.begin(); it5 != atList.end();
-                     ++it5)
+                for (auto it5 = atList.begin(); it5 != atList.end(); ++it5)
                 {
                     Particle &at2 = **it5;
                     if (int_c(at.pib()) <= ntrotter)
@@ -1078,8 +1063,7 @@ void PIAdressIntegrator::transMom1()
                 Real3D zero(0.0, 0.0, 0.0);
                 at.velocity() = zero;
 
-                for (auto it5 = atList.begin(); it5 != atList.end();
-                     ++it5)
+                for (auto it5 = atList.begin(); it5 != atList.end(); ++it5)
                 {
                     Particle &at2 = **it5;
                     if (int_c(at.pib()) <= ntrotter)
@@ -1180,8 +1164,7 @@ void PIAdressIntegrator::transMom2()
                 Real3D zero(0.0, 0.0, 0.0);
                 at.modemom() = zero;
 
-                for (auto it5 = atList.begin(); it5 != atList.end();
-                     ++it5)
+                for (auto it5 = atList.begin(); it5 != atList.end(); ++it5)
                 {
                     Particle &at2 = **it5;
                     if (int_c(at.pib()) <= ntrotter)
@@ -1264,8 +1247,7 @@ void PIAdressIntegrator::transForces()
             {
                 Particle &at = **it3;
 
-                for (auto it5 = atList.begin(); it5 != atList.end();
-                     ++it5)
+                for (auto it5 = atList.begin(); it5 != atList.end(); ++it5)
                 {
                     Particle &at2 = **it5;
                     if (at.pib() == 1)
@@ -1348,8 +1330,7 @@ void PIAdressIntegrator::calcForcesF()
                 if (it2 != fixedtupleList->end())
                 {
                     std::vector<Particle *> atList = it2->second;
-                    for (auto it3 = atList.begin();
-                         it3 != atList.end(); ++it3)
+                    for (auto it3 = atList.begin(); it3 != atList.end(); ++it3)
                     {
                         Particle &at = **it3;
                         if (at.pib() > 1 && int_c(at.pib()) <= ntrotter)
@@ -1363,8 +1344,7 @@ void PIAdressIntegrator::calcForcesF()
                             if (vp.lambda() < 1.0 && vp.lambda() > 0.0)
                             {
                                 real xi = 0.0;
-                                for (auto it5 = atList.begin();
-                                     it5 != atList.end(); ++it5)
+                                for (auto it5 = atList.begin(); it5 != atList.end(); ++it5)
                                 {
                                     Particle &at2 = **it5;
                                     if (at2.pib() != 1)
@@ -1372,8 +1352,7 @@ void PIAdressIntegrator::calcForcesF()
                                         xi += at2.modepos().sqr() * Eigenvalues[at2.pib() - 1];
                                     }
                                 }
-                                auto it2 =
-                                    verletList->getAdrPositions().begin();
+                                auto it2 = verletList->getAdrPositions().begin();
                                 Real3D pa = **it2;
                                 Real3D mindriftforce(0.0, 0.0, 0.0);
                                 verletList->getSystem()->bc->getMinimumImageVector(
@@ -1451,8 +1430,7 @@ void PIAdressIntegrator::calcForcesF()
             if (it2 != fixedtupleList->end())
             {
                 std::vector<Particle *> atList = it2->second;
-                for (auto it3 = atList.begin(); it3 != atList.end();
-                     ++it3)
+                for (auto it3 = atList.begin(); it3 != atList.end(); ++it3)
                 {
                     Particle &at = **it3;
                     if (at.pib() > 1 && int_c(at.pib()) <= ntrotter)
@@ -1466,8 +1444,7 @@ void PIAdressIntegrator::calcForcesF()
                         if (vp.lambda() < 1.0 && vp.lambda() > 0.0)
                         {
                             real xi = 0.0;
-                            for (auto it5 = atList.begin();
-                                 it5 != atList.end(); ++it5)
+                            for (auto it5 = atList.begin(); it5 != atList.end(); ++it5)
                             {
                                 Particle &at2 = **it5;
                                 if (at2.pib() != 1)
@@ -1475,8 +1452,7 @@ void PIAdressIntegrator::calcForcesF()
                                     xi += at2.modepos().sqr() * Eigenvalues[at2.pib() - 1];
                                 }
                             }
-                            auto it2 =
-                                verletList->getAdrPositions().begin();
+                            auto it2 = verletList->getAdrPositions().begin();
                             Real3D pa = **it2;
                             Real3D mindriftforce(0.0, 0.0, 0.0);
                             verletList->getSystem()->bc->getMinimumImageVector(
@@ -1632,8 +1608,7 @@ void PIAdressIntegrator::initForces(int f)
         // real atomistic particles
         CellList localCells = system.storage->getLocalCells();
         ParticleList &adrATparticles = system.storage->getAdrATParticles();
-        for (auto it = adrATparticles.begin();
-             it != adrATparticles.end(); ++it)
+        for (auto it = adrATparticles.begin(); it != adrATparticles.end(); ++it)
         {
             it->forcem() = 0.0;
         }
@@ -1650,8 +1625,7 @@ void PIAdressIntegrator::initForces(int f)
         }
         // real atomistic particles
         ParticleList &adrATparticles = system.storage->getAdrATParticles();
-        for (auto it = adrATparticles.begin();
-             it != adrATparticles.end(); ++it)
+        for (auto it = adrATparticles.begin(); it != adrATparticles.end(); ++it)
         {
             it->force() = 0.0;
             it->forcem() = 0.0;
@@ -1659,8 +1633,7 @@ void PIAdressIntegrator::initForces(int f)
         // atomistic ghost particles
         typedef std::list<ParticleList> ParticleListAdr;
         ParticleListAdr &adrATparticlesG = system.storage->getAdrATParticlesG();
-        for (auto it = adrATparticlesG.begin(); it != adrATparticlesG.end();
-             ++it)
+        for (auto it = adrATparticlesG.begin(); it != adrATparticlesG.end(); ++it)
         {
             for (auto it2 = it->begin(); it2 != it->end(); ++it2)
             {
@@ -1875,8 +1848,7 @@ real PIAdressIntegrator::computeMomentumDrift(int parttype)
             if (it3 != fixedtupleList->end())
             {
                 std::vector<Particle *> atList = it3->second;
-                for (auto it2 = atList.begin(); it2 != atList.end();
-                     ++it2)
+                for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
                 {
                     Particle &at = **it2;
                     if (at.pib() == 1)
@@ -1937,8 +1909,7 @@ real PIAdressIntegrator::computePositionDrift(int parttype)
             if (it3 != fixedtupleList->end())
             {
                 std::vector<Particle *> atList = it3->second;
-                for (auto it2 = atList.begin(); it2 != atList.end();
-                     ++it2)
+                for (auto it2 = atList.begin(); it2 != atList.end(); ++it2)
                 {
                     Particle &at = **it2;
                     if (at.pib() == 1)

--- a/src/interaction/PotentialVSpherePair.hpp
+++ b/src/interaction/PotentialVSpherePair.hpp
@@ -287,7 +287,8 @@ inline python::list PotentialVSpherePairTemplate<Derived>::computeForce(const Pa
                                                                         const Particle& p2) const
 {
     Real3D fr;
-    real fsi, fsj;
+    real fsi = 0;
+    real fsj = 0;
     python::list pl;
     bool ret;
     ret = _computeForce(fr, fsi, fsj, p1, p2);
@@ -308,7 +309,8 @@ inline python::list PotentialVSpherePairTemplate<Derived>::computeForce(const Re
                                                                         const real& sigmaj) const
 {
     Real3D fr;
-    real fsi, fsj;
+    real fsi = 0;
+    real fsj = 0;
     python::list pl;
     bool ret;
     ret = _computeForce(fr, fsi, fsj, dist, sigmai, sigmaj);

--- a/src/interaction/VerletListVSphereInteractionTemplate.hpp
+++ b/src/interaction/VerletListVSphereInteractionTemplate.hpp
@@ -234,7 +234,8 @@ inline real VerletListVSphereInteractionTemplate<_Potential>::computeVirial()
         // std::shared_ptr<Potential> potential = getPotential(type1, type2);
 
         Real3D force(0.0, 0.0, 0.0);
-        real fsi, fsj;
+        real fsi = 0;
+        real fsj = 0;
         if (potential._computeForce(force, fsi, fsj, p1, p2))
         {
             // if(potential->_computeForce(force, p1, p2)) {
@@ -266,7 +267,8 @@ inline void VerletListVSphereInteractionTemplate<_Potential>::computeVirialTenso
         // std::shared_ptr<Potential> potential = getPotential(type1, type2);
 
         Real3D force(0.0, 0.0, 0.0);
-        real fsi, fsj;
+        real fsi = 0;
+        real fsj = 0;
         if (potential._computeForce(force, fsi, fsj, p1, p2))
         {
             // if(potential->_computeForce(force, p1, p2)) {
@@ -324,7 +326,8 @@ inline void VerletListVSphereInteractionTemplate<_Potential>::computeVirialTenso
             const Potential &potential = getPotential(type1, type2);
 
             Real3D force(0.0, 0.0, 0.0);
-            real fsi, fsj;
+            real fsi = 0;
+            real fsj = 0;
             if (potential._computeForce(force, fsi, fsj, p1, p2))
             {
                 // TODO think of how to incorporate sigmaij-force into virial calculation
@@ -366,7 +369,8 @@ inline void VerletListVSphereInteractionTemplate<_Potential>::computeVirialTenso
 
         Real3D force(0.0, 0.0, 0.0);
         Tensor ww;
-        real fsi, fsj;
+        real fsi = 0;
+        real fsj = 0;
         if (potential._computeForce(force, fsi, fsj, p1, p2))
         {
             // TODO think of how to incorporate sigmaij-force into virial calculation

--- a/src/storage/DomainDecompositionAdress.cpp
+++ b/src/storage/DomainDecompositionAdress.cpp
@@ -556,8 +556,7 @@ inline void DomainDecompositionAdress::copyGhostTuples(Particle &src,
             tmp2.resize(atList.size());
             appendParticleListToGhosts(tmp2);  // insert into list
             ParticleList::iterator itv2 = (getAdrATParticlesG().back()).begin();
-            for (auto itv = atList.begin(); itv != atList.end();
-                 ++itv, ++itv2)
+            for (auto itv = atList.begin(); itv != atList.end(); ++itv, ++itv2)
             {
                 Particle &at = **itv;
                 Particle &atg = *itv2;
@@ -569,7 +568,7 @@ inline void DomainDecompositionAdress::copyGhostTuples(Particle &src,
         }
 
         else
-        {  // if the dst tuple already exists
+        {                                                   // if the dst tuple already exists
             std::vector<Particle *> atgList = itd->second;  // dst atomistic ghost list
             std::vector<Particle *>::iterator itv;
             std::vector<Particle *>::iterator itv2 = atgList.begin();
@@ -696,8 +695,7 @@ void DomainDecompositionAdress::unpackAndAddForces(Cell &_reals, InBuffer &buf)
             std::vector<Particle *> atList1 = it->second;
 
             // std::cout << "AT forces ...\n";
-            for (auto itv = atList1.begin(); itv != atList1.end();
-                 ++itv)
+            for (auto itv = atList1.begin(); itv != atList1.end(); ++itv)
             {
                 Particle &p3 = **itv;
                 // std::cout << getSystem()->comm->rank() << ": buf.read(AT force)
@@ -748,8 +746,8 @@ inline void DomainDecompositionAdress::addAdrGhostForcesToReals(Particle &src, P
         std::vector<Particle *> atList1 = its->second;
         std::vector<Particle *> atList2 = itd->second;
 
-        for (auto itv = atList1.begin(), itv2 = atList2.begin();
-             itv != atList1.end(); ++itv, ++itv2)
+        for (auto itv = atList1.begin(), itv2 = atList2.begin(); itv != atList1.end();
+             ++itv, ++itv2)
         {
             Particle &p3 = **itv;
             Particle &p4 = **itv2;
@@ -827,8 +825,7 @@ void DomainDecompositionAdress::decomposeRealParticles()
 
             if (nodeGrid.getGridSize(coord) > 1)
             {
-                for (auto it = realCells.begin(), end = realCells.end();
-                     it != end; ++it)
+                for (auto it = realCells.begin(), end = realCells.end(); it != end; ++it)
                 {
                     Cell &cell = **it;
 
@@ -925,8 +922,7 @@ void DomainDecompositionAdress::decomposeRealParticles()
             {
                 /* Single node direction case (no communication)
                    Fold particles that have left the box */
-                for (auto it = realCells.begin(), end = realCells.end();
-                     it != end; ++it)
+                for (auto it = realCells.begin(), end = realCells.end(); it != end; ++it)
                 {
                     Cell &cell = **it;
                     // do not use an iterator here, since we have need to take out particles during

--- a/src/storage/DomainDecompositionAdress.cpp
+++ b/src/storage/DomainDecompositionAdress.cpp
@@ -395,13 +395,12 @@ void DomainDecompositionAdress::packPositionsEtc(OutBuffer &buf,
         it = fixedtupleList->find(&(*src));
         if (it != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it->second;
+            std::vector<Particle *> atList = it->second;
 
             int size = atList.size();
             buf.write(size);  // write size of vector first
 
-            for (std::vector<Particle *>::iterator itv = atList.begin(); itv != atList.end(); ++itv)
+            for (auto itv = atList.begin(); itv != atList.end(); ++itv)
             {
                 Particle &at = **itv;
 
@@ -454,7 +453,7 @@ void DomainDecompositionAdress::unpackPositionsEtc(Cell &_ghosts, InBuffer &buf,
         {
             std::vector<Particle *> atList = it->second;
 
-            for (std::vector<Particle *>::iterator itv = atList.begin(); itv != atList.end(); ++itv)
+            for (auto itv = atList.begin(); itv != atList.end(); ++itv)
             {
                 Particle &atg = **itv;
                 buf.read(atg,
@@ -546,8 +545,7 @@ inline void DomainDecompositionAdress::copyGhostTuples(Particle &src,
     its = fixedtupleList->find(&src);
     if (its != fixedtupleList->end())
     {
-        std::vector<Particle *> atList;
-        atList = its->second;  // src atomistic list
+        std::vector<Particle *> atList = its->second;  // src atomistic list
 
         FixedTupleListAdress::iterator itd;
         itd = fixedtupleList->find(&dst);
@@ -558,7 +556,7 @@ inline void DomainDecompositionAdress::copyGhostTuples(Particle &src,
             tmp2.resize(atList.size());
             appendParticleListToGhosts(tmp2);  // insert into list
             ParticleList::iterator itv2 = (getAdrATParticlesG().back()).begin();
-            for (std::vector<Particle *>::iterator itv = atList.begin(); itv != atList.end();
+            for (auto itv = atList.begin(); itv != atList.end();
                  ++itv, ++itv2)
             {
                 Particle &at = **itv;
@@ -572,8 +570,7 @@ inline void DomainDecompositionAdress::copyGhostTuples(Particle &src,
 
         else
         {  // if the dst tuple already exists
-            std::vector<Particle *> atgList;
-            atgList = itd->second;  // dst atomistic ghost list
+            std::vector<Particle *> atgList = itd->second;  // dst atomistic ghost list
             std::vector<Particle *>::iterator itv;
             std::vector<Particle *>::iterator itv2 = atgList.begin();
             for (itv = atList.begin(); itv != atList.end(); ++itv, ++itv2)
@@ -603,8 +600,7 @@ void DomainDecompositionAdress::foldAdrPartCoor(Particle& part, Real3D& oldpos, 
         FixedTupleList::iterator it;
         it = fixedtupleList->find(&part);
         if (it != fixedtupleList->end()) {
-            std::vector<Particle*> atList;
-            atList = it->second;
+            std::vector<Particle*> atList = it->second;
 
             for (std::vector<Particle*>::iterator itv = atList.begin();
                   itv != atList.end(); ++itv) {
@@ -647,10 +643,9 @@ void DomainDecompositionAdress::packForces(OutBuffer &buf, Cell &_ghosts)
         it = fixedtupleList->find(&(*src));
         if (it != fixedtupleList->end())
         {
-            std::vector<Particle *> atList;
-            atList = it->second;
+            std::vector<Particle *> atList = it->second;
 
-            for (std::vector<Particle *>::iterator itv = atList.begin(); itv != atList.end(); ++itv)
+            for (auto itv = atList.begin(); itv != atList.end(); ++itv)
             {
                 Particle &at = **itv;
 
@@ -698,11 +693,10 @@ void DomainDecompositionAdress::unpackAndAddForces(Cell &_reals, InBuffer &buf)
 
         if (it != fixedtupleList->end())
         {
-            std::vector<Particle *> atList1;
-            atList1 = it->second;
+            std::vector<Particle *> atList1 = it->second;
 
             // std::cout << "AT forces ...\n";
-            for (std::vector<Particle *>::iterator itv = atList1.begin(); itv != atList1.end();
+            for (auto itv = atList1.begin(); itv != atList1.end();
                  ++itv)
             {
                 Particle &p3 = **itv;
@@ -751,12 +745,10 @@ inline void DomainDecompositionAdress::addAdrGhostForcesToReals(Particle &src, P
     // std::cout << "\nInteraction " << p1.id() << " - " << p2.id() << "\n";
     if (its != fixedtupleList->end() && itd != fixedtupleList->end())
     {
-        std::vector<Particle *> atList1;
-        std::vector<Particle *> atList2;
-        atList1 = its->second;
-        atList2 = itd->second;
+        std::vector<Particle *> atList1 = its->second;
+        std::vector<Particle *> atList2 = itd->second;
 
-        for (std::vector<Particle *>::iterator itv = atList1.begin(), itv2 = atList2.begin();
+        for (auto itv = atList1.begin(), itv2 = atList2.begin();
              itv != atList1.end(); ++itv, ++itv2)
         {
             Particle &p3 = **itv;
@@ -835,7 +827,7 @@ void DomainDecompositionAdress::decomposeRealParticles()
 
             if (nodeGrid.getGridSize(coord) > 1)
             {
-                for (std::vector<Cell *>::iterator it = realCells.begin(), end = realCells.end();
+                for (auto it = realCells.begin(), end = realCells.end();
                      it != end; ++it)
                 {
                     Cell &cell = **it;
@@ -933,7 +925,7 @@ void DomainDecompositionAdress::decomposeRealParticles()
             {
                 /* Single node direction case (no communication)
                    Fold particles that have left the box */
-                for (std::vector<Cell *>::iterator it = realCells.begin(), end = realCells.end();
+                for (auto it = realCells.begin(), end = realCells.end();
                      it != end; ++it)
                 {
                     Cell &cell = **it;


### PR DESCRIPTION
Resolve some potential sources for #433

Warnings still occur in:
- src/interaction/LJcos.cpp
- src/interaction/Harmonic.cpp
- src/interaction/LennardJones.cpp
- src/interaction/LennardJonesAutoBonds.cpp
- src/interaction/LennardJonesCapped.cpp
- ...

Warnigns only occur if optimizations are enabled.