### PR TITLE
Adapting for recent changes in HPX

### DIFF
--- a/src/hpx4espp/HPXRuntime.cpp
+++ b/src/hpx4espp/HPXRuntime.cpp
@@ -34,8 +34,6 @@
 #include <hpx/runtime/agas/addressing_service.hpp>
 #endif
 
-#include <hpx/runtime/parcelset/parcelhandler.hpp>
-
 #include "python.hpp"
 
 int __argc = 0;

--- a/src/hpx4espp/HPXRuntime.hpp
+++ b/src/hpx4espp/HPXRuntime.hpp
@@ -65,8 +65,8 @@ protected:
     int hpx_main(int argc, char** argv);
 
 private:
-    hpx::lcos::local::spinlock mtx_;
-    hpx::lcos::local::condition_variable_any cond_;
+    hpx::spinlock mtx_;
+    hpx::condition_variable_any cond_;
     std::mutex startup_mtx_;
     std::condition_variable startup_cond_;
     bool running_;

--- a/src/hpx4espp/include/errors.hpp
+++ b/src/hpx4espp/include/errors.hpp
@@ -37,7 +37,7 @@
         ss_ << "MPI rank " << _rank_ << ", file \"" << __FILE__ << "\", line " << __LINE__        \
             << ", in " << f << "\n  " << msg;                                                     \
         std::cerr << "\nHPX4ESPP_THROW_EXCEPTION: " << ss_.str() << ": HPX("                      \
-                  << hpx::error_names[errcode] << ")\n"                                           \
+                  << hpx::get_error_name(errcode) << ")\n"                                        \
                   << std::endl;                                                                   \
         HPX_THROW_EXCEPTION(errcode, f, ss_.str());                                               \
     }                                                                                             \

--- a/src/hpx4espp/storage/Channels.cpp
+++ b/src/hpx4espp/storage/Channels.cpp
@@ -158,7 +158,7 @@ void Channels::verifyChannels()
             }
         }
 
-        std::vector<AlignedVectorChar> bufs = hpx::util::unwrap(futures);
+        std::vector<AlignedVectorChar> bufs = hpx::unwrap(futures);
         for (int coord = 0; coord < 3; ++coord)
         {
             const int nsub = numSubNodes[coord];

--- a/src/hpx4espp/storage/DomainDecomposition.cpp
+++ b/src/hpx4espp/storage/DomainDecomposition.cpp
@@ -35,8 +35,8 @@
 
 #include <boost/python/numpy.hpp>
 
-using hpx::parallel::for_loop;
-using hpx::parallel::execution::par;
+using hpx::for_loop;
+using hpx::execution::par;
 
 #include "integrator/MDIntegrator.hpp"
 

--- a/src/hpx4espp/utils/algorithms/for_loop.hpp
+++ b/src/hpx4espp/utils/algorithms/for_loop.hpp
@@ -44,7 +44,7 @@ inline void parallelForLoop(typename std::decay<I>::type first, I last, F&& func
 {
     if (hpx::threads::get_self_ptr() != nullptr)
     {
-        hpx::parallel::for_loop(hpx::parallel::execution::par, first, last, func);
+        hpx::experimental::for_loop(hpx::execution::par, first, last, func);
     }
     else
     {

--- a/src/hpx4espp/utils/algorithms/transform_reduce.hpp
+++ b/src/hpx4espp/utils/algorithms/transform_reduce.hpp
@@ -44,15 +44,13 @@ inline T parallelTransformReduce(
 {
     if (hpx::threads::get_self_ptr() != nullptr)
     {
-        return hpx::parallel::transform_reduce(hpx::parallel::execution::par, first, last,
-                                               std::move(init), std::forward<Reduce>(red_op),
-                                               std::forward<Convert>(conv_op));
+        return hpx::transform_reduce(hpx::execution::par, first, last, std::move(init),
+                                     std::forward<Reduce>(red_op), std::forward<Convert>(conv_op));
     }
     else
     {
-        return hpx::parallel::transform_reduce(hpx::parallel::execution::seq, first, last,
-                                               std::move(init), std::forward<Reduce>(red_op),
-                                               std::forward<Convert>(conv_op));
+        return hpx::transform_reduce(hpx::execution::seq, first, last, std::move(init),
+                                     std::forward<Reduce>(red_op), std::forward<Convert>(conv_op));
     }
 }
 

--- a/src/hpx4espp/utils/assert_msg.hpp
+++ b/src/hpx4espp/utils/assert_msg.hpp
@@ -26,7 +26,7 @@
 #define HPX4ESPP_ASSERT_MSG(VALUE, MSG)                                                 \
     {                                                                                   \
         if (!(VALUE))                                                                   \
-            HPX4ESPP_THROW_EXCEPTION(hpx::assertion_failure, __FUNCTION__,              \
+            HPX4ESPP_THROW_EXCEPTION(hpx::error::assertion_failure, __FUNCTION__,       \
                                      "HPX4ESPP_ASSERT FAILED. " #VALUE "="              \
                                          << (VALUE ? "true" : "false") << ". " << MSG); \
     }                                                                                   \
@@ -35,7 +35,7 @@
 #define HPX4ESPP_ASSERT_EQUAL_MSG(VALUE1, VALUE2, MSG)                                         \
     {                                                                                          \
         if (!((VALUE1) == (VALUE2)))                                                           \
-            HPX4ESPP_THROW_EXCEPTION(hpx::assertion_failure, __FUNCTION__,                     \
+            HPX4ESPP_THROW_EXCEPTION(hpx::error::assertion_failure, __FUNCTION__,              \
                                      "HPX4ESPP_ASSERT_EQUAL FAILED."                           \
                                          << " " #VALUE1 "=" << (VALUE1) << " and " #VALUE2 "=" \
                                          << (VALUE2) << " are not equal. " << MSG);            \
@@ -45,7 +45,7 @@
 #define HPX4ESPP_ASSERT_NEQ_MSG(VALUE1, VALUE2, MSG)                                           \
     {                                                                                          \
         if (!((VALUE1) != (VALUE2)))                                                           \
-            HPX4ESPP_THROW_EXCEPTION(hpx::assertion_failure, __FUNCTION__,                     \
+            HPX4ESPP_THROW_EXCEPTION(hpx::error::assertion_failure, __FUNCTION__,              \
                                      "HPX4ESPP_ASSERT_NEQ FAILED."                             \
                                          << " " #VALUE1 "=" << (VALUE1) << " and " #VALUE2 "=" \
                                          << (VALUE2) << " are not unequal. " << MSG);          \
@@ -55,7 +55,7 @@
 #define HPX4ESPP_ASSERT_LT_MSG(VALUE1, VALUE2, MSG)                                           \
     {                                                                                         \
         if (!((VALUE1) < (VALUE2)))                                                           \
-            HPX4ESPP_THROW_EXCEPTION(hpx::assertion_failure, __FUNCTION__,                    \
+            HPX4ESPP_THROW_EXCEPTION(hpx::error::assertion_failure, __FUNCTION__,             \
                                      "HPX4ESPP_ASSERT_LT FAILED."                             \
                                          << " " #VALUE1 "=" << (VALUE1)                       \
                                          << " not less than " #VALUE2 "=" << (VALUE2) << ". " \
@@ -66,7 +66,7 @@
 #define HPX4ESPP_ASSERT_GT_MSG(VALUE1, VALUE2, MSG)                                              \
     {                                                                                            \
         if (!((VALUE1) > (VALUE2)))                                                              \
-            HPX4ESPP_THROW_EXCEPTION(hpx::assertion_failure, __FUNCTION__,                       \
+            HPX4ESPP_THROW_EXCEPTION(hpx::error::assertion_failure, __FUNCTION__,                \
                                      "HPX4ESPP_ASSERT_GT FAILED."                                \
                                          << " " #VALUE1 "=" << (VALUE1)                          \
                                          << " not greater than " #VALUE2 "=" << (VALUE2) << ". " \
@@ -77,7 +77,7 @@
 #define HPX4ESPP_ASSERT_LEQ_MSG(VALUE1, VALUE2, MSG)                                               \
     {                                                                                              \
         if (!((VALUE1) <= (VALUE2)))                                                               \
-            HPX4ESPP_THROW_EXCEPTION(hpx::assertion_failure, __FUNCTION__,                         \
+            HPX4ESPP_THROW_EXCEPTION(hpx::error::assertion_failure, __FUNCTION__,                  \
                                      "HPX4ESPP_ASSERT_LEQ FAILED."                                 \
                                          << " " #VALUE1 "=" << (VALUE1)                            \
                                          << " not less than nor equal to " #VALUE2 "=" << (VALUE2) \
@@ -88,7 +88,7 @@
 #define HPX4ESPP_ASSERT_GEQ_MSG(VALUE1, VALUE2, MSG)                                      \
     {                                                                                     \
         if (!((VALUE1) >= (VALUE2)))                                                      \
-            HPX4ESPP_THROW_EXCEPTION(hpx::assertion_failure, __FUNCTION__,                \
+            HPX4ESPP_THROW_EXCEPTION(hpx::error::assertion_failure, __FUNCTION__,         \
                                      "HPX4ESPP_ASSERT_GEQ FAILED."                        \
                                          << " " #VALUE1 "=" << (VALUE1)                   \
                                          << " not greater than nor equal to " #VALUE2 "=" \


### PR DESCRIPTION
@junghans: As requested, this applies changes caused by recent API modifications in HPX. There are no big surprises, except for the fact, that for whatever reason the HPX error names were not exposed publicly anymore (which is a bug). I have created a PR on the HPX side (see: https://github.com/STEllAR-GROUP/hpx/pull/6279) that reintroduces this functionality. Please note that this PR here relies on the newly added API function, which will be available with the upcoming HPX V1.9.1 release only.

PS: I was not sure whether you preferred having these changes applied conditionally. For now this PR applies the changes unconditionally, that however should give you a hint what needs changing.